### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,4 +1,6 @@
 name: E2E Tests
+permissions:
+  contents: read
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/omarluq/termisu/security/code-scanning/2](https://github.com/omarluq/termisu/security/code-scanning/2)

In general, the fix is to add an explicit `permissions` block to the workflow (or to each job) that restricts the `GITHUB_TOKEN` to the least privileges needed. This workflow only checks out code and uses artifacts, runs language setup actions, installs dependencies, and runs tests. None of these steps require writing to repository contents, issues, or pull requests. Therefore, a root-level `permissions` block with `contents: read` is sufficient and is the simplest way to address the issue for all jobs.

The single best fix is to add a `permissions:` section at the top workflow level, just under `name: E2E Tests` and before `on:`. This will apply to both `build` and `e2e` jobs, since neither defines its own `permissions`. No imports or additional methods are needed; it is a pure YAML configuration change. Concretely, in `.github/workflows/e2e.yml`, insert:

```yaml
permissions:
  contents: read
```

after line 1. This documents that the workflow only needs read access to repository contents and ensures that the token is not granted broader default permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
