### PR TITLE
UTF-8/Hangul/CJK input with IME preedit

### DIFF
--- a/spec/termisu/input/parser_spec.cr
+++ b/spec/termisu/input/parser_spec.cr
@@ -584,3 +584,52 @@ describe Termisu::Input::Parser do
     end
   end
 end
+
+# Drives the parser over a single byte stream, polling `count` events. Used to
+# exercise the interaction between a Kitty CSI-u text report and the raw-byte
+# path that immediately follows it.
+private def parse_events(bytes : Bytes, count : Int32) : Array(Termisu::Event::Any?)
+  read_fd, write_fd = create_pipe
+  reader = nil
+  events = [] of Termisu::Event::Any?
+  begin
+    LibC.write(write_fd, bytes, bytes.size)
+    reader = Termisu::Reader.new(read_fd)
+    parser = Termisu::Input::Parser.new(reader)
+    count.times { events << parser.poll_event(100) }
+  ensure
+    reader.try(&.close)
+    LibC.close(read_fd)
+    LibC.close(write_fd)
+  end
+  events
+end
+
+describe Termisu::Input::Parser do
+  describe "Kitty report_text (CSI >17u) + raw printable bytes" do
+    # Under flags 17u (disambiguate + report_text, NO report_all_keys), modified
+    # keys arrive as CSI-u while plain unmodified keys still arrive as raw bytes.
+    # A text-bearing CSI-u event must NOT cause subsequent plain raw keys to be
+    # dropped — only an exact duplicate echo of that one char is a duplicate.
+    it "keeps plain raw keys typed after a CSI-u text event" do
+      # Shift+a -> 'A' (codepoint 97, shift mod 2, text 65), then raw "bc".
+      bytes = Bytes[0x1B, '['.ord, '9'.ord, '7'.ord, ';'.ord, '2'.ord, ';'.ord, '6'.ord, '5'.ord, 'u'.ord,
+        'b'.ord, 'c'.ord]
+      events = parse_events(bytes, 3)
+      events[0].as(Termisu::Event::Key).char.should eq('A')
+      events[1].as(Termisu::Event::Key).char.should eq('b')
+      events[2].as(Termisu::Event::Key).char.should eq('c')
+    end
+
+    it "drops only an exact duplicate raw echo of the CSI-u char" do
+      # CSI-u 'x' (codepoint 120, text 120), then raw 'x' (the echo), then raw 'y'.
+      bytes = Bytes[0x1B, '['.ord, '1'.ord, '2'.ord, '0'.ord, ';'.ord, '1'.ord, ';'.ord, '1'.ord, '2'.ord, '0'.ord, 'u'.ord,
+        'x'.ord, 'y'.ord]
+      events = parse_events(bytes, 3)
+      events[0].as(Termisu::Event::Key).char.should eq('x')
+      # the duplicate echo is swallowed (Unknown, no char)
+      events[1].as(Termisu::Event::Key).char.should be_nil
+      events[2].as(Termisu::Event::Key).char.should eq('y')
+    end
+  end
+end

--- a/spec/termisu/input/parser_spec.cr
+++ b/spec/termisu/input/parser_spec.cr
@@ -633,3 +633,35 @@ describe Termisu::Input::Parser do
     end
   end
 end
+
+describe Termisu::Input::Parser do
+  describe "Kitty CSI-u text field parsing" do
+    it "keeps all codepoints of a multi-codepoint text field (no ':' truncation)" do
+      # CSI 0;1;4352:4449 u -> pure-text (preedit) event carrying two Hangul jamo.
+      bytes = Bytes[0x1B, '['.ord, '0'.ord, ';'.ord, '1'.ord, ';'.ord,
+        '4'.ord, '3'.ord, '5'.ord, '2'.ord, ':'.ord, '4'.ord, '4'.ord, '4'.ord, '9'.ord, 'u'.ord]
+      event = parse_sequence(bytes)
+      event.should be_a(Termisu::Event::Preedit)
+      event.as(Termisu::Event::Preedit).text.size.should eq(2)
+    end
+
+    it "emits Preedit with empty text for a codepoint-0 report with no text (preedit cleared)" do
+      # CSI 0;1 u -> terminal signalling composition cleared.
+      bytes = Bytes[0x1B, '['.ord, '0'.ord, ';'.ord, '1'.ord, 'u'.ord]
+      event = parse_sequence(bytes)
+      event.should be_a(Termisu::Event::Preedit)
+      event.as(Termisu::Event::Preedit).text.empty?.should be_true
+    end
+
+    it "parses an event-type in the modifier field without dropping the key" do
+      # CSI 97;5:1 u -> Ctrl+a press (mods=5, event_type=1); the ':' is the event type.
+      bytes = Bytes[0x1B, '['.ord, '9'.ord, '7'.ord, ';'.ord, '5'.ord, ':'.ord, '1'.ord, 'u'.ord]
+      event = parse_sequence(bytes)
+      event.should be_a(Termisu::Event::Key)
+      if event.is_a?(Termisu::Event::Key)
+        event.char.should eq('a')
+        event.modifiers.ctrl?.should be_true
+      end
+    end
+  end
+end

--- a/src/termisu/event.cr
+++ b/src/termisu/event.cr
@@ -38,7 +38,12 @@ require "./event/source/*"
 # Union type for all terminal events.
 # Use Event::Any for type annotations and collections.
 # Individual event types (Event::Key, Event::Mouse, etc.) work in case statements.
-alias Termisu::Event::Any = Termisu::Event::Key | Termisu::Event::Mouse | Termisu::Event::Resize | Termisu::Event::Tick | Termisu::Event::ModeChange | Termisu::Event::Preedit
+alias Termisu::Event::Any = Termisu::Event::Key |
+                            Termisu::Event::Mouse |
+                            Termisu::Event::Resize |
+                            Termisu::Event::Tick |
+                            Termisu::Event::ModeChange |
+                            Termisu::Event::Preedit
 
 # Preedit text from the input method during composition (e.g. partial Hangul
 # syllable as jamo are typed). The TUI should render this at the current cursor

--- a/src/termisu/event.cr
+++ b/src/termisu/event.cr
@@ -38,4 +38,24 @@ require "./event/source/*"
 # Union type for all terminal events.
 # Use Event::Any for type annotations and collections.
 # Individual event types (Event::Key, Event::Mouse, etc.) work in case statements.
-alias Termisu::Event::Any = Termisu::Event::Key | Termisu::Event::Mouse | Termisu::Event::Resize | Termisu::Event::Tick | Termisu::Event::ModeChange
+alias Termisu::Event::Any = Termisu::Event::Key | Termisu::Event::Mouse | Termisu::Event::Resize | Termisu::Event::Tick | Termisu::Event::ModeChange | Termisu::Event::Preedit
+
+# Preedit text from the input method during composition (e.g. partial Hangul
+# syllable as jamo are typed). The TUI should render this at the current cursor
+# position, typically with an underline or other composing indicator (not
+# yet committed to the buffer). When the user completes the composition (e.g.
+# presses space or the next key that commits), the terminal will send the
+# final committed character(s) as normal Key event(s) with 'char', and the
+# preedit will be cleared (a Preedit with empty text or subsequent commit).
+#
+# Note: Support for actually receiving Preedit events depends on the terminal
+# emulator supporting client-side preedit reporting via the keyboard protocol
+# (e.g. Kitty with report_text) or other mechanisms. termisu delivers them if
+# the terminal sends the appropriate sequences; otherwise only committed chars
+# arrive (as before).
+struct Termisu::Event::Preedit
+  getter text : String
+
+  def initialize(@text : String)
+  end
+end

--- a/src/termisu/event/key.cr
+++ b/src/termisu/event/key.cr
@@ -22,8 +22,9 @@ struct Termisu::Event::Key
 
   # The Unicode character for printable input (e.g. Hangul syllables, CJK,
   # accented letters, etc.). This is set for direct UTF-8 input and takes
-  # precedence over key.to_char for text editing.
-  getter char : Char?
+  # precedence over key.to_char for text editing. Exposed via the custom
+  # `#char` reader below (which falls back to `key.to_char`).
+  @char : Char?
 
   def initialize(@key : Input::Key, @modifiers : Input::Modifier = Input::Modifier::None, @char : Char? = nil)
   end

--- a/src/termisu/event/key.cr
+++ b/src/termisu/event/key.cr
@@ -20,7 +20,12 @@ struct Termisu::Event::Key
   # Modifier keys held during the keypress.
   getter modifiers : Input::Modifier
 
-  def initialize(@key : Input::Key, @modifiers : Input::Modifier = Input::Modifier::None)
+  # The Unicode character for printable input (e.g. Hangul syllables, CJK,
+  # accented letters, etc.). This is set for direct UTF-8 input and takes
+  # precedence over key.to_char for text editing.
+  getter char : Char?
+
+  def initialize(@key : Input::Key, @modifiers : Input::Modifier = Input::Modifier::None, @char : Char? = nil)
   end
 
   # Returns true if Ctrl modifier was held.
@@ -64,8 +69,9 @@ struct Termisu::Event::Key
   end
 
   # Returns the character for this key, if printable.
+  # Prefers the explicitly attached @char (for full Unicode input).
   def char : Char?
-    key.to_char
+    @char || key.to_char
   end
 
   private def ctrl_plain_key?(& : Input::Key -> Bool) : Bool

--- a/src/termisu/input/parser.cr
+++ b/src/termisu/input/parser.cr
@@ -129,34 +129,33 @@ class Termisu::Input::Parser
   # not delivered as key events here. Full preedit support would require terminal-
   # specific protocols (e.g. kitty's input protocol extensions or IM protocol).
   private def read_utf8_char(first_byte : UInt8) : Char?
-    # ASCII fast path
-    return first_byte.chr if first_byte < 0x80
+    return first_byte.chr if first_byte < 0x80 # ASCII fast path
 
-    # Number of continuation bytes from lead
-    ncont = case first_byte
-            when 0xC0..0xDF then 1
-            when 0xE0..0xEF then 2
-            when 0xF0..0xF7 then 3
-            else                 return nil
-            end
+    # Sequence length from the lead byte: count the leading 1-bits (2..4 for a
+    # valid multibyte lead). Anything else (lone continuation byte, 0xFF, etc.)
+    # is rejected here; full validity is confirmed by valid_encoding? below.
+    len = (~first_byte).leading_zeros_count.to_i
+    return nil unless 2 <= len <= 4
 
-    bytes = Bytes.new(1 + ncont)
+    bytes = Bytes.new(len)
     bytes[0] = first_byte
 
-    ncont.times do |i|
-      b = @reader.read_byte
-      return nil unless b
-      # must be continuation 10xxxxxx
-      return nil unless (b & 0xC0) == 0x80
-      bytes[i + 1] = b
+    (1...len).each do |i|
+      # wait_for_data reuses the split-read tolerance so a char fragmented
+      # across two reads survives; peek + confirm before consuming so a
+      # non-continuation byte is left in the buffer rather than swallowed.
+      return nil unless @reader.wait_for_data(ESCAPE_TIMEOUT_MS)
+      b = @reader.peek_byte
+      return nil unless b && (b & 0xC0) == 0x80 # continuation 10xxxxxx
+      @reader.read_byte
+      bytes[i] = b
     end
 
-    begin
-      s = String.new(bytes)
-      s.size > 0 ? s[0] : nil
-    rescue
-      nil
-    end
+    # valid_encoding? is a full RFC-3629 check: it rejects overlong encodings,
+    # surrogates, and anything above U+10FFFF. String.new never raises on bad
+    # UTF-8 (it yields U+FFFD), so no begin/rescue is needed.
+    s = String.new(bytes)
+    s.valid_encoding? ? s[0]? : nil
   end
 
   # Polls for an input event with optional timeout.
@@ -404,10 +403,22 @@ class Termisu::Input::Parser
     Event::Key.new(key, modifiers, char: c)
   end
 
+  # Whether `cp` is a scalar Unicode codepoint that maps to a real Char: in
+  # range and not a UTF-16 surrogate (U+D800..U+DFFF), which `Int#chr` would
+  # otherwise accept. Filtering here keeps the intent explicit and surrogate-safe.
+  private def valid_codepoint?(cp : Int32) : Bool
+    cp >= 0 && cp <= Char::MAX_CODEPOINT && !(0xD800..0xDFFF).includes?(cp)
+  end
+
   private def build_text_from_codepoints(text_param : String?) : String
     return "" if text_param.nil? || text_param.empty?
-    codes = text_param.split(':').compact_map(&.to_i?)
-    codes.map { |cp| (cp.chr rescue nil) }.compact.join
+
+    String.build do |io|
+      text_param.split(':').each do |part|
+        cp = part.to_i?
+        io << cp.chr if cp && valid_codepoint?(cp)
+      end
+    end
   end
 
   # Kitty protocol codepoint to Key mapping for special keys.

--- a/src/termisu/input/parser.cr
+++ b/src/termisu/input/parser.cr
@@ -210,22 +210,27 @@ class Termisu::Input::Parser
     when 0x7F # DEL (Backspace on most terminals)
       Event::Key.new(Key::Backspace)
     else
-      # Printable character - support full UTF-8 (Hangul, CJK, etc. for text input).
-      # Always read the full UTF-8 char first (so multibyte continuation bytes are
-      # consumed even when we end up discarding it — otherwise they'd be misparsed).
-      c = read_utf8_char(byte)
-      return Event::Key.new(Key::Unknown) unless c
-
-      # Under the Kitty protocol (report_text), plain unmodified keys still arrive
-      # as raw bytes (report_all_keys is off), so we must NOT blanket-drop them.
-      # Only swallow a raw byte that exactly duplicates the char just emitted by
-      # the immediately-preceding CSI-u text event (a terminal echoing an IME
-      # commit on both channels).
-      return Event::Key.new(Key::Unknown) if @protocol_active && dup == c
-
-      key = Key.from_char(c) || Key::Unknown
-      Event::Key.new(key, char: c)
+      parse_printable(byte, dup)
     end
+  end
+
+  # Handles a printable (non-control) byte: reads the full UTF-8 char and emits
+  # a Key event, supporting Hangul, CJK, accented letters, etc. for text input.
+  private def parse_printable(byte : UInt8, dup : Char?) : Event::Any
+    # Always read the full UTF-8 char first (so multibyte continuation bytes are
+    # consumed even when we end up discarding it — otherwise they'd be misparsed).
+    c = read_utf8_char(byte)
+    return Event::Key.new(Key::Unknown) unless c
+
+    # Under the Kitty protocol (report_text), plain unmodified keys still arrive
+    # as raw bytes (report_all_keys is off), so we must NOT blanket-drop them.
+    # Only swallow a raw byte that exactly duplicates the char just emitted by
+    # the immediately-preceding CSI-u text event (a terminal echoing an IME
+    # commit on both channels).
+    return Event::Key.new(Key::Unknown) if @protocol_active && dup == c
+
+    key = Key.from_char(c) || Key::Unknown
+    Event::Key.new(key, char: c)
   end
 
   # Parses an escape sequence starting with ESC (0x1B).
@@ -356,13 +361,11 @@ class Termisu::Input::Parser
     text_str = build_text_from_codepoints(text_param)
 
     # Prefer associated text (report_text) for the actual inserted char (e.g. shift+a gives 'A' in text)
-    c = text_str[0]? || ((codepoint > 0 && codepoint <= 0x10FFFF) ? (codepoint.chr rescue nil) : nil)
+    c = text_str[0]? || (valid_codepoint?(codepoint) ? codepoint.chr : nil)
 
     # If we saw a text-producing CSI report, terminal is using protocol for chars too (report_all+text or similar);
     # skip raw byte path for printables from now to avoid duplicates.
-    if c && c.printable? && c.ord >= 32
-      @protocol_active = true
-    end
+    @protocol_active = true if producing_text?(c)
 
     if codepoint == 0
       # Pure text event (no associated key), typically from IME or direct text input.
@@ -378,8 +381,15 @@ class Termisu::Input::Parser
     key = codepoint_to_key(codepoint)
     # Arm the one-shot dup guard so a duplicate raw echo of this exact char
     # (same byte immediately following) is swallowed; plain keys never match it.
-    @dup_guard = c if c && c.printable? && c.ord >= 32
+    @dup_guard = c if producing_text?(c)
     Event::Key.new(key, modifiers, char: c)
+  end
+
+  # Whether `c` is a text-producing printable char (printable and not a control
+  # codepoint). Used to gate Kitty text-protocol dedup state.
+  private def producing_text?(c : Char?) : Bool
+    return false unless c
+    c.printable? && c.ord >= 32
   end
 
   # Parses modifyOtherKeys sequence.
@@ -395,7 +405,7 @@ class Termisu::Input::Parser
     # If modify reports a printable via CSI, the terminal is using the protocol
     # for text; arm the one-shot dup guard so only a duplicate raw echo of this
     # exact char is swallowed (plain raw keys keep flowing).
-    if c && c.printable? && c.ord >= 32
+    if producing_text?(c)
       @protocol_active = true
       @dup_guard = c
     end

--- a/src/termisu/input/parser.cr
+++ b/src/termisu/input/parser.cr
@@ -106,6 +106,7 @@ class Termisu::Input::Parser
   }
 
   @reader : Reader
+  @protocol_active : Bool = false
 
   def initialize(@reader : Reader)
   end
@@ -196,6 +197,12 @@ class Termisu::Input::Parser
     when 0x7F # DEL (Backspace on most terminals)
       Event::Key.new(Key::Backspace)
     else
+      if @protocol_active
+        # With Kitty keyboard protocol + report_text active, text (including IME composed)
+        # is reported via CSI 27;...~ or CSI ... u (with text field). Ignore raw printable
+        # bytes to prevent duplicate input (English doubles, Hangul jamo split).
+        return Event::Key.new(Key::Unknown)
+      end
       # Printable character - support full UTF-8 (Hangul, CJK, etc. for text input)
       c = read_utf8_char(byte)
       return Event::Key.new(Key::Unknown) unless c
@@ -331,11 +338,18 @@ class Termisu::Input::Parser
     # Prefer associated text (report_text) for the actual inserted char (e.g. shift+a gives 'A' in text)
     c = text_str[0]? || ((codepoint > 0 && codepoint <= 0x10FFFF) ? (codepoint.chr rescue nil) : nil)
 
+    # If we saw a text-producing CSI report, terminal is using protocol for chars too (report_all+text or similar);
+    # skip raw byte path for printables from now to avoid duplicates.
+    if c && c.printable? && c.ord >= 32
+      @protocol_active = true
+    end
+
     if codepoint == 0 && !text_str.empty?
       # Pure text event (no associated key), typically from IME or direct text input.
       # Emit as Preedit so TUI can show composing state with underline (e.g. building Hangul jamo -> syllable).
       # On commit, terminal should deliver the final syllable as a normal Key+char (or another report);
       # consumers should clear preedit on the committed char Key and insert it.
+      @protocol_active = true
       return Event::Preedit.new(text_str)
     end
 
@@ -352,6 +366,11 @@ class Termisu::Input::Parser
     modifiers = Modifier.from_xterm_code(mod_code)
     key = codepoint_to_key(keycode)
     c = (keycode > 0 && keycode <= 0x10FFFF) ? (keycode.chr rescue nil) : nil
+
+    # If modify reports a printable via CSI, assume protocol for text; skip raw bytes to dedup.
+    if c && c.printable? && c.ord >= 32
+      @protocol_active = true
+    end
 
     Event::Key.new(key, modifiers, char: c)
   end

--- a/src/termisu/input/parser.cr
+++ b/src/termisu/input/parser.cr
@@ -110,6 +110,46 @@ class Termisu::Input::Parser
   def initialize(@reader : Reader)
   end
 
+  # Reads a complete UTF-8 character (1-4 bytes) starting from the given lead byte.
+  # Consumes the additional continuation bytes from the reader.
+  # Returns nil if incomplete, invalid, or not UTF-8 text.
+  #
+  # Note on Hangul/IME: This receives *committed* characters after IME composition
+  # completes (e.g. after typing jamo for a full syllable). Preedit/composing text
+  # during input is typically handled by the terminal emulator or OS IME overlay,
+  # not delivered as key events here. Full preedit support would require terminal-
+  # specific protocols (e.g. kitty's input protocol extensions or IM protocol).
+  private def read_utf8_char(first_byte : UInt8) : Char?
+    # ASCII fast path
+    return first_byte.chr if first_byte < 0x80
+
+    # Number of continuation bytes from lead
+    ncont = case first_byte
+            when 0xC0..0xDF then 1
+            when 0xE0..0xEF then 2
+            when 0xF0..0xF7 then 3
+            else                 return nil
+            end
+
+    bytes = Bytes.new(1 + ncont)
+    bytes[0] = first_byte
+
+    ncont.times do |i|
+      b = @reader.read_byte
+      return nil unless b
+      # must be continuation 10xxxxxx
+      return nil unless (b & 0xC0) == 0x80
+      bytes[i + 1] = b
+    end
+
+    begin
+      s = String.new(bytes)
+      s.size > 0 ? s[0] : nil
+    rescue
+      nil
+    end
+  end
+
   # Polls for an input event with optional timeout.
   #
   # - `timeout_ms` - Timeout in milliseconds (-1 for blocking)
@@ -156,9 +196,12 @@ class Termisu::Input::Parser
     when 0x7F # DEL (Backspace on most terminals)
       Event::Key.new(Key::Backspace)
     else
-      # Printable character
-      key = Key.from_char(byte.chr)
-      Event::Key.new(key)
+      # Printable character - support full UTF-8 (Hangul, CJK, etc. for text input)
+      c = read_utf8_char(byte)
+      return Event::Key.new(Key::Unknown) unless c
+
+      key = Key.from_char(c) || Key::Unknown
+      Event::Key.new(key, char: c)
     end
   end
 
@@ -182,10 +225,11 @@ class Termisu::Input::Parser
       @reader.read_byte # consume 'O'
       parse_ss3_sequence
     else
-      # Alt+key: \e followed by printable char
-      @reader.read_byte # consume the char
-      key = Key.from_char(byte.chr)
-      Event::Key.new(key, Modifier::Alt)
+      # Alt+key: \e followed by printable char (UTF-8 capable)
+      @reader.read_byte # consume the (first) char byte
+      c = read_utf8_char(byte)
+      key = c ? (Key.from_char(c) || Key::Unknown) : Key::Unknown
+      Event::Key.new(key, Modifier::Alt, char: c)
     end
   end
 
@@ -229,7 +273,8 @@ class Termisu::Input::Parser
 
   # Decodes a CSI sequence into a KeyEvent using hash lookups.
   # Handles standard CSI sequences, Kitty keyboard protocol, and modifyOtherKeys.
-  private def decode_csi_key(params : String, final : Char) : Event::Key
+  # Returns Any because kitty text events with codepoint 0 are emitted as Preedit.
+  private def decode_csi_key(params : String, final : Char) : Event::Any
     # Kitty keyboard protocol: CSI codepoint ; modifiers u
     # or: CSI codepoint ; modifiers : event_type u
     if final == 'u'
@@ -269,20 +314,33 @@ class Termisu::Input::Parser
   #
   # Codepoint is the Unicode codepoint of the key.
   # Modifiers use the same encoding as xterm (1 + shift + alt*2 + ctrl*4 + meta*8).
-  private def parse_kitty_key(params : String) : Event::Key
+  # With report_text, a 3rd field carries the produced text codepoints (prefer for .char).
+  private def parse_kitty_key(params : String) : Event::Any
     # Handle colon separator for event type (e.g., "97;5:1" for Ctrl+A press)
     clean_params = params.split(':').first || params
     parts = clean_params.split(';')
 
     codepoint = parts[0]?.try(&.to_i?) || 0
     mod_code = parts[1]?.try(&.to_i?) || 1
+    text_param = parts[2]?
 
     modifiers = Modifier.from_xterm_code(mod_code)
 
-    # Convert codepoint to key
-    key = codepoint_to_key(codepoint)
+    text_str = build_text_from_codepoints(text_param)
 
-    Event::Key.new(key, modifiers)
+    # Prefer associated text (report_text) for the actual inserted char (e.g. shift+a gives 'A' in text)
+    c = text_str[0]? || ((codepoint > 0 && codepoint <= 0x10FFFF) ? (codepoint.chr rescue nil) : nil)
+
+    if codepoint == 0 && !text_str.empty?
+      # Pure text event (no associated key), typically from IME or direct text input.
+      # Emit as Preedit so TUI can show composing state with underline (e.g. building Hangul jamo -> syllable).
+      # On commit, terminal should deliver the final syllable as a normal Key+char (or another report);
+      # consumers should clear preedit on the committed char Key and insert it.
+      return Event::Preedit.new(text_str)
+    end
+
+    key = codepoint_to_key(codepoint)
+    Event::Key.new(key, modifiers, char: c)
   end
 
   # Parses modifyOtherKeys sequence.
@@ -293,8 +351,15 @@ class Termisu::Input::Parser
 
     modifiers = Modifier.from_xterm_code(mod_code)
     key = codepoint_to_key(keycode)
+    c = (keycode > 0 && keycode <= 0x10FFFF) ? (keycode.chr rescue nil) : nil
 
-    Event::Key.new(key, modifiers)
+    Event::Key.new(key, modifiers, char: c)
+  end
+
+  private def build_text_from_codepoints(text_param : String?) : String
+    return "" if text_param.nil? || text_param.empty?
+    codes = text_param.split(':').compact_map(&.to_i?)
+    codes.map { |cp| (cp.chr rescue nil) }.compact.join
   end
 
   # Kitty protocol codepoint to Key mapping for special keys.

--- a/src/termisu/input/parser.cr
+++ b/src/termisu/input/parser.cr
@@ -107,6 +107,14 @@ class Termisu::Input::Parser
 
   @reader : Reader
   @protocol_active : Bool = false
+  # One-shot de-duplication guard. When a CSI-u event reports an associated
+  # text char, some terminals ALSO echo that same char as a raw UTF-8 byte
+  # (notably IME commits). We remember the just-emitted protocol char here so
+  # the immediately-following raw byte, IF it is the exact same char, can be
+  # swallowed as a duplicate. It is consumed (cleared) by the very next byte —
+  # so plain unmodified keys (which arrive as raw bytes under the 17u flag set,
+  # since report_all_keys is off) are never wrongly dropped.
+  @dup_guard : Char? = nil
 
   def initialize(@reader : Reader)
   end
@@ -178,6 +186,12 @@ class Termisu::Input::Parser
   # Also: Modifier keys alone (Ctrl, Alt, Shift) don't send any bytes in
   # standard terminal input. We can only detect them combined with other keys.
   private def parse_byte(byte : UInt8) : Event::Any
+    # Snapshot + clear the one-shot dup guard: it only matches a raw byte that
+    # arrives IMMEDIATELY after the CSI-u event that set it (handled in the
+    # printable branch below). Any other byte clears it. The escape branch may
+    # set a fresh guard for the *next* call.
+    dup = @dup_guard
+    @dup_guard = nil
     case byte
     when 0x1B # ESC - could be escape key or start of sequence
       parse_escape_sequence
@@ -197,15 +211,18 @@ class Termisu::Input::Parser
     when 0x7F # DEL (Backspace on most terminals)
       Event::Key.new(Key::Backspace)
     else
-      if @protocol_active
-        # With Kitty keyboard protocol + report_text active, text (including IME composed)
-        # is reported via CSI 27;...~ or CSI ... u (with text field). Ignore raw printable
-        # bytes to prevent duplicate input (English doubles, Hangul jamo split).
-        return Event::Key.new(Key::Unknown)
-      end
-      # Printable character - support full UTF-8 (Hangul, CJK, etc. for text input)
+      # Printable character - support full UTF-8 (Hangul, CJK, etc. for text input).
+      # Always read the full UTF-8 char first (so multibyte continuation bytes are
+      # consumed even when we end up discarding it — otherwise they'd be misparsed).
       c = read_utf8_char(byte)
       return Event::Key.new(Key::Unknown) unless c
+
+      # Under the Kitty protocol (report_text), plain unmodified keys still arrive
+      # as raw bytes (report_all_keys is off), so we must NOT blanket-drop them.
+      # Only swallow a raw byte that exactly duplicates the char just emitted by
+      # the immediately-preceding CSI-u text event (a terminal echoing an IME
+      # commit on both channels).
+      return Event::Key.new(Key::Unknown) if @protocol_active && dup == c
 
       key = Key.from_char(c) || Key::Unknown
       Event::Key.new(key, char: c)
@@ -354,6 +371,9 @@ class Termisu::Input::Parser
     end
 
     key = codepoint_to_key(codepoint)
+    # Arm the one-shot dup guard so a duplicate raw echo of this exact char
+    # (same byte immediately following) is swallowed; plain keys never match it.
+    @dup_guard = c if c && c.printable? && c.ord >= 32
     Event::Key.new(key, modifiers, char: c)
   end
 
@@ -367,9 +387,12 @@ class Termisu::Input::Parser
     key = codepoint_to_key(keycode)
     c = (keycode > 0 && keycode <= 0x10FFFF) ? (keycode.chr rescue nil) : nil
 
-    # If modify reports a printable via CSI, assume protocol for text; skip raw bytes to dedup.
+    # If modify reports a printable via CSI, the terminal is using the protocol
+    # for text; arm the one-shot dup guard so only a duplicate raw echo of this
+    # exact char is swallowed (plain raw keys keep flowing).
     if c && c.printable? && c.ord >= 32
       @protocol_active = true
+      @dup_guard = c
     end
 
     Event::Key.new(key, modifiers, char: c)

--- a/src/termisu/input/parser.cr
+++ b/src/termisu/input/parser.cr
@@ -340,12 +340,16 @@ class Termisu::Input::Parser
   # Modifiers use the same encoding as xterm (1 + shift + alt*2 + ctrl*4 + meta*8).
   # With report_text, a 3rd field carries the produced text codepoints (prefer for .char).
   private def parse_kitty_key(params : String) : Event::Any
-    # Handle colon separator for event type (e.g., "97;5:1" for Ctrl+A press)
-    clean_params = params.split(':').first || params
-    parts = clean_params.split(';')
+    # Fields are ';'-separated: codepoint ; modifiers ; text. The ':' separator is
+    # used *within* fields — alternate keys in the codepoint field
+    # (unicode:shifted:base), an event type in the modifier field (mods:event_type),
+    # and MULTIPLE codepoints in the text field (cp1:cp2:...). Split on ';' first and
+    # strip ':' only from the codepoint/modifier fields; never from the text field,
+    # or multi-codepoint text (e.g. composed Hangul jamo) would be truncated.
+    parts = params.split(';')
 
-    codepoint = parts[0]?.try(&.to_i?) || 0
-    mod_code = parts[1]?.try(&.to_i?) || 1
+    codepoint = parts[0]?.try(&.split(':').first).try(&.to_i?) || 0
+    mod_code = parts[1]?.try(&.split(':').first).try(&.to_i?) || 1
     text_param = parts[2]?
 
     modifiers = Modifier.from_xterm_code(mod_code)
@@ -361,11 +365,13 @@ class Termisu::Input::Parser
       @protocol_active = true
     end
 
-    if codepoint == 0 && !text_str.empty?
+    if codepoint == 0
       # Pure text event (no associated key), typically from IME or direct text input.
-      # Emit as Preedit so TUI can show composing state with underline (e.g. building Hangul jamo -> syllable).
-      # On commit, terminal should deliver the final syllable as a normal Key+char (or another report);
-      # consumers should clear preedit on the committed char Key and insert it.
+      # Emit as Preedit so the TUI can show composing state with underline (e.g.
+      # building Hangul jamo -> syllable). An EMPTY text here is the terminal
+      # signalling "preedit cleared" — emit Preedit("") so consumers can clear stale
+      # composition UI, rather than dropping it as Key::Unknown. On commit the final
+      # syllable arrives as a normal Key+char (or another report).
       @protocol_active = true
       return Event::Preedit.new(text_str)
     end

--- a/src/termisu/terminal.cr
+++ b/src/termisu/terminal.cr
@@ -573,8 +573,8 @@ class Termisu::Terminal < Termisu::Renderer
   #   https://sw.kovidgoyal.net/kitty/keyboard-protocol/
   #   Flags: 1=disambiguate, 2=report_event_types, 4=report_alternate_keys
   #         8=report_all_keys, 16=report_text
-  KITTY_KEYBOARD_ENABLE  = "\e[>1u" # Enable with disambiguate flag
-  KITTY_KEYBOARD_DISABLE = "\e[<u"  # Pop keyboard mode
+  KITTY_KEYBOARD_ENABLE  = "\e[>17u" # disambiguate + report_text (safer for Hangul IME compose than 31u)
+  KITTY_KEYBOARD_DISABLE = "\e[<u"   # Pop keyboard mode
 
   # modifyOtherKeys (xterm, widely supported):
   #   Mode 2 reports modified keys as CSI 27 ; modifier ; keycode ~


### PR DESCRIPTION
@omarluq 
Hi! It's been a while. Hope you've been doing well.

This PR adds proper UTF-8 text input support so international characters (Hangul, CJK, accented letters, etc.) work correctly, including IME composition.

- Decode full UTF-8 printable input and attach the composed character to Event::Key
- Enable Kitty keyboard report_text flag (CSI >17u) and prefer the reported text for the inserted character
- Add Event::Preedit so TUIs can render in-progress IME composition (e.g., Hangul jamo combining into a syllable) before commit
- Drop duplicate raw-byte input once the terminal reports text via the protocol (fixes doubled ASCII and split Hangul jamo)

## Testing

```bash
crystal spec spec/termisu/input spec/termisu/event
# Finished in 988.08 milliseconds
# 473 examples, 0 failures, 0 errors, 0 pending
```

Let me know if you spot any areas for improvement or issues while reviewing. Thanks :)

---

*PS: I noticed this issue while using termisu in an ongoing private project. That aside, it's been making development much smoother. Thanks for making such a great library!!*