### PR TITLE
perf: eliminate allocations and syscalls from the render hot path

### DIFF
--- a/spec/termisu/buffer_spec.cr
+++ b/spec/termisu/buffer_spec.cr
@@ -105,6 +105,14 @@ describe Termisu::Buffer do
       buffer.set_cell(0, 0, '~').should be_true # 0x7E
     end
 
+    it "pins validation behavior at the single-byte fast-path boundary" do
+      buffer = Termisu::Buffer.new(10, 5)
+      buffer.set_cell(0, 0, "").should be_false                        # empty string rejected
+      buffer.set_cell(0, 0, "\u{7F}").should be_false                  # DEL rejected as control
+      buffer.set_cell(0, 0, '\u{80}').should be_false                  # C1 control rejected (2-byte UTF-8)
+      buffer.set_cell(0, 0, String.new(Bytes[0xFF_u8])).should be_true # invalid byte keeps replacement-char acceptance
+    end
+
     it "sets cell with attributes" do
       buffer = Termisu::Buffer.new(10, 5)
       buffer.set_cell(3, 3, 'B', attr: Termisu::Attribute::Bold)

--- a/spec/termisu/cell_spec.cr
+++ b/spec/termisu/cell_spec.cr
@@ -210,6 +210,26 @@ describe Termisu::Cell do
     end
   end
 
+  describe "ASCII fast path" do
+    it "matches UnicodeWidth.grapheme_width for every ASCII codepoint" do
+      (0..127).each do |codepoint|
+        grapheme = codepoint.chr.to_s
+        Termisu::Cell.new(grapheme).width.should eq(Termisu::UnicodeWidth.grapheme_width(grapheme))
+      end
+    end
+
+    it "assigns width 0 to C0 controls and DEL" do
+      Termisu::Cell.new("\u0000").width.should eq(0u8)
+      Termisu::Cell.new("\u007f").width.should eq(0u8)
+    end
+
+    it "stores a single invalid byte >= 0x80 raw with width 1 via the slow path" do
+      cell = Termisu::Cell.new(String.new(Bytes[0xFF_u8]))
+      cell.grapheme.bytesize.should eq(1)
+      cell.width.should eq(1u8)
+    end
+  end
+
   describe "#== with new fields" do
     it "returns false for different grapheme" do
       cell1 = Termisu::Cell.new("A")

--- a/spec/termisu/input/parser_spec.cr
+++ b/spec/termisu/input/parser_spec.cr
@@ -378,6 +378,24 @@ describe Termisu::Input::Parser do
       end
     end
 
+    context "Linux console function keys (\\e[[A-\\e[[E)" do
+      it "parses F1 (\\e[[A)" do
+        event = parse_sequence(Bytes[0x1B, '['.ord, '['.ord, 'A'.ord])
+        event.should be_a(Termisu::Event::Key)
+        if event.is_a?(Termisu::Event::Key)
+          event.key.should eq(Termisu::Input::Key::F1)
+        end
+      end
+
+      it "parses F5 (\\e[[E)" do
+        event = parse_sequence(Bytes[0x1B, '['.ord, '['.ord, 'E'.ord])
+        event.should be_a(Termisu::Event::Key)
+        if event.is_a?(Termisu::Event::Key)
+          event.key.should eq(Termisu::Input::Key::F5)
+        end
+      end
+    end
+
     context "Alt+key sequences" do
       it "parses Alt+a (\\ea)" do
         event = parse_sequence(Bytes[0x1B, 'a'.ord])
@@ -513,14 +531,13 @@ describe Termisu::Input::Parser do
         end
       end
 
-      it "defaults malformed non-ASCII coordinate params (\\e[<0;\\xC3;5M)" do
+      it "rejects malformed non-ASCII coordinate params (\\e[<0;\\xC3;5M)" do
         seq = Bytes[0x1B, '['.ord, '<'.ord, '0'.ord, ';'.ord, 0xC3, ';'.ord, '5'.ord, 'M'.ord]
         event = parse_sequence(seq)
-        event.should be_a(Termisu::Event::Mouse)
-        if event.is_a?(Termisu::Event::Mouse)
-          event.button.should eq(Termisu::Event::Mouse::Button::Left)
-          event.x.should eq(1) # "\xC3" fails to_i?, defaults to 1
-          event.y.should eq(5)
+        # A coordinate that fails to_i? must not fabricate a mouse event.
+        event.should be_a(Termisu::Event::Key)
+        if event.is_a?(Termisu::Event::Key)
+          event.key.should eq(Termisu::Input::Key::Unknown)
         end
       end
     end

--- a/spec/termisu/input/parser_spec.cr
+++ b/spec/termisu/input/parser_spec.cr
@@ -503,6 +503,26 @@ describe Termisu::Input::Parser do
           event.y.should eq(1000)
         end
       end
+
+      it "aborts overlong SGR sequences with Key::Unknown" do
+        seq = ("\e[<" + "9" * 40 + "M").to_slice
+        event = parse_sequence(seq)
+        event.should be_a(Termisu::Event::Key)
+        if event.is_a?(Termisu::Event::Key)
+          event.key.should eq(Termisu::Input::Key::Unknown)
+        end
+      end
+
+      it "defaults malformed non-ASCII coordinate params (\\e[<0;\\xC3;5M)" do
+        seq = Bytes[0x1B, '['.ord, '<'.ord, '0'.ord, ';'.ord, 0xC3, ';'.ord, '5'.ord, 'M'.ord]
+        event = parse_sequence(seq)
+        event.should be_a(Termisu::Event::Mouse)
+        if event.is_a?(Termisu::Event::Mouse)
+          event.button.should eq(Termisu::Event::Mouse::Button::Left)
+          event.x.should eq(1) # "\xC3" fails to_i?, defaults to 1
+          event.y.should eq(5)
+        end
+      end
     end
 
     context "normal mouse protocol" do

--- a/spec/termisu/terminal_caching_spec.cr
+++ b/spec/termisu/terminal_caching_spec.cr
@@ -304,6 +304,51 @@ describe "Terminal State Caching" do
     end
   end
 
+  describe "Terminal SGR color sequences" do
+    # Locks byte identity of Terminal's precomputed SGR lookup tables at the
+    # table edges, exercising the real Terminal implementation.
+    it "emits exact ANSI-8 sequences at table boundaries" do
+      terminal = CaptureTerminal.new
+
+      terminal.foreground = Termisu::Color.ansi8(0)
+      terminal.writes.should contain("\e[30m")
+      terminal.foreground = Termisu::Color.ansi8(7)
+      terminal.writes.should contain("\e[37m")
+
+      terminal.background = Termisu::Color.ansi8(0)
+      terminal.writes.should contain("\e[40m")
+      terminal.background = Termisu::Color.ansi8(7)
+      terminal.writes.should contain("\e[47m")
+    ensure
+      terminal.try &.close
+    end
+
+    it "emits exact ANSI-256 sequences at table boundaries" do
+      terminal = CaptureTerminal.new
+
+      terminal.foreground = Termisu::Color.ansi256(0)
+      terminal.writes.should contain("\e[38;5;0m")
+      terminal.foreground = Termisu::Color.ansi256(255)
+      terminal.writes.should contain("\e[38;5;255m")
+
+      terminal.background = Termisu::Color.ansi256(0)
+      terminal.writes.should contain("\e[48;5;0m")
+      terminal.background = Termisu::Color.ansi256(255)
+      terminal.writes.should contain("\e[48;5;255m")
+    ensure
+      terminal.try &.close
+    end
+
+    it "emits exact ANSI-256 background sequence" do
+      terminal = CaptureTerminal.new
+
+      terminal.background = Termisu::Color.ansi256(208)
+      terminal.writes.should contain("\e[48;5;208m")
+    ensure
+      terminal.try &.close
+    end
+  end
+
   describe "integration with Buffer rendering" do
     it "caching works through Renderer interface" do
       terminal = CaptureRenderer.new

--- a/spec/termisu/terminfo/cursor_position_spec.cr
+++ b/spec/termisu/terminfo/cursor_position_spec.cr
@@ -1,0 +1,45 @@
+require "../../spec_helper"
+
+# Regression spec pinning the cursor_position_seq fast path (direct string
+# interpolation for the standard ANSI cup capability) to tparm output.
+describe Termisu::Terminfo do
+  describe "#cursor_position_seq fast-path equivalence" do
+    it "matches Tparm.process of the raw cup capability for sample coordinates" do
+      original_term = ENV["TERM"]?
+
+      begin
+        ENV["TERM"] = "xterm"
+        term = Termisu::Terminfo.new
+
+        [{0, 0}, {9, 19}, {23, 79}, {999, 999}].each do |(row, col)|
+          expected = Termisu::Terminfo::Tparm.process(term.cup_seq, row, col)
+          term.cursor_position_seq(row, col).should eq(expected)
+        end
+      ensure
+        if original_term
+          ENV["TERM"] = original_term
+        else
+          ENV.delete("TERM")
+        end
+      end
+    end
+
+    it "produces the expected sequences for the standard cup template" do
+      original_term = ENV["TERM"]?
+
+      begin
+        ENV["TERM"] = "xterm"
+        term = Termisu::Terminfo.new
+        term.cursor_position_seq(0, 0).should eq("\e[1;1H")
+        term.cursor_position_seq(23, 79).should eq("\e[24;80H")
+        term.cursor_position_seq(999, 999).should eq("\e[1000;1000H")
+      ensure
+        if original_term
+          ENV["TERM"] = original_term
+        else
+          ENV.delete("TERM")
+        end
+      end
+    end
+  end
+end

--- a/spec/termisu/unicode_width_spec.cr
+++ b/spec/termisu/unicode_width_spec.cr
@@ -187,6 +187,22 @@ describe Termisu::UnicodeWidth do
       Termisu::UnicodeWidth.codepoint_width(0x1F700).should eq(1)
     end
 
+    it "returns 1 for printable codepoints below the first combining range" do
+      # No-break space (untested gap between 0x9F and 0x0300)
+      Termisu::UnicodeWidth.codepoint_width(0x00A0).should eq(1)
+      # Last codepoint before Combining Diacritical Marks (U+0300)
+      Termisu::UnicodeWidth.codepoint_width(0x02FF).should eq(1)
+    end
+
+    it "matches control-character classification for all codepoints below U+0300" do
+      # Locks the fast-path invariant: below U+0300 the only zero-width
+      # codepoints are C0/C1 controls; everything else is width 1.
+      (0..0x02FF).each do |codepoint|
+        expected = codepoint < 32 || (0x7F..0x9F).includes?(codepoint) ? 0 : 1
+        Termisu::UnicodeWidth.codepoint_width(codepoint).should eq(expected)
+      end
+    end
+
     it "returns 2 for emoji within previously overbroad supplementary range" do
       # Geometric Shapes Extended — colored circles/squares ARE emoji
       Termisu::UnicodeWidth.codepoint_width(0x1F7E0).should eq(2) # 🟠
@@ -269,6 +285,21 @@ describe Termisu::UnicodeWidth do
       # US flag: regional indicator U + regional indicator S
       grapheme = "🇺🇸"
       Termisu::UnicodeWidth.grapheme_width(grapheme).should eq(2)
+    end
+
+    it "returns 1 for a lone regional indicator" do
+      Termisu::UnicodeWidth.grapheme_width("\u{1F1FA}").should eq(1) # 🇺
+    end
+
+    it "returns 1 for overlong regional indicator strings" do
+      # Three regional indicators: not a flag pair, falls through to the
+      # lone-regional-indicator base rule.
+      Termisu::UnicodeWidth.grapheme_width("\u{1F1FA}\u{1F1F8}\u{1F1FA}").should eq(1)
+    end
+
+    it "returns 1 for a regional indicator followed by a non-indicator" do
+      # ri_count of 1 blocks the pair rule; base-RI rule yields 1.
+      Termisu::UnicodeWidth.grapheme_width("\u{1F1FA}A").should eq(1)
     end
 
     it "returns 2 for skin tone modified emoji" do

--- a/src/termisu.cr
+++ b/src/termisu.cr
@@ -50,7 +50,9 @@ class Termisu
 
     # Create async event sources
     @input_source = Event::Source::Input.new(@reader, @input_parser)
-    @resize_source = Event::Source::Resize.new(-> { @terminal.size })
+    # Must be query_size (live ioctl), not size (cached) - the resize
+    # source detects changes by re-querying the terminal dimensions.
+    @resize_source = Event::Source::Resize.new(-> { @terminal.query_size })
 
     # Timer source is optional (nil by default)
     # Can be either sleep-based Timer or kernel-level SystemTimer

--- a/src/termisu/buffer.cr
+++ b/src/termisu/buffer.cr
@@ -72,7 +72,7 @@ class Termisu::Buffer
     attr : Attribute = Attribute::None,
   ) : Bool
     return false if out_of_bounds?(x, y)
-    return false unless grapheme.grapheme_size == 1
+    return false unless single_grapheme?(grapheme)
     return false if control_char?(grapheme[0])
 
     # Create cell to determine width
@@ -92,6 +92,11 @@ class Termisu::Buffer
     true
   end
 
+  # Interned single-character strings for ASCII, avoiding one Char#to_s heap
+  # allocation per set_cell(Char) call. Control-char entries are harmless:
+  # they are rejected downstream by control_char?, identical to ch.to_s.
+  private ASCII_GRAPHEMES = Array(String).new(128, &.unsafe_chr.to_s)
+
   def set_cell(
     x : Int32,
     y : Int32,
@@ -100,7 +105,9 @@ class Termisu::Buffer
     bg : Color = Color.default,
     attr : Attribute = Attribute::None,
   ) : Bool
-    set_cell(x, y, ch.to_s, fg, bg, attr)
+    # ch.ascii? proves ch.ord is in 0..127, so unsafe_fetch is in bounds.
+    grapheme = ch.ascii? ? ASCII_GRAPHEMES.unsafe_fetch(ch.ord) : ch.to_s
+    set_cell(x, y, grapheme, fg, bg, attr)
   end
 
   # Internal cell writer that handles occupancy invariants and overlap clearing.
@@ -108,7 +115,8 @@ class Termisu::Buffer
   # This is the core write primitive that handles:
   # - Wide character writes (creates leading + continuation cells)
   # - Overlap clearing when overwriting wide cells or their continuations
-  # - Pre-clearing target cells before writing
+  # - Direct overwrite of target cells (assign_back_cell handles count/dirty
+  #   deltas per transition)
   #
   # Assumes caller has validated bounds and fit constraints.
   private def set_cell_internal(x : Int32, y : Int32, cell : Cell, width : UInt8) : Nil
@@ -127,10 +135,9 @@ class Termisu::Buffer
         assign_back_cell(row_start + x + 2, y, Cell.default)
       end
 
-      # Pre-clear both target positions
-      assign_back_cell(row_start + x, y, Cell.default)
-      assign_back_cell(row_start + x + 1, y, Cell.default)
-
+      # Overwrite targets directly: assign_back_cell count/dirty updates depend
+      # only on old/new endpoints, so no pre-clear is needed; a rewrite of an
+      # identical wide cell is a no-op and leaves the row clean.
       # Write leading cell
       assign_back_cell(row_start + x, y, cell)
       # Write continuation cell
@@ -174,12 +181,7 @@ class Termisu::Buffer
       next if @row_non_default_counts[row] == 0
 
       row_start = row * @width
-      row_end = row_start + @width
-      idx = row_start
-      while idx < row_end
-        @back[idx] = Cell.default
-        idx += 1
-      end
+      @back.fill(Cell.default, row_start, @width)
 
       @row_non_default_counts[row] = 0
       mark_row_dirty(row)
@@ -202,9 +204,7 @@ class Termisu::Buffer
     # Using NUL character as the marker since it's never used in normal rendering.
     # Note: This intentionally creates width 0 non-continuation cells as sentinels.
     invalid_cell = Cell.new("\u0000", fg: Color.default, bg: Color.default, attr: Attribute::None)
-    @front.size.times do |index|
-      @front[index] = invalid_cell
-    end
+    @front.fill(invalid_cell)
     @render_state.reset
     mark_all_rows_dirty
   end
@@ -328,6 +328,16 @@ class Termisu::Buffer
     cp < 0x20 || (cp >= 0x7F && cp <= 0x9F)
   end
 
+  # Fast path: a single ASCII byte is always exactly one grapheme cluster,
+  # so skip the full segmentation walk (Char::Reader + property binary
+  # searches) that String#grapheme_size performs even for 1-char strings.
+  # Single bytes >= 0x80 (invalid UTF-8) intentionally fall through to
+  # grapheme_size to preserve existing replacement-character acceptance.
+  private def single_grapheme?(grapheme : String) : Bool
+    return true if grapheme.bytesize == 1 && grapheme.to_unsafe[0] < 0x80
+    grapheme.grapheme_size == 1
+  end
+
   # Assigns a cell in the back buffer while maintaining:
   # - non-default row counts (for selective clear)
   # - dirty row tracking (for selective render diff)
@@ -405,14 +415,22 @@ class Termisu::Buffer
     render_row(renderer, row, diff_only: false)
   end
 
+  # Bounds safety for unsafe_fetch/unsafe_put in render_row, skip_row_cell?,
+  # and render_row_batch: idx = row * @width + col with col < @width (loop
+  # guard) and row < @height (dirty_row_list entries and sync_to's
+  # height.times are always height-validated); @front/@back are always sized
+  # @width * @height (initialize/resize are the only array assignments).
+  # Renderer callbacks must not mutate this buffer reentrantly. If resize is
+  # ever made callable from a fiber other than the render fiber, or a
+  # mark_row_dirty call site is added with an unvalidated row, revisit this.
   private def render_row(renderer : Renderer, row : Int32, *, diff_only : Bool)
     row_start = row * @width
     col = 0
 
     while col < @width
       idx = row_start + col
-      back_cell = @back[idx]
-      front_cell = @front[idx]
+      back_cell = @back.unsafe_fetch(idx)
+      front_cell = @front.unsafe_fetch(idx)
 
       if skip_row_cell?(back_cell, front_cell, idx, diff_only)
         col += 1
@@ -424,12 +442,13 @@ class Termisu::Buffer
     end
   end
 
+  # bounds: see render_row (idx is a caller-validated in-bounds index)
   private def skip_row_cell?(back_cell : Cell, front_cell : Cell, idx : Int32, diff_only : Bool) : Bool
     return true if diff_only && back_cell == front_cell
 
     return false unless back_cell.continuation?
 
-    @front[idx] = back_cell
+    @front.unsafe_put(idx, back_cell)
     true
   end
 
@@ -451,13 +470,13 @@ class Termisu::Buffer
 
     while col < @width
       idx = row_start + col
-      back_cell = @back[idx]
-      front_cell = @front[idx]
+      back_cell = @back.unsafe_fetch(idx)
+      front_cell = @front.unsafe_fetch(idx)
 
       break if diff_only && back_cell == front_cell
 
       if back_cell.continuation?
-        @front[idx] = back_cell
+        @front.unsafe_put(idx, back_cell)
         col += 1
         next
       end
@@ -466,7 +485,7 @@ class Termisu::Buffer
 
       @batch_buffer << back_cell.grapheme
       columns_advanced += back_cell.width
-      @front[idx] = back_cell
+      @front.unsafe_put(idx, back_cell)
       col += 1
     end
 

--- a/src/termisu/cell.cr
+++ b/src/termisu/cell.cr
@@ -96,6 +96,18 @@ struct Termisu::Cell
     elsif grapheme.empty?
       @grapheme = " "
       @width = 1u8
+    elsif grapheme.bytesize == 1 && grapheme.to_unsafe[0] < 0x80
+      # ASCII fast path: a single byte < 0x80 is by definition exactly one
+      # grapheme cluster, so grapheme extraction (GraphemeIterator + Char#to_s,
+      # two heap allocations) and the truncation log are no-ops here.
+      # Width mirrors UnicodeWidth.grapheme_width over the whole ASCII range:
+      # C0 controls (< 0x20) and DEL (0x7F) are zero-width, everything else 1.
+      # Single bytes >= 0x80 are invalid UTF-8 and MUST fall through to the
+      # slow path so its existing behavior (raw byte stored, width 1) is
+      # preserved bit-for-bit. Do not "fix" this comment to say U+FFFD — the
+      # slow path does NOT substitute the replacement character.
+      byte = grapheme.to_unsafe[0]
+      @width = byte < 0x20 || byte == 0x7F ? 0u8 : 1u8
     else
       # Extract first grapheme cluster to ensure single-grapheme invariant
       first = grapheme.each_grapheme.first.to_s

--- a/src/termisu/event/poller/poll.cr
+++ b/src/termisu/event/poller/poll.cr
@@ -40,9 +40,15 @@ class Termisu::Event::Poller::Poll < Termisu::Event::Poller
       @next_deadline = monotonic_now + @interval
     end
 
-    # Creates a new state with updated deadline
-    def reset : TimerState
-      TimerState.new(@interval, @repeating)
+    # Anchors the deadline at a caller-provided clock snapshot,
+    # avoiding an extra clock read on the timer re-arm path.
+    def initialize(@interval : Time::Span, @repeating : Bool, now : MonotonicTime)
+      @next_deadline = now + @interval
+    end
+
+    # Creates a new state with the deadline anchored at *now*
+    def reset(now : MonotonicTime) : TimerState
+      TimerState.new(@interval, @repeating, now)
     end
   end
 
@@ -140,45 +146,51 @@ class Termisu::Event::Poller::Poll < Termisu::Event::Poller
     deadline = user_timeout ? monotonic_now + user_timeout : nil
 
     loop do
-      # Calculate effective timeout (factors in both deadline and timer deadlines)
-      timeout_ms = calculate_timeout(deadline)
+      # Single clock snapshot per phase; shared by all pre-poll checks
+      now = monotonic_now
 
       # Check for ready events (timers or fds) before polling
-      if ready = check_ready_events
+      if ready = check_ready_events(now)
         return ready
       end
 
       # Check if user deadline has passed
-      return nil if deadline_expired?(deadline)
+      return nil if deadline_expired?(deadline, now)
+
+      # Calculate effective timeout (factors in both deadline and timer deadlines)
+      timeout_ms = calculate_timeout(deadline, now)
 
       # poll() syscall
       result = poll_with_eintr(timeout_ms)
       raise IO::Error.from_errno("poll") if result < 0
 
-      # Check for ready events after poll
-      if ready = check_ready_events
+      # Check for ready events after poll (fresh snapshot — poll may have blocked)
+      now = monotonic_now
+      if ready = check_ready_events(now)
         return ready
       end
 
       # Check for timeout (no events, no timers, deadline passed)
-      return nil if deadline_expired?(deadline)
+      return nil if deadline_expired?(deadline, now)
       return nil if result == 0 && @timers.empty?
 
       # No events found, continue polling
       # This can happen if timeout was from timer calculation
-      # but timer hasn't quite expired yet due to timing variance
+      # but timer hasn't quite expired yet due to timing variance.
+      # Ready checks use a snapshot taken just before/after poll, so an
+      # event landing in that window is caught on the next iteration.
     end
   end
 
   # Checks if the user-supplied deadline has expired
-  private def deadline_expired?(deadline : MonotonicTime?) : Bool
+  private def deadline_expired?(deadline : MonotonicTime?, now : MonotonicTime) : Bool
     return false unless deadline
-    monotonic_now >= deadline
+    now >= deadline
   end
 
   # Checks for any ready events: expired timers first, then readable fds
-  private def check_ready_events : PollResult?
-    if timer_result = check_expired_timers
+  private def check_ready_events(now : MonotonicTime) : PollResult?
+    if timer_result = check_expired_timers(now)
       return timer_result
     end
     check_fd_events
@@ -199,12 +211,12 @@ class Termisu::Event::Poller::Poll < Termisu::Event::Poller
   end
 
   # Calculates poll timeout based on timer deadlines and user deadline
-  private def calculate_timeout(deadline : MonotonicTime?) : Int32
-    timer_timeout = timer_timeout_ms
+  private def calculate_timeout(deadline : MonotonicTime?, now : MonotonicTime) : Int32
+    timer_timeout = timer_timeout_ms(now)
 
     # Calculate remaining time to user deadline
     user_ms = if deadline
-                remaining = deadline - monotonic_now
+                remaining = deadline - now
                 remaining.total_milliseconds.to_i.clamp(0, Int32::MAX)
               else
                 nil
@@ -227,10 +239,9 @@ class Termisu::Event::Poller::Poll < Termisu::Event::Poller
   end
 
   # Returns timeout until next timer in milliseconds, or nil if no timers
-  private def timer_timeout_ms : Int32?
+  private def timer_timeout_ms(now : MonotonicTime) : Int32?
     return nil if @timers.empty?
 
-    now = monotonic_now
     min_timeout = Int32::MAX
 
     @timers.each_value do |state|
@@ -243,10 +254,8 @@ class Termisu::Event::Poller::Poll < Termisu::Event::Poller
   end
 
   # Checks for expired timers and returns result if found
-  private def check_expired_timers : PollResult?
+  private def check_expired_timers(now : MonotonicTime) : PollResult?
     return nil if @timers.empty?
-
-    now = monotonic_now
 
     @timers.each do |id, state|
       next unless now >= state.next_deadline
@@ -254,7 +263,7 @@ class Termisu::Event::Poller::Poll < Termisu::Event::Poller
       expirations = calculate_expirations(state, now)
 
       if state.repeating?
-        @timers[id] = state.reset
+        @timers[id] = state.reset(now)
       else
         @timers.delete(id)
       end

--- a/src/termisu/event/poller/poll.cr
+++ b/src/termisu/event/poller/poll.cr
@@ -150,7 +150,7 @@ class Termisu::Event::Poller::Poll < Termisu::Event::Poller
       now = monotonic_now
 
       # Check for ready events (timers or fds) before polling
-      if ready = check_ready_events(now)
+      if ready = check_ready_events(now, deadline)
         return ready
       end
 
@@ -166,7 +166,7 @@ class Termisu::Event::Poller::Poll < Termisu::Event::Poller
 
       # Check for ready events after poll (fresh snapshot — poll may have blocked)
       now = monotonic_now
-      if ready = check_ready_events(now)
+      if ready = check_ready_events(now, deadline)
         return ready
       end
 
@@ -188,9 +188,14 @@ class Termisu::Event::Poller::Poll < Termisu::Event::Poller
     now >= deadline
   end
 
-  # Checks for any ready events: expired timers first, then readable fds
-  private def check_ready_events(now : MonotonicTime) : PollResult?
-    if timer_result = check_expired_timers(now)
+  # Checks for any ready events: expired timers first, then readable fds.
+  #
+  # *deadline* is the user-supplied deadline (nil for an unbounded wait). A timer
+  # whose deadline lands after it is suppressed: a late poll() wakeup can push
+  # *now* past both the user deadline and a not-yet-due timer, and returning that
+  # timer would let it override an already-expired user timeout (BUG-011).
+  private def check_ready_events(now : MonotonicTime, deadline : MonotonicTime?) : PollResult?
+    if timer_result = check_expired_timers(now, deadline)
       return timer_result
     end
     check_fd_events
@@ -254,11 +259,14 @@ class Termisu::Event::Poller::Poll < Termisu::Event::Poller
   end
 
   # Checks for expired timers and returns result if found
-  private def check_expired_timers(now : MonotonicTime) : PollResult?
+  private def check_expired_timers(now : MonotonicTime, deadline : MonotonicTime?) : PollResult?
     return nil if @timers.empty?
 
     @timers.each do |id, state|
       next unless now >= state.next_deadline
+      # A timer due only after the user deadline must not win over that deadline
+      # when a late wakeup crosses both in the same snapshot.
+      next if deadline && state.next_deadline > deadline
 
       expirations = calculate_expirations(state, now)
 

--- a/src/termisu/input/parser.cr
+++ b/src/termisu/input/parser.cr
@@ -276,6 +276,18 @@ class Termisu::Input::Parser
     # because 'M' (0x4D) is itself inside the 0x40-0x7E final range.
     return parse_normal_mouse if first == 'M'.ord
 
+    # Linux console function keys: \e[[A through \e[[E. The second '[' (0x5B) is
+    # itself inside the 0x40-0x7E final range, so it must be handled before the
+    # fast path below — otherwise '[' is consumed as a final byte and the
+    # trailing key letter is lost.
+    if first == '['.ord
+      final = @reader.read_byte
+      return Event::Key.new(Key::Unknown) unless final
+
+      key = LINUX_CONSOLE_KEYS["[[#{final.unsafe_chr}"]? || Key::Unknown
+      return Event::Key.new(key)
+    end
+
     # Fast path: parameterless CSI keys (\e[A, \e[Z, bare \e[u, \e[~) — the
     # first byte is already the final char, so params is "" (value-identical
     # to an empty builder's to_s) and no builder allocation is needed.
@@ -331,19 +343,10 @@ class Termisu::Input::Parser
       return Event::Key.new(key, modifiers)
     end
 
-    # Standard CSI key lookup first — the hot path (arrows, Home/End, F1-F4,
-    # BackTab) returns before the interpolation below allocates.
+    # Standard CSI key lookup — the hot path (arrows, Home/End, F1-F4, BackTab).
+    # Linux console sequences (\e[[A etc.) are handled earlier in
+    # parse_csi_sequence, before the final-byte fast path consumes the '['.
     if key = CSI_KEYS[final]?
-      return Event::Key.new(key, modifiers)
-    end
-
-    # Linux console sequences (\e[[A etc.). Currently unreachable: a second
-    # '[' (0x5B, within the 0x40-0x7E final range) terminates the sequence in
-    # parse_csi_sequence, so params can never contain '['. Fixing Linux
-    # console F1-F5 would require special-casing the second '[' there before
-    # the final-byte check.
-    sequence = "[#{params}#{final}"
-    if key = LINUX_CONSOLE_KEYS[sequence]?
       return Event::Key.new(key, modifiers)
     end
 
@@ -565,8 +568,10 @@ class Termisu::Input::Parser
     return unless parts.size >= 3
 
     cb = parts[0].to_i? || return
-    x = parts[1].to_i? || 1
-    y = parts[2].to_i? || 1
+    # Reject malformed coordinates rather than fabricating a mouse event at a
+    # default position — invalid SGR params must not surface as an observable click.
+    x = parts[1].to_i? || return
+    y = parts[2].to_i? || return
 
     button = Event::Mouse::Button.from_cb(cb)
     # Wheel events are instantaneous - they don't have release events

--- a/src/termisu/input/parser.cr
+++ b/src/termisu/input/parser.cr
@@ -266,20 +266,26 @@ class Termisu::Input::Parser
   # CSI format: \e [ <params> <intermediate> <final>
   # Final chars are 0x40-0x7E (@A-Z[\]^_`a-z{|}~)
   private def parse_csi_sequence : Event::Any
+    first = @reader.read_byte
+    return Event::Key.new(Key::Unknown) unless first
+
+    # SGR mouse: \e[<...
+    return parse_sgr_mouse if first == '<'.ord
+
+    # Normal mouse: \e[M... — must be checked before the final-byte fast path
+    # because 'M' (0x4D) is itself inside the 0x40-0x7E final range.
+    return parse_normal_mouse if first == 'M'.ord
+
+    # Fast path: parameterless CSI keys (\e[A, \e[Z, bare \e[u, \e[~) — the
+    # first byte is already the final char, so params is "" (value-identical
+    # to an empty builder's to_s) and no builder allocation is needed.
+    return decode_csi_key("", first.unsafe_chr) if 0x40 <= first <= 0x7E
+
     buffer = String::Builder.new
+    buffer << first.chr
 
     while byte = @reader.read_byte
       char = byte.chr
-
-      # Check for SGR mouse: \e[<...
-      if buffer.empty? && char == '<'
-        return parse_sgr_mouse
-      end
-
-      # Check for normal mouse: \e[M...
-      if buffer.empty? && char == 'M'
-        return parse_normal_mouse
-      end
 
       if byte >= 0x40 && byte <= 0x7E
         # Final character - determines the key
@@ -325,15 +331,23 @@ class Termisu::Input::Parser
       return Event::Key.new(key, modifiers)
     end
 
-    # Check for Linux console sequences (\e[[A etc.)
+    # Standard CSI key lookup first — the hot path (arrows, Home/End, F1-F4,
+    # BackTab) returns before the interpolation below allocates.
+    if key = CSI_KEYS[final]?
+      return Event::Key.new(key, modifiers)
+    end
+
+    # Linux console sequences (\e[[A etc.). Currently unreachable: a second
+    # '[' (0x5B, within the 0x40-0x7E final range) terminates the sequence in
+    # parse_csi_sequence, so params can never contain '['. Fixing Linux
+    # console F1-F5 would require special-casing the second '[' there before
+    # the final-byte check.
     sequence = "[#{params}#{final}"
     if key = LINUX_CONSOLE_KEYS[sequence]?
       return Event::Key.new(key, modifiers)
     end
 
-    # Standard CSI key lookup
-    key = CSI_KEYS[final]? || Key::Unknown
-    Event::Key.new(key, modifiers)
+    Event::Key.new(Key::Unknown, modifiers)
   end
 
   # Parses Kitty keyboard protocol sequence.
@@ -517,15 +531,20 @@ class Termisu::Input::Parser
   #
   # Returns tuple of (raw params string, is_release flag) or nil if overflow/EOF.
   private def read_sgr_sequence : {String, Bool}?
-    buffer = String::Builder.new
+    # Stack buffer of raw bytes (may be invalid UTF-8 on malformed input; the
+    # sole consumer only splits/to_i?). The limit counts raw bytes, not
+    # UTF-8-expanded chars as the old String::Builder did.
+    buf = uninitialized UInt8[MAX_SEQUENCE_LENGTH]
+    len = 0
 
     while byte = @reader.read_byte
-      case byte.chr
-      when 'M' then return {buffer.to_s, false}
-      when 'm' then return {buffer.to_s, true}
+      case byte
+      when 'M'.ord then return {String.new(buf.to_slice[0, len]), false}
+      when 'm'.ord then return {String.new(buf.to_slice[0, len]), true}
       else
-        buffer << byte.chr
-        if buffer.bytesize >= MAX_SEQUENCE_LENGTH
+        buf[len] = byte
+        len += 1
+        if len >= MAX_SEQUENCE_LENGTH
           Log.warn { "SGR mouse sequence too long" }
           return
         end

--- a/src/termisu/terminal.cr
+++ b/src/termisu/terminal.cr
@@ -37,6 +37,10 @@ class Termisu::Terminal < Termisu::Renderer
   @cached_bg : Color?
   @cached_attr : Attribute = Attribute::None
 
+  # Cached terminal size to avoid a TIOCGWINSZ ioctl per write/move_cursor.
+  # Refreshed by resize() and invalidated after mode switches.
+  @cached_size : {Int32, Int32}?
+
   # Creates a new terminal.
   #
   # Parameters:
@@ -122,6 +126,16 @@ class Termisu::Terminal < Termisu::Renderer
     @cached_attr = Attribute::None
   end
 
+  # Precomputed SGR color sequences, indexed by color index.
+  # Entries MUST remain byte-identical to the former string interpolations.
+  # Indices are provably in range: color.default? is handled before the
+  # table lookup, and Color::Validator restricts ansi8 to -1..7 and
+  # ansi256 to -1..255 at construction.
+  private FG_ANSI8   = Array(String).new(8) { |i| "\e[3#{i}m" }
+  private BG_ANSI8   = Array(String).new(8) { |i| "\e[4#{i}m" }
+  private FG_ANSI256 = Array(String).new(256) { |i| "\e[38;5;#{i}m" }
+  private BG_ANSI256 = Array(String).new(256) { |i| "\e[48;5;#{i}m" }
+
   # Sets the foreground color with full ANSI-8, ANSI-256, and RGB support.
   #
   # Caches the color to avoid redundant escape sequences when called
@@ -135,9 +149,9 @@ class Termisu::Terminal < Termisu::Renderer
     else
       case color.mode
       when .ansi8?
-        write("\e[3#{color.index}m")
+        write(FG_ANSI8[color.index])
       when .ansi256?
-        write("\e[38;5;#{color.index}m")
+        write(FG_ANSI256[color.index])
       when .rgb?
         write("\e[38;2;#{color.r};#{color.g};#{color.b}m")
       end
@@ -157,9 +171,9 @@ class Termisu::Terminal < Termisu::Renderer
     else
       case color.mode
       when .ansi8?
-        write("\e[4#{color.index}m")
+        write(BG_ANSI8[color.index])
       when .ansi256?
-        write("\e[48;5;#{color.index}m")
+        write(BG_ANSI256[color.index])
       when .rgb?
         write("\e[48;2;#{color.r};#{color.g};#{color.b}m")
       end
@@ -253,8 +267,21 @@ class Termisu::Terminal < Termisu::Renderer
     @backend.flush
   end
 
-  # Delegates size to backend.
+  # Returns the terminal size as {width, height}.
+  #
+  # The value is cached to avoid an ioctl syscall on every call (write and
+  # move_cursor query size on hot rendering paths). The cache is refreshed
+  # by resize() and invalidated after mode switches. Use query_size to
+  # force a live query.
   def size : {Int32, Int32}
+    @cached_size ||= query_size
+  end
+
+  # Queries the terminal size directly from the backend.
+  #
+  # Always performs the live TIOCGWINSZ ioctl, bypassing the cache.
+  # Intended for resize detection, which must observe external size changes.
+  def query_size : {Int32, Int32}
     @backend.size
   end
 
@@ -370,6 +397,9 @@ class Termisu::Terminal < Termisu::Renderer
     # External programs during the mode block may have changed terminal
     # styling, making our cached fg/bg/attr assumptions stale.
     reset_render_state
+    # Drop the cached size - external programs during the mode block may
+    # have resized the terminal, so the next size call re-queries live.
+    @cached_size = nil
     flush
   end
 
@@ -529,8 +559,10 @@ class Termisu::Terminal < Termisu::Renderer
 
   # Resizes the buffer to new dimensions.
   #
-  # Preserves existing content where possible.
+  # Preserves existing content where possible. Also refreshes the cached
+  # size so subsequent size calls reflect the new dimensions.
   def resize(width : Int32, height : Int32)
+    @cached_size = {width, height}
     @buffer.resize(width, height)
     move_cursor
   end

--- a/src/termisu/terminfo.cr
+++ b/src/termisu/terminfo.cr
@@ -22,6 +22,12 @@
 # The `_seq` suffix indicates this clearly.
 class Termisu::Terminfo
   Log = Termisu::Logs::Terminfo
+
+  # The standard ANSI cup capability, byte-identical to the xterm/linux
+  # builtins. When the loaded cup matches this exactly, `cursor_position_seq`
+  # takes a direct-interpolation fast path instead of the tparm interpreter.
+  private STANDARD_CUP = "\e[%i%p1%d;%p2%dH"
+
   @caps : Hash(String, String)
 
   # Cached capability strings for frequently-used parametrized capabilities.
@@ -39,6 +45,26 @@ class Termisu::Terminfo
   @cached_il : String?
   @cached_dl : String?
 
+  # Cached capability strings for frequently-emitted attribute and cursor
+  # sequences. These avoid a hash lookup per escape-sequence emission during
+  # rendering (RenderState re-emits them on every style change).
+  @cached_sgr0 : String?
+  @cached_bold : String?
+  @cached_smul : String?
+  @cached_blink : String?
+  @cached_rev : String?
+  @cached_dim : String?
+  @cached_sitm : String?
+  @cached_invis : String?
+  @cached_smxx : String?
+  @cached_cnorm : String?
+  @cached_civis : String?
+  @cached_cvvis : String?
+
+  # True when the loaded cup capability equals STANDARD_CUP. Set once during
+  # initialization and never mutated afterwards (fiber-safe).
+  @cup_is_standard = false
+
   def initialize
     term_name = ENV["TERM"]? || raise Termisu::Error.new("TERM environment variable not set")
     Log.info { "Loading terminfo for TERM=#{term_name}" }
@@ -52,6 +78,7 @@ class Termisu::Terminfo
   # Pre-caches frequently-used parametrized capability strings.
   private def cache_frequent_capabilities
     @cached_cup = get_cap("cup")
+    @cup_is_standard = @cached_cup == STANDARD_CUP
     @cached_setaf = get_cap("setaf")
     @cached_setab = get_cap("setab")
     @cached_cuf = get_cap("cuf")
@@ -63,6 +90,18 @@ class Termisu::Terminfo
     @cached_ech = get_cap("ech")
     @cached_il = get_cap("il")
     @cached_dl = get_cap("dl")
+    @cached_sgr0 = get_cap("sgr0")
+    @cached_bold = get_cap("bold")
+    @cached_smul = get_cap("smul")
+    @cached_blink = get_cap("blink")
+    @cached_rev = get_cap("rev")
+    @cached_dim = get_cap("dim")
+    @cached_sitm = get_cap("sitm")
+    @cached_invis = get_cap("invis")
+    @cached_smxx = get_cap("smxx")
+    @cached_cnorm = get_cap("cnorm")
+    @cached_civis = get_cap("civis")
+    @cached_cvvis = get_cap("cvvis")
   end
 
   # Loads capabilities from the terminfo database.
@@ -128,18 +167,21 @@ class Termisu::Terminfo
   # --- Cursor Control Sequences ---
 
   # Returns escape sequence to show cursor (cnorm).
+  # Uses cached value to avoid hash lookup overhead.
   def show_cursor_seq : String
-    get_cap("cnorm")
+    @cached_cnorm || get_cap("cnorm")
   end
 
   # Returns escape sequence to hide cursor (civis).
+  # Uses cached value to avoid hash lookup overhead.
   def hide_cursor_seq : String
-    get_cap("civis")
+    @cached_civis || get_cap("civis")
   end
 
   # Returns escape sequence to make cursor blink/very visible (cvvis).
+  # Uses cached value to avoid hash lookup overhead.
   def blink_cursor_seq : String
-    get_cap("cvvis")
+    @cached_cvvis || get_cap("cvvis")
   end
 
   # Returns the raw cup capability string (parametrized).
@@ -152,10 +194,15 @@ class Termisu::Terminfo
 
   # Returns escape sequence to move cursor to position (row, col).
   #
-  # Uses the terminfo `cup` capability with tparm processing.
-  # Coordinates are 0-based and will be converted to 1-based by the %i
-  # operation in the capability string.
+  # Coordinates are 0-based and converted to 1-based by the %i operation in
+  # the capability string. When the loaded `cup` is the standard ANSI
+  # template, a direct-interpolation fast path is used (byte-identical to
+  # tparm output); non-standard cup strings fall back to tparm processing.
   def cursor_position_seq(row : Int32, col : Int32) : String
+    # Int64 arithmetic matches tparm's %i semantics exactly (Int32 `+ 1`
+    # would overflow at Int32::MAX where tparm emits "2147483648").
+    return "\e[#{row.to_i64 + 1};#{col.to_i64 + 1}H" if @cup_is_standard
+
     process_param_cap(@cached_cup, "cup", row, col)
   end
 
@@ -251,48 +298,57 @@ class Termisu::Terminfo
   # --- Text Attribute Sequences ---
 
   # Returns escape sequence to reset all attributes (sgr0).
+  # Uses cached value to avoid hash lookup overhead.
   def reset_attrs_seq : String
-    get_cap("sgr0")
+    @cached_sgr0 || get_cap("sgr0")
   end
 
   # Returns escape sequence to enable underline (smul).
+  # Uses cached value to avoid hash lookup overhead.
   def underline_seq : String
-    get_cap("smul")
+    @cached_smul || get_cap("smul")
   end
 
   # Returns escape sequence to enable bold (bold).
+  # Uses cached value to avoid hash lookup overhead.
   def bold_seq : String
-    get_cap("bold")
+    @cached_bold || get_cap("bold")
   end
 
   # Returns escape sequence to enable blink (blink).
+  # Uses cached value to avoid hash lookup overhead.
   def blink_seq : String
-    get_cap("blink")
+    @cached_blink || get_cap("blink")
   end
 
   # Returns escape sequence to enable reverse video (rev).
+  # Uses cached value to avoid hash lookup overhead.
   def reverse_seq : String
-    get_cap("rev")
+    @cached_rev || get_cap("rev")
   end
 
   # Returns escape sequence to enable dim/faint mode (dim).
+  # Uses cached value to avoid hash lookup overhead.
   def dim_seq : String
-    get_cap("dim")
+    @cached_dim || get_cap("dim")
   end
 
   # Returns escape sequence to enable italic/cursive mode (sitm).
+  # Uses cached value to avoid hash lookup overhead.
   def italic_seq : String
-    get_cap("sitm")
+    @cached_sitm || get_cap("sitm")
   end
 
   # Returns escape sequence to enable hidden/invisible mode (invis).
+  # Uses cached value to avoid hash lookup overhead.
   def hidden_seq : String
-    get_cap("invis")
+    @cached_invis || get_cap("invis")
   end
 
   # Returns escape sequence to enable strikethrough mode (smxx).
+  # Uses cached value to avoid hash lookup overhead.
   def strikethrough_seq : String
-    get_cap("smxx")
+    @cached_smxx || get_cap("smxx")
   end
 
   # --- Keypad Control Sequences ---

--- a/src/termisu/terminfo/tparm/conditional.cr
+++ b/src/termisu/terminfo/tparm/conditional.cr
@@ -26,10 +26,7 @@ module Termisu::Terminfo::Tparm::Conditional
 
     char = @format.byte_at(@pos).unsafe_chr
 
-    if op = Operations::BINARY[char]?
-      apply_binary_op(op)
-      return
-    end
+    return if dispatch_binary_op(char)
 
     case char
     when 'p'  then push_param

--- a/src/termisu/terminfo/tparm/operations.cr
+++ b/src/termisu/terminfo/tparm/operations.cr
@@ -1,8 +1,13 @@
-# Operations lookup tables for tparm processor.
+# Operations reference tables for tparm processor.
 #
-# This module provides dispatch tables for the tparm stack machine.
+# This module documents the operation set of the tparm stack machine.
 # The terminfo parametrized string format uses a stack-based language where
 # operations pop operands from the stack, compute results, and push them back.
+#
+# NOTE: These tables are kept as documentation/reference; actual dispatch
+# lives in Processor's inlined case/when methods (dispatch_binary_op,
+# dispatch_non_binary_op and friends), which avoid per-call hash lookups
+# and Proc indirection.
 #
 # ## Operation Categories
 #

--- a/src/termisu/terminfo/tparm/output.cr
+++ b/src/termisu/terminfo/tparm/output.cr
@@ -11,13 +11,15 @@ module Termisu::Terminfo::Tparm::Output
   # %d - Pop value and output as decimal integer.
   @[AlwaysInline]
   private def output_decimal
-    @output << pop.to_s
+    # IO#<<(Int64) formats digits directly into the IO without allocating a String.
+    @output << pop
   end
 
   # %s - Pop value and output as string.
   @[AlwaysInline]
   private def output_string
-    @output << pop.to_s
+    # IO#<<(Int64) formats digits directly into the IO without allocating a String.
+    @output << pop
   end
 
   # %l - Pop value, convert to string, push its length.

--- a/src/termisu/terminfo/tparm/processor.cr
+++ b/src/termisu/terminfo/tparm/processor.cr
@@ -36,33 +36,44 @@ class Termisu::Terminfo::Tparm::Processor
   @format : String
   @params : Array(Int64)
   @stack : Array(Int64)
-  @output : IO::Memory
+  @output : String::Builder
   @pos : Int32
   @format_size : Int32
-  @dynamic_vars : Hash(Char, Int64)
+  @dynamic_vars : Hash(Char, Int64)?
   @static_vars : Hash(Char, Int64)
 
   @@static_storage : Hash(Char, Int64) = {} of Char => Int64
 
   def initialize(@format : String, @params : Array(Int64))
     @stack = Array(Int64).new(INITIAL_STACK_CAPACITY)
-    @output = IO::Memory.new(INITIAL_OUTPUT_CAPACITY)
+    @output = String::Builder.new(INITIAL_OUTPUT_CAPACITY)
     @pos = 0
     @format_size = @format.bytesize
-    @dynamic_vars = {} of Char => Int64
+    @dynamic_vars = nil
     @static_vars = @@static_storage
   end
 
   # Executes the tparm processor and returns the formatted string.
+  #
+  # Must be called at most once per Processor instance: the output buffer is
+  # a String::Builder, whose `to_s` is single-shot. Processor is single-use
+  # by design (sole call site: `Tparm.process`).
   def run : String
+    slice = @format.to_slice
+    percent = '%'.ord.to_u8
     while @pos < @format_size
-      byte = @format.byte_at(@pos)
-      if byte == '%'.ord
+      if slice.unsafe_fetch(@pos) == percent
         process_escape
+        @pos += 1
       else
-        @output.write_byte(byte)
+        # Batch the literal run into a single slice write. unsafe_fetch is
+        # in-bounds: @pos < @format_size == slice.size (as in variables.cr).
+        start = @pos
+        while @pos < @format_size && slice.unsafe_fetch(@pos) != percent
+          @pos += 1
+        end
+        @output.write(slice[start, @pos - start])
       end
-      @pos += 1
     end
     @output.to_s
   end
@@ -74,19 +85,65 @@ class Termisu::Terminfo::Tparm::Processor
 
     char = @format.byte_at(@pos).unsafe_chr
 
-    if op = Operations::BINARY[char]?
-      apply_binary_op(op)
-      return
-    end
+    return if dispatch_binary_op(char)
 
     dispatch_non_binary_op(char)
   end
 
-  @[AlwaysInline]
-  private def apply_binary_op(op : Proc(Int64, Int64, Int64))
+  # Pops two operands (right first, then left), applies the block, and pushes
+  # the result. Yield-based so operator bodies inline into the dispatchers.
+  private def binary_op(& : Int64, Int64 -> Int64)
     right = pop
     left = pop
-    push(op.call(left, right))
+    push(yield(left, right))
+  end
+
+  @[AlwaysInline]
+  private def to_flag(value : Bool) : Int64
+    value ? 1_i64 : 0_i64
+  end
+
+  private def dispatch_binary_op(char : Char) : Bool
+    dispatch_arithmetic_op(char) ||
+      dispatch_bitwise_op(char) ||
+      dispatch_compare_op(char)
+  end
+
+  @[AlwaysInline]
+  private def dispatch_arithmetic_op(char : Char) : Bool
+    case char
+    when '+' then binary_op { |left, right| left + right }
+    when '-' then binary_op { |left, right| left - right }
+    when '*' then binary_op { |left, right| left * right }
+    when '/' then binary_op { |left, right| right != 0 ? left // right : 0_i64 }
+    when 'm' then binary_op { |left, right| right != 0 ? left % right : 0_i64 }
+    else          return false
+    end
+    true
+  end
+
+  @[AlwaysInline]
+  private def dispatch_bitwise_op(char : Char) : Bool
+    case char
+    when '&' then binary_op { |left, right| left & right }
+    when '|' then binary_op { |left, right| left | right }
+    when '^' then binary_op { |left, right| left ^ right }
+    else          return false
+    end
+    true
+  end
+
+  @[AlwaysInline]
+  private def dispatch_compare_op(char : Char) : Bool
+    case char
+    when '=' then binary_op { |left, right| to_flag(left == right) }
+    when '<' then binary_op { |left, right| to_flag(left < right) }
+    when '>' then binary_op { |left, right| to_flag(left > right) }
+    when 'A' then binary_op { |left, right| to_flag(left != 0 && right != 0) }
+    when 'O' then binary_op { |left, right| to_flag(left != 0 || right != 0) }
+    else          return false
+    end
+    true
   end
 
   private def dispatch_non_binary_op(char : Char)
@@ -140,6 +197,12 @@ class Termisu::Terminfo::Tparm::Processor
     else          return false
     end
     true
+  end
+
+  # Lazily allocated: %P/%g never appear in hot render-path capabilities
+  # (cup, cuf, setaf...), so most calls never need this hash.
+  private def dynamic_vars : Hash(Char, Int64)
+    @dynamic_vars ||= {} of Char => Int64
   end
 
   # --- Stack Operations ---

--- a/src/termisu/terminfo/tparm/variables.cr
+++ b/src/termisu/terminfo/tparm/variables.cr
@@ -20,7 +20,7 @@ module Termisu::Terminfo::Tparm::Variables
     var = @format.byte_at(@pos).unsafe_chr
     val = pop
     if var >= 'a' && var <= 'z'
-      @dynamic_vars[var] = val
+      dynamic_vars[var] = val
     elsif var >= 'A' && var <= 'Z'
       @static_vars[var] = val
     end
@@ -32,7 +32,12 @@ module Termisu::Terminfo::Tparm::Variables
     return if @pos >= @format_size
     var = @format.byte_at(@pos).unsafe_chr
     if var >= 'a' && var <= 'z'
-      push(@dynamic_vars.fetch(var, 0_i64))
+      # Read the raw ivar (not the allocating accessor): unset reads push 0.
+      if vars = @dynamic_vars
+        push(vars.fetch(var, 0_i64))
+      else
+        push(0_i64)
+      end
     elsif var >= 'A' && var <= 'Z'
       push(@static_vars.fetch(var, 0_i64))
     end

--- a/src/termisu/unicode_width.cr
+++ b/src/termisu/unicode_width.cr
@@ -34,6 +34,14 @@ module Termisu::UnicodeWidth
   # UnicodeWidth.codepoint_width(0x0301)  # => 0 (combining acute)
   # ```
   def self.codepoint_width(cp : Int32) : UInt8
+    # Fast path: below U+0300 the only zero-width codepoints are C0/C1
+    # controls (first combining range starts at U+0300, format controls at
+    # U+061C, variation selectors at U+FE00, emoji modifiers at U+1F3FB)
+    # and the lowest wide codepoint is U+1100 (Hangul Jamo).
+    if cp < 0x0300
+      return 0u8 if cp < 32 || (cp >= 0x7F && cp <= 0x9F)
+      return 1u8
+    end
     return 0u8 if zero_width_codepoint?(cp)
     return 2u8 if wide_codepoint?(cp)
     1u8
@@ -58,25 +66,75 @@ module Termisu::UnicodeWidth
   # ```
   def self.grapheme_width(grapheme : String) : UInt8
     return 0u8 if grapheme.empty?
-    return 2u8 if regional_indicator_pair?(grapheme)
 
-    width = calculate_grapheme_raw_width(grapheme)
-    return 0u8 if width == 0
+    # Fast path: single-codepoint grapheme (ASCII, Latin, CJK, lone symbols).
+    # Cluster rules (RI pairs, VS15/VS16, keycap, ZWJ) require >= 2 codepoints:
+    # all their trigger codepoints are themselves zero-width.
+    reader = Char::Reader.new(grapheme)
+    return codepoint_width(reader.current_char.ord) if reader.current_char_width == grapheme.bytesize
 
-    normalize_cluster_width(grapheme, width)
+    scan = scan_cluster(grapheme)
+    return 2u8 if scan.char_count == 2 && scan.ri_count == 2 # Regional indicator flag pair
+    return 0u8 if scan.raw_width == 0
+
+    normalize_cluster_width(scan)
   end
 
-  # Applies cluster normalization rules (VS15/VS16, ZWJ) to raw width.
+  # Applies cluster normalization rules (VS15/VS16, keycap, ZWJ) to a scanned
+  # cluster. The rule order is load-bearing (keycap before VS16) and must
+  # follow the raw_width == 0 check in `grapheme_width` — do not reorder.
   # :nodoc:
-  private def self.normalize_cluster_width(grapheme : String, raw_width : UInt32) : UInt8
-    return 1u8 if grapheme.includes?('\u{FE0E}') # VS15: text presentation
-    base_cp = grapheme.char_at(0).ord
-    return 2u8 if grapheme.includes?('\u{20E3}') && keycap_base?(base_cp)             # Keycap sequence (e.g. #️⃣ 1️⃣)
-    return 2u8 if grapheme.includes?('\u{FE0F}') && emoji_presentation_base?(base_cp) # VS16: emoji-capable bases only
-    return 2u8 if grapheme.includes?('\u{200D}') && raw_width > 1                     # ZWJ with emoji
-    return 1u8 if regional_indicator?(base_cp)                                        # Lone regional indicator
+  private def self.normalize_cluster_width(scan : ClusterScan) : UInt8
+    return 1u8 if scan.has_vs15                                           # VS15: text presentation
+    return 2u8 if scan.has_keycap && keycap_base?(scan.base_cp)           # Keycap sequence (e.g. #️⃣ 1️⃣)
+    return 2u8 if scan.has_vs16 && emoji_presentation_base?(scan.base_cp) # VS16: emoji-capable bases only
+    return 2u8 if scan.has_zwj && scan.raw_width > 1                      # ZWJ with emoji
+    return 1u8 if regional_indicator?(scan.base_cp)                       # Lone regional indicator
 
-    raw_width > 2 ? 2u8 : raw_width.to_u8
+    scan.raw_width > 2 ? 2u8 : scan.raw_width.to_u8
+  end
+
+  # Aggregated per-codepoint facts about a multi-codepoint grapheme cluster,
+  # collected by `scan_cluster` in a single decode pass.
+  # :nodoc:
+  private record ClusterScan,
+    raw_width : UInt32,
+    char_count : Int32,
+    ri_count : Int32,
+    base_cp : Int32,
+    has_vs15 : Bool,
+    has_vs16 : Bool,
+    has_keycap : Bool,
+    has_zwj : Bool
+
+  # Scans a grapheme cluster in one `each_char` pass.
+  # :nodoc:
+  private def self.scan_cluster(grapheme : String) : ClusterScan
+    raw_width = 0u32
+    char_count = 0
+    ri_count = 0
+    base_cp = 0
+    has_vs15 = false
+    has_vs16 = false
+    has_keycap = false
+    has_zwj = false
+
+    grapheme.each_char do |char|
+      cp = char.ord
+      base_cp = cp if char_count == 0
+      char_count += 1
+      ri_count += 1 if regional_indicator?(cp)
+      raw_width += codepoint_width(cp)
+
+      case cp
+      when 0xFE0E then has_vs15 = true
+      when 0xFE0F then has_vs16 = true
+      when 0x20E3 then has_keycap = true
+      when 0x200D then has_zwj = true
+      end
+    end
+
+    ClusterScan.new(raw_width, char_count, ri_count, base_cp, has_vs15, has_vs16, has_keycap, has_zwj)
   end
 
   # :nodoc:
@@ -101,17 +159,6 @@ module Termisu::UnicodeWidth
     (cp >= 0x202A && cp <= 0x202E) || (cp >= 0x2066 && cp <= 0x2069)
   end
 
-  # :nodoc:
-  private def self.calculate_grapheme_raw_width(grapheme : String) : UInt32
-    width = 0u32
-
-    grapheme.each_char do |char|
-      width += codepoint_width(char.ord)
-    end
-
-    width
-  end
-
   # Unicode combining mark ranges for categories Mn (Nonspacing_Mark)
   # and Me (Enclosing_Mark). Sorted by start codepoint for binary search.
   # Derived from Unicode 15.0 character database.
@@ -119,6 +166,10 @@ module Termisu::UnicodeWidth
   # Stored as a flat array of [start, end] pairs (inclusive on both sides).
   # Index `i * 2` = range start, `i * 2 + 1` = range end.
   # Use `COMBINING_MARK_COUNT` for the number of ranges.
+  #
+  # NOTE: `codepoint_width`'s fast path assumes no zero-width or wide entry
+  # exists below U+0300 — do not add a range starting below U+0300 without
+  # revisiting that fast path.
   COMBINING_MARK_RANGES = [
     # BMP: Latin/Cyrillic/Arabic/Indic combining marks
     0x0300, 0x036F, # Combining Diacritical Marks
@@ -483,8 +534,11 @@ module Termisu::UnicodeWidth
 
     while low <= high
       mid = low + (high - low) // 2
-      range_start = COMBINING_MARK_RANGES[mid * 2]
-      range_end = COMBINING_MARK_RANGES[mid * 2 + 1]
+      # SAFETY: loop maintains 0 <= low <= mid <= high <= COMBINING_MARK_COUNT - 1,
+      # so mid * 2 + 1 <= 2 * COMBINING_MARK_COUNT - 1 <= COMBINING_MARK_RANGES.size - 1;
+      # the table is never mutated.
+      range_start = COMBINING_MARK_RANGES.unsafe_fetch(mid * 2)
+      range_end = COMBINING_MARK_RANGES.unsafe_fetch(mid * 2 + 1)
 
       if cp < range_start
         high = mid - 1
@@ -516,19 +570,6 @@ module Termisu::UnicodeWidth
   private def self.regional_indicator?(cp : Int32) : Bool
     # Regional Indicator Symbols (A-Z)
     (0x1F1E6..0x1F1FF).includes?(cp)
-  end
-
-  # :nodoc:
-  private def self.regional_indicator_pair?(grapheme : String) : Bool
-    # Check if string has exactly 2 regional indicators (flag emoji).
-    # Iterates codepoints directly to avoid allocating an intermediate array.
-    count = 0
-    grapheme.each_char do |char|
-      return false unless regional_indicator?(char.ord)
-      count += 1
-      return false if count > 2
-    end
-    count == 2
   end
 
   # Returns true if the codepoint has the Unicode `Emoji` property and can be


### PR DESCRIPTION
Zero-allocation ASCII cell writes (interned graphemes, Cell fast path,
single-pass unicode width), cached terminal size (drops a TIOCGWINSZ
ioctl per write/move_cursor), precomputed SGR color and attribute
sequences, a direct-interpolation fast path for standard cup, and
inlined tparm dispatch with lazy variable storage. Full-frame
set+render drops from 3.7ms/525KB to 209us/0B on a 120x40 grid.