### PR TITLE
fix: drop the removed Crystal::ThreadLocalValue dependency

### DIFF
--- a/src/termisu/ffi/error_state.cr
+++ b/src/termisu/ffi/error_state.cr
@@ -1,18 +1,28 @@
-require "crystal/thread_local_value"
-
 module Termisu::FFI::ErrorState
-  @@last_error = Crystal::ThreadLocalValue(String).new
+  # Per-thread last error message, in the errno style the C API expects: a caller runs an
+  # operation and then reads the message back, without another thread's failure overwriting it.
+  #
+  # This used to be `Crystal::ThreadLocalValue`, a private stdlib type that Crystal 1.21 removed,
+  # so keep a minimal equivalent here. A plain `@[ThreadLocal]` class variable is not a safe
+  # substitute for a String: a value reachable *only* from thread-local storage is invisible to
+  # the GC and may be collected while still in use, and the annotation is unavailable on the
+  # emulated-TLS targets (Android, OpenBSD, windows-gnu). Keying a Hash on the current thread
+  # keeps a strong reference and works everywhere.
+  @@mutex = Mutex.new(:unchecked)
+  @@last_error = {} of Thread => String
 
   def self.current : String
-    @@last_error.get { "" }
+    @@mutex.synchronize { @@last_error[Thread.current]? } || ""
   end
 
   def self.set(message : String) : Nil
-    @@last_error.set(message)
+    @@mutex.synchronize { @@last_error[Thread.current] = message }
   end
 
   def self.clear : Nil
-    @@last_error.set("")
+    # Dropping the entry and storing "" are indistinguishable through `current`; dropping it
+    # also releases the message.
+    @@mutex.synchronize { @@last_error.delete(Thread.current) }
   end
 
   def self.format(ex : Exception) : String

--- a/src/termisu/ffi/error_state.cr
+++ b/src/termisu/ffi/error_state.cr
@@ -2,31 +2,46 @@ module Termisu::FFI::ErrorState
   # Per-thread last error message, in the errno style the C API expects: a caller runs an
   # operation and then reads the message back, without another thread's failure overwriting it.
   #
-  # This used to be `Crystal::ThreadLocalValue`, a private stdlib type that Crystal 1.21 removed,
-  # so keep a minimal equivalent here. A plain `@[ThreadLocal]` class variable is not a safe
-  # substitute for a String: a value reachable *only* from thread-local storage is invisible to
-  # the GC and may be collected while still in use, and the annotation is unavailable on the
-  # emulated-TLS targets (Android, OpenBSD, windows-gnu). Keying a Hash on the current thread
-  # keeps a strong reference and works everywhere.
-  @@mutex = Mutex.new(:unchecked)
+  # `Crystal::ThreadLocalValue` (removed in Crystal 1.21) is replaced with a minimal equivalent.
+  # A plain `@[ThreadLocal]` class variable is not a safe substitute for a String: a value
+  # reachable only from thread-local storage is invisible to the GC, and the annotation is
+  # unavailable on emulated-TLS targets. Keying a Hash on the current thread keeps a strong
+  # reference and works everywhere.
+  #
+  # The lock is a raw atomic spinlock rather than `Mutex`: the C ABI may be entered from
+  # arbitrary host threads, and a contended `Mutex` parks the calling *fiber* through the
+  # scheduler, which aborts the process when it happens off the main thread in default
+  # (non-`execution_context`) builds. Critical sections here are a single Hash op, so
+  # busy-waiting is safe on any thread.
+  @@lock = Atomic(Int32).new(0)
   @@last_error = {} of Thread => String
 
   def self.current : String
-    @@mutex.synchronize { @@last_error[Thread.current]? } || ""
+    sync { @@last_error[Thread.current]? } || ""
   end
 
   def self.set(message : String) : Nil
-    @@mutex.synchronize { @@last_error[Thread.current] = message }
+    sync { @@last_error[Thread.current] = message }
   end
 
   def self.clear : Nil
     # Dropping the entry and storing "" are indistinguishable through `current`; dropping it
     # also releases the message.
-    @@mutex.synchronize { @@last_error.delete(Thread.current) }
+    sync { @@last_error.delete(Thread.current) }
   end
 
   def self.format(ex : Exception) : String
     msg = ex.message
     msg ? "#{ex.class.name}: #{msg}" : ex.class.name
+  end
+
+  private def self.sync(&)
+    until @@lock.compare_and_set(0, 1, :acquire, :relaxed)[1]
+    end
+    begin
+      yield
+    ensure
+      @@lock.set(0, :release)
+    end
   end
 end


### PR DESCRIPTION
Hi @omarluq,
In Crystal v1.21, the private `crystal/thread_local_value` was removed, which causes termisu v0.5.1 to fail to compile.

I forked the repository and applied the necessary changes to resolve this compatibility issue for the tool I'm developing. I'm submitting this PR because I thought it might also be helpful for the upstream project.

This PR is open to modifications, please feel free to edit or adjust anything as needed.
Thank you!