### PR TITLE
fix(input): a Ctrl/Alt chord must not arm the dup guard

### DIFF
--- a/spec/termisu/input/parser_spec.cr
+++ b/spec/termisu/input/parser_spec.cr
@@ -668,6 +668,40 @@ describe Termisu::Input::Parser do
       events[1].as(Termisu::Event::Key).char.should be_nil
       events[2].as(Termisu::Event::Key).char.should eq('y')
     end
+
+    # A modified key arrives as CSI-u with an EMPTY text field, so `c` falls back
+    # to the codepoint and Ctrl+P yields c == 'p'. The terminal sends Ctrl+P as
+    # the control byte 0x10 and never as a raw 'p', so such a report must not arm
+    # the dup guard — otherwise it eats the next plain 'p' the user types.
+    it "keeps a plain key typed right after the same letter under Ctrl" do
+      # Ctrl+p -> CSI 112;5u (no text field), then raw "pet".
+      bytes = Bytes[0x1B, '['.ord, '1'.ord, '1'.ord, '2'.ord, ';'.ord, '5'.ord, 'u'.ord,
+        'p'.ord, 'e'.ord, 't'.ord]
+      events = parse_events(bytes, 4)
+      events[0].as(Termisu::Event::Key).modifiers.ctrl?.should be_true
+      events[1].as(Termisu::Event::Key).char.should eq('p')
+      events[2].as(Termisu::Event::Key).char.should eq('e')
+      events[3].as(Termisu::Event::Key).char.should eq('t')
+    end
+
+    it "keeps a plain key typed right after the same letter under Alt" do
+      # Alt+p -> CSI 112;3u, then raw 'p'.
+      bytes = Bytes[0x1B, '['.ord, '1'.ord, '1'.ord, '2'.ord, ';'.ord, '3'.ord, 'u'.ord,
+        'p'.ord]
+      events = parse_events(bytes, 2)
+      events[0].as(Termisu::Event::Key).modifiers.alt?.should be_true
+      events[1].as(Termisu::Event::Key).char.should eq('p')
+    end
+
+    it "keeps a plain key typed right after the same letter under modifyOtherKeys Ctrl" do
+      # Ctrl+p via modifyOtherKeys -> CSI 27;5;112~, then raw 'p'.
+      bytes = Bytes[0x1B, '['.ord, '2'.ord, '7'.ord, ';'.ord, '5'.ord, ';'.ord,
+        '1'.ord, '1'.ord, '2'.ord, '~'.ord,
+        'p'.ord]
+      events = parse_events(bytes, 2)
+      events[0].as(Termisu::Event::Key).modifiers.ctrl?.should be_true
+      events[1].as(Termisu::Event::Key).char.should eq('p')
+    end
   end
 end
 

--- a/src/termisu/input/parser.cr
+++ b/src/termisu/input/parser.cr
@@ -398,7 +398,7 @@ class Termisu::Input::Parser
     key = codepoint_to_key(codepoint)
     # Arm the one-shot dup guard so a duplicate raw echo of this exact char
     # (same byte immediately following) is swallowed; plain keys never match it.
-    @dup_guard = c if producing_text?(c)
+    @dup_guard = c if echoable_text?(c, modifiers)
     Event::Key.new(key, modifiers, char: c)
   end
 
@@ -407,6 +407,20 @@ class Termisu::Input::Parser
   private def producing_text?(c : Char?) : Bool
     return false unless c
     c.printable? && c.ord >= 32
+  end
+
+  # Whether this CSI-u report is one the terminal might ALSO echo as a raw byte —
+  # the only case the dup guard exists for.
+  #
+  # Ctrl/Alt/Meta-modified keys never are: a terminal sends Ctrl+P as the control
+  # byte 0x10, never as a raw 'p'. But `c` falls back to the CODEPOINT when the
+  # text field is empty, so Ctrl+P yields c == 'p' and gating on producing_text?
+  # alone armed the guard with 'p' — swallowing the very next plain 'p' the user
+  # typed. Shift+letter and IME commits (which DO carry text and DO get echoed)
+  # are unaffected, since they carry no Ctrl/Alt/Meta.
+  private def echoable_text?(c : Char?, modifiers : Modifier) : Bool
+    return false unless producing_text?(c)
+    !(modifiers.ctrl? || modifiers.alt? || modifiers.meta?)
   end
 
   # Parses modifyOtherKeys sequence.
@@ -421,10 +435,11 @@ class Termisu::Input::Parser
 
     # If modify reports a printable via CSI, the terminal is using the protocol
     # for text; arm the one-shot dup guard so only a duplicate raw echo of this
-    # exact char is swallowed (plain raw keys keep flowing).
+    # exact char is swallowed (plain raw keys keep flowing). Same modifier caveat
+    # as the Kitty path — see echoable_text?.
     if producing_text?(c)
       @protocol_active = true
-      @dup_guard = c
+      @dup_guard = c if echoable_text?(c, modifiers)
     end
 
     Event::Key.new(key, modifiers, char: c)


### PR DESCRIPTION
Hi @omarluq 
There was an issue with key input, so I fixed it in my fork. I thought it would be good to contribute this upstream as well, so I’m submitting a PR. 

This is an editable PR, so feel free to make any changes :)

---
Under the Kitty protocol (`\e[>17u`) a modified key arrives as CSI-u with an **empty text field**, so `parse_kitty_key`'s

```crystal
c = text_str[0]? || (valid_codepoint?(codepoint) ? codepoint.chr : nil)
```

falls back to the codepoint and `Ctrl+P` yields `c == 'p'`. The one-shot dup guard — which exists to swallow a terminal echoing an IME commit on both the CSI-u and raw-byte channels — was then armed with `'p'` by a bare `producing_text?(c)` check that never looked at the modifiers, and it ate the very next raw `'p'` the user typed.

Concretely, in a host app: `^P` to open a command palette and then typing `pet` produced `et`.

A terminal sends `Ctrl+P` as the control byte `0x10` and never as a raw `'p'`, so a Ctrl/Alt/Meta report must never arm the guard.

### Fix

A new `echoable_text?(c, modifiers)` applied at both arming sites (`parse_kitty_key` and `parse_modify_other_keys`). Shift+letter and IME commits are unaffected: they carry text and no Ctrl/Alt/Meta, so they still dedup.

### Tests

Three regression specs drive the parser over an `IO.pipe`:

- Kitty `Ctrl+p` (`CSI 112;5u`) then raw `pet`
- `Alt+p` (`CSI 112;3u`) then raw `p`
- the modifyOtherKeys form `CSI 27;5;112~` then raw `p`

All three fail without the fix (verified by reverting the change and re-running); the guard's real case — the existing "drops only an exact duplicate raw echo of the CSI-u char" spec — still passes.

Full suite is green (1327 examples, 0 failures) when run under a pty. Without one, the FFI/backend specs fail on `/dev/tty` regardless of this change.

Note: this does **not** reproduce under tmux, which ignores `\e[>17u` — only on a real Kitty-protocol terminal (Ghostty/Kitty/WezTerm).
