### PR TITLE
fix(termios): raw mode never actually cleared the input/output flags

### DIFF
--- a/spec/termisu/termios_spec.cr
+++ b/spec/termisu/termios_spec.cr
@@ -1,5 +1,13 @@
 require "../spec_helper"
 
+# The terminal attributes as the kernel currently holds them — the flag specs below assert
+# against the fd, never against `Termios#current_mode`.
+private def attrs_of(fd : Int32) : LibC::Termios
+  tios = uninitialized LibC::Termios
+  LibC.tcgetattr(fd, pointerof(tios)).should eq(0)
+  tios
+end
+
 describe Termisu::Termios do
   describe "#enable_raw_mode" do
     it "raises IO::Error with invalid file descriptor" do
@@ -154,8 +162,7 @@ describe Termisu::Termios do
       termios = Termisu::Termios.new(STDOUT.fd)
       termios.enable_raw_mode
 
-      tios = uninitialized LibC::Termios
-      LibC.tcgetattr(STDOUT.fd, pointerof(tios)).should eq(0)
+      tios = attrs_of(STDOUT.fd)
       (tios.c_iflag & LibC::ICRNL).should eq(0)
       (tios.c_iflag & LibC::IXON).should eq(0)
       (tios.c_oflag & LibC::OPOST).should eq(0)
@@ -163,14 +170,32 @@ describe Termisu::Termios do
       termios.try &.restore
     end
 
-    it "honours a mode that asks for CR→NL back" do
+    # ROUND-TRIP, not a single positive assertion. `Mode::CrToNl`, `Mode::FlowControl` and
+    # `Mode::OutputProcessing` were dead for the same reason, so each needs covering — but
+    # asserting only that a mode which ASKS for a flag ends up with it set proves nothing
+    # here: the terminal a developer runs the suite in already has ICRNL/IXON/OPOST on, so
+    # that assertion passes against the broken code too (measured — an earlier draft of this
+    # spec did exactly that and stayed green with the fix reverted). Asking for the flag and
+    # then asking for raw, on the same fd, is what a discarded copy cannot satisfy.
+    it "round-trips every flag it claims to control" do
       pending! "needs a real tty" unless STDOUT.tty?
       termios = Termisu::Termios.new(STDOUT.fd)
-      termios.set_mode(Termisu::Terminal::Mode::CrToNl)
+      raw = Termisu::Terminal::Mode.raw
 
-      tios = uninitialized LibC::Termios
-      LibC.tcgetattr(STDOUT.fd, pointerof(tios)).should eq(0)
-      (tios.c_iflag & LibC::ICRNL).should_not eq(0)
+      termios.set_mode(Termisu::Terminal::Mode::CrToNl)
+      (attrs_of(STDOUT.fd).c_iflag & LibC::ICRNL).should_not eq(0)
+      termios.set_mode(raw)
+      (attrs_of(STDOUT.fd).c_iflag & LibC::ICRNL).should eq(0)
+
+      termios.set_mode(Termisu::Terminal::Mode::FlowControl)
+      (attrs_of(STDOUT.fd).c_iflag & LibC::IXON).should_not eq(0)
+      termios.set_mode(raw)
+      (attrs_of(STDOUT.fd).c_iflag & LibC::IXON).should eq(0)
+
+      termios.set_mode(Termisu::Terminal::Mode::OutputProcessing)
+      (attrs_of(STDOUT.fd).c_oflag & LibC::OPOST).should_not eq(0)
+      termios.set_mode(raw)
+      (attrs_of(STDOUT.fd).c_oflag & LibC::OPOST).should eq(0)
     ensure
       termios.try &.restore
     end

--- a/spec/termisu/termios_spec.cr
+++ b/spec/termisu/termios_spec.cr
@@ -138,4 +138,41 @@ describe Termisu::Termios do
       termios.try &.restore
     end
   end
+
+  # `apply_input_flags`/`apply_output_flags` take `LibC::Termios` — a STRUCT, so by value.
+  # Every c_iflag/c_oflag change they made was written to a copy and discarded, leaving raw
+  # mode with ICRNL, IXON and OPOST still on: a pasted CRLF arrived as two newlines and
+  # Ctrl+S froze the application. Only c_lflag/c_cflag/c_cc, mutated inline in `set_mode`,
+  # ever reached the terminal, so `Mode::CrToNl`, `Mode::FlowControl` and
+  # `Mode::OutputProcessing` had no effect either.
+  #
+  # Assert against the FD, not the tracked mode — `current_mode` was right the whole time,
+  # which is how every existing spec in this file passed against the broken code.
+  describe "raw mode input/output flags" do
+    it "clears CR→NL translation, flow control and output post-processing" do
+      pending! "needs a real tty" unless STDOUT.tty?
+      termios = Termisu::Termios.new(STDOUT.fd)
+      termios.enable_raw_mode
+
+      tios = uninitialized LibC::Termios
+      LibC.tcgetattr(STDOUT.fd, pointerof(tios)).should eq(0)
+      (tios.c_iflag & LibC::ICRNL).should eq(0)
+      (tios.c_iflag & LibC::IXON).should eq(0)
+      (tios.c_oflag & LibC::OPOST).should eq(0)
+    ensure
+      termios.try &.restore
+    end
+
+    it "honours a mode that asks for CR→NL back" do
+      pending! "needs a real tty" unless STDOUT.tty?
+      termios = Termisu::Termios.new(STDOUT.fd)
+      termios.set_mode(Termisu::Terminal::Mode::CrToNl)
+
+      tios = uninitialized LibC::Termios
+      LibC.tcgetattr(STDOUT.fd, pointerof(tios)).should eq(0)
+      (tios.c_iflag & LibC::ICRNL).should_not eq(0)
+    ensure
+      termios.try &.restore
+    end
+  end
 end

--- a/src/termisu/termios.cr
+++ b/src/termisu/termios.cr
@@ -97,10 +97,10 @@ class Termisu::Termios
     tios.c_lflag |= LibC::IEXTEN if mode.extended?
 
     # Input flags handling
-    apply_input_flags(tios, orig, mode)
+    tios = apply_input_flags(tios, orig, mode)
 
     # Output flags handling
-    apply_output_flags(tios, orig, mode)
+    tios = apply_output_flags(tios, orig, mode)
 
     # Control flags - 8-bit chars, no parity
     tios.c_cflag &= ~(LibC::CSIZE | LibC::PARENB)
@@ -141,9 +141,18 @@ class Termisu::Termios
     end
   end
 
-  # Applies input flags (c_iflag) based on mode.
+  # Applies input flags (c_iflag) based on mode, returning the updated attrs.
   # Handles IXON (flow control) and ICRNL (CR→NL translation).
-  private def apply_input_flags(tios : LibC::Termios, orig : LibC::Termios, mode : Terminal::Mode)
+  #
+  # RETURNS the struct rather than mutating the argument: `LibC::Termios` is a
+  # struct, so the parameter is a COPY and every assignment here was discarded on
+  # return. Only c_lflag/c_cflag/c_cc, mutated inline in `set_mode`, ever reached
+  # the terminal — which is why `current_mode` and ICANON/ECHO looked right while
+  # raw mode kept ICRNL, IXON and OPOST set, the opposite of the table in
+  # `Terminal::Mode`. With ICRNL on the line discipline rewrites every CR to NL
+  # before any read sees it, so a pasted CRLF arrives as two newlines; with IXON
+  # on, Ctrl+S freezes a full-screen application instead of arriving as a key.
+  private def apply_input_flags(tios : LibC::Termios, orig : LibC::Termios, mode : Terminal::Mode) : LibC::Termios
     if mode.canonical?
       # Start with original input flags for canonical mode
       tios.c_iflag = orig.c_iflag
@@ -165,11 +174,13 @@ class Termisu::Termios
       tios.c_iflag |= LibC::IXON if mode.flow_control?
       tios.c_iflag |= LibC::ICRNL if mode.cr_to_nl?
     end
+    tios
   end
 
-  # Applies output flags (c_oflag) based on mode.
+  # Applies output flags (c_oflag) based on mode, returning the updated attrs.
   # Handles OPOST (output processing) for NL→CRNL translation etc.
-  private def apply_output_flags(tios : LibC::Termios, orig : LibC::Termios, mode : Terminal::Mode)
+  # Returns rather than mutates — see `apply_input_flags`.
+  private def apply_output_flags(tios : LibC::Termios, orig : LibC::Termios, mode : Terminal::Mode) : LibC::Termios
     if mode.canonical?
       # Start with original output flags for canonical mode
       tios.c_oflag = orig.c_oflag
@@ -185,5 +196,6 @@ class Termisu::Termios
       # Apply explicit flag request
       tios.c_oflag |= LibC::OPOST if mode.output_processing?
     end
+    tios
   end
 end


### PR DESCRIPTION
## The bug

`Termios#set_mode` passes its `LibC::Termios` to `apply_input_flags` and `apply_output_flags` **by value** — it is a struct — so every `c_iflag` / `c_oflag` assignment those methods make is written to a copy and discarded:

```crystal
# set_mode
tios.c_lflag |= LibC::ICANON if mode.canonical?   # inline — reaches the terminal
apply_input_flags(tios, orig, mode)               # mutates a COPY — discarded
apply_output_flags(tios, orig, mode)              # mutates a COPY — discarded
set_attrs(tios)
```

Only `c_lflag` / `c_cflag` / `c_cc`, mutated inline in `set_mode`, ever reach the terminal. That is why the modes always *looked* right — `current_mode` and ICANON/ECHO were correct — while raw mode silently kept `ICRNL`, `IXON` and `OPOST` set, the opposite of the table documented in `Terminal::Mode`:

> `| Raw | ICANON OFF | ECHO OFF | ISIG OFF | IEXTEN OFF | IXON OFF | OPOST OFF | ICRNL OFF |`

It also means `Mode::CrToNl`, `Mode::FlowControl` and `Mode::OutputProcessing` have never done anything — setting or clearing them produces the same terminal state. `git log -S` puts that at `941c093` (2025-12-13), the commit that introduced those three flags.

## Measured

macOS, inside tmux. After `Termisu.new` (which calls `enable_raw_mode`), reading the flags back off the fd:

```
before:  iflag=0x6b02   ICRNL=true    ICANON=false
after:   iflag=0x6800   ICRNL=false   ICANON=false
```

ICANON was correct all along, which is the part that made this easy to miss.

## Consequences for an application

- **`ICRNL` on** — the line discipline rewrites every CR to NL before any read sees it. A pasted CRLF arrives as two newlines, so every pasted line gains a blank line after it. This is what led me here: multi-line paste into a text editor widget was silently double-spacing.
- **`IXON` on** — `Ctrl+S` freezes a full-screen application (XOFF) instead of being delivered as a key.
- **`OPOST` on** — output post-processing stays enabled in raw mode.

## The fix

Both methods return the updated attrs and the caller reassigns. Four functional lines; the rest is comments explaining why the signature is shaped that way, so it does not regress back into a silent no-op.

## Tests

Two specs that read the flags back off the fd — raw mode clears `ICRNL` / `IXON` / `OPOST`, and `Mode::CrToNl` still gets `ICRNL` back. They deliberately do **not** assert on `current_mode`: that was right the whole time, and asserting on it is how all 14 existing assertions in `termios_spec.cr` passed against the broken code. `pending!` without a real tty, like the rest of the file.

Suite on my machine, `main` vs this branch: **1324 → 1326 examples, 3 failures / 121 errors on both** (all tty-dependent, pre-existing in my environment). The two added examples are the two new `pending`s.