### PR TITLE
fix(input): report which byte produced an Enter

### DIFF
--- a/spec/termisu/input/parser_spec.cr
+++ b/spec/termisu/input/parser_spec.cr
@@ -161,6 +161,19 @@ describe Termisu::Input::Parser do
           event.ctrl?.should be_false
         end
       end
+
+      # Both bytes are Key::Enter, so `char` is the ONLY way an application can tell a
+      # pasted CRLF (0x0D 0x0A — one line break) from two separate newlines. Without it
+      # every pasted line gains a blank line after it.
+      it "reports which byte produced Enter" do
+        cr = parse_sequence(Bytes[0x0D])
+        cr.should be_a(Termisu::Event::Key)
+        cr.as(Termisu::Event::Key).char.should eq('\r')
+
+        lf = parse_sequence(Bytes[0x0A])
+        lf.should be_a(Termisu::Event::Key)
+        lf.as(Termisu::Event::Key).char.should eq('\n')
+      end
     end
 
     context "CSI sequences (arrow keys)" do

--- a/src/termisu/input/parser.cr
+++ b/src/termisu/input/parser.cr
@@ -184,6 +184,21 @@ class Termisu::Input::Parser
   #
   # Also: Modifier keys alone (Ctrl, Alt, Shift) don't send any bytes in
   # standard terminal input. We can only detect them combined with other keys.
+  #
+  # Both 0x0D and 0x0A yield Key::Enter, but they carry the byte that produced
+  # them as `char` ('\r' / '\n'). Without bracketed paste a terminal hands a
+  # pasted CRLF over as those two bytes back to back, and an application that
+  # cannot tell them apart inserts TWO newlines per pasted line. `char` lets a
+  # caller collapse the pair; nothing else changes (`Event::Key#char` already
+  # fell back to '\n' for Enter, so a caller that ignores it sees no difference
+  # on the 0x0A path).
+  #
+  # That collapse is only available when CR LF actually arrives as CR LF, which is
+  # not something a terminal guarantees. Some normalize the LF of a pasted CRLF
+  # into a SECOND CR, and CR CR is by definition what pressing Enter twice looks
+  # like — no inspection of `char` separates those. Reporting the byte is what a
+  # caller has to work with; telling a paste from typing at all needs boundary
+  # markers from the terminal (DEC private mode 2004), not byte content.
   private def parse_byte(byte : UInt8) : Event::Any
     # Snapshot + clear the one-shot dup guard: it only matches a raw byte that
     # arrives IMMEDIATELY after the CSI-u event that set it (handled in the
@@ -201,9 +216,9 @@ class Termisu::Input::Parser
     when 0x09 # Tab (technically Ctrl+I, but always treat as Tab)
       Event::Key.new(Key::Tab)
     when 0x0A # Line feed (Ctrl+J) - treat as Enter
-      Event::Key.new(Key::Enter)
+      Event::Key.new(Key::Enter, char: '\n')
     when 0x0D # Carriage return (Ctrl+M) - treat as Enter
-      Event::Key.new(Key::Enter)
+      Event::Key.new(Key::Enter, char: '\r')
     when 0x01..0x1A # Ctrl+A through Ctrl+Z (excluding special cases above)
       key = Key.from_char(('a'.ord + byte - 1).chr)
       Event::Key.new(key, Modifier::Ctrl)


### PR DESCRIPTION
Hi @omarluq

This is the piece I should have put in #164 and didn't — it lived in my fork bundled with the termios fix, and I only sent the termios half upstream.

This is an editable PR, so feel free to make any changes :)

---

Both `0x0D` and `0x0A` parse to `Key::Enter`, and the event carries nothing to tell them apart:

```crystal
when 0x0A # Line feed (Ctrl+J) - treat as Enter
  Event::Key.new(Key::Enter)
when 0x0D # Carriage return (Ctrl+M) - treat as Enter
  Event::Key.new(Key::Enter)
```

Without bracketed paste a terminal hands a pasted CRLF over as those two bytes back to back, so an application that treats every Enter alike inserts **two** line breaks per pasted line.

Concretely, in the tool I'm building: an HTTP request pasted from Burp Suite gained a blank line after every line of the request.

### Fix

Populate the `char` field `Event::Key` already has — `'\r'` for `0x0D`, `'\n'` for `0x0A` — so a caller can collapse a CR LF pair.

Nothing changes for a caller that ignores it. `Event::Key#char` already fell back to the key's own character:

```crystal
def char : Char?
  @char || key.to_char
end
```

and `Key::Enter.to_char` is `'\n'`, so on the `0x0A` path the explicit value is exactly what the fallback returned before. The `0x0D` path is the only one that reports something new.

### Tests

One spec, driving the parser over an `IO.pipe`, asserting `0x0D` -> `'\r'` and `0x0A` -> `'\n'`. It fails on the first half without the change.

Full suite green (1330 examples, 0 failures) run under a pty. Without one the FFI/backend specs fail on `/dev/tty` regardless of this change.

### Scope

This is not a complete answer to pasting on its own. Some terminals map the LF of a pasted CRLF to a **second CR**, and CR CR is by definition what pressing Enter twice looks like — no amount of inspecting `char` separates those. DEC mode 2004 is the reliable fix and I'm sending that as a separate PR. `char` is what a caller has to work with when the mode isn't available.
