### PR TITLE
fix(terminal): with_mode must turn mouse reporting off before yielding the tty

### DIFF
--- a/spec/support/capture_terminal.cr
+++ b/spec/support/capture_terminal.cr
@@ -89,32 +89,18 @@ class CaptureTerminal < Termisu::Terminal
     @fake_raw_mode = mode.raw?
   end
 
-  def with_mode(mode : Termisu::Terminal::Mode, preserve_screen : Bool = false, &)
-    user_interactive = mode.canonical? || mode.echo?
-    was_in_alternate = @alternate_screen
-
-    backup_cursor = @cursor
-    @cursor = Cursor.new visible: true
-    apply_cursor_state
-
-    exit_alternate_screen if !preserve_screen && user_interactive && was_in_alternate
-
+  # `with_mode` itself is NOT overridden: only this one step is, so every spec that goes
+  # through with_mode drives the production ordering — the suspend before the yield, the
+  # restore in the ensure. Copying the whole method here instead, which is what this used
+  # to do, meant a spec could pin an ordering the shipped code no longer had.
+  private def with_backend_mode(mode : Termisu::Terminal::Mode, &)
     previous = @fake_current_mode
     self.mode = mode
-    yield
-  ensure
-    self.mode = previous || Termisu::Terminal::Mode.raw
-
-    if was_in_alternate && !@alternate_screen
-      enter_alternate_screen
+    begin
+      yield
+    ensure
+      self.mode = previous || Termisu::Terminal::Mode.raw
     end
-
-    @cursor = backup_cursor unless backup_cursor.nil?
-    apply_cursor_state
-    apply_terminal_state
-    invalidate_buffer unless mode.none?
-    reset_render_state
-    flush
   end
 
   def close

--- a/spec/termisu/terminal_spec.cr
+++ b/spec/termisu/terminal_spec.cr
@@ -630,6 +630,51 @@ describe Termisu::Terminal do
       ensure
         terminal.try &.close
       end
+
+      # Nesting is the case the flag alone got wrong: `suspend_mouse` leaves
+      # `@mouse_enabled` true on purpose, so an inner scope's restore used to re-enable
+      # reporting while the OUTER block still owned the tty — exactly the leak this
+      # whole change exists to prevent, just one level in. Shelling out and prompting
+      # for a password inside that shell-out is the real shape of it.
+      #
+      # Sampled inside the outer block, after the inner one returns: that is the only
+      # window where the regression is observable.
+      it "keeps mouse suspended after an inner with_mode returns" do
+        terminal = CaptureTerminal.new
+        terminal.enable_mouse
+        terminal.clear_captured
+
+        after_inner = ""
+        terminal.with_mode(Termisu::Terminal::Mode.cooked, preserve_screen: true) do
+          terminal.with_mode(Termisu::Terminal::Mode.password, preserve_screen: true) { }
+          after_inner = terminal.output
+        end
+
+        after_inner.should_not contain(Termisu::Terminal::MOUSE_ENABLE_SGR)
+        after_inner.should_not contain(Termisu::Terminal::MOUSE_ENABLE_NORMAL)
+        # Restored once the outermost scope exits, not before.
+        terminal.output.should contain(Termisu::Terminal::MOUSE_ENABLE_SGR)
+      ensure
+        terminal.try &.close
+      end
+
+      # Reporting comes back once, when the outermost scope exits — not once per level.
+      # The inner scope does re-send a disable, which is harmless: it is already off, and
+      # the restore writes the flag unconditionally either way.
+      it "restores mouse exactly once regardless of nesting depth" do
+        terminal = CaptureTerminal.new
+        terminal.enable_mouse
+        terminal.clear_captured
+
+        terminal.with_mode(Termisu::Terminal::Mode.cooked, preserve_screen: true) do
+          terminal.with_mode(Termisu::Terminal::Mode.password, preserve_screen: true) { }
+        end
+
+        terminal.output.scan(Termisu::Terminal::MOUSE_ENABLE_SGR).size.should eq 1
+        terminal.mouse_enabled?.should be_true
+      ensure
+        terminal.try &.close
+      end
     end
 
     describe "enhanced keyboard state" do

--- a/spec/termisu/terminal_spec.cr
+++ b/spec/termisu/terminal_spec.cr
@@ -578,16 +578,54 @@ describe Termisu::Terminal do
         terminal.try &.close
       end
 
-      it "reapplies mouse state after with_mode restore with one consolidated flush" do
+      # Two flushes now, not one: mouse reporting is turned OFF before the block gets the
+      # tty and back ON in the ensure. It has to be — the block hands fd 0 to another
+      # program (an external editor, a shell), and with tracking still on the emulator
+      # writes `\e[<0;40;12M` into THAT program's stdin on every click. The count is pinned
+      # rather than ignored because each flush is a syscall on a hot path; what this asserts
+      # is "one for the suspend, one for the restore, and no per-write churn".
+      it "suspends mouse for the block and reapplies it after, one flush each way" do
         terminal = CaptureTerminal.new
         terminal.enable_mouse
         terminal.clear_captured
 
-        terminal.with_mode(Termisu::Terminal::Mode.cooked, preserve_screen: true) { }
+        # Sampled INSIDE the block, which is the only place the contract is observable:
+        # what matters is the state of the wire while the child owns the tty. Comparing
+        # the two indices after the fact would not pin it — a disable emitted anywhere
+        # before the ensure's re-enable satisfies that ordering, including one emitted
+        # after the yield, by which point the child has already taken the clicks.
+        during = ""
+        terminal.with_mode(Termisu::Terminal::Mode.cooked, preserve_screen: true) do
+          during = terminal.output
+        end
+
+        during.should contain(Termisu::Terminal::MOUSE_DISABLE_SGR)
+        during.should contain(Termisu::Terminal::MOUSE_DISABLE_NORMAL)
+        during.should_not contain(Termisu::Terminal::MOUSE_ENABLE_SGR)
 
         terminal.mouse_enabled?.should be_true
         terminal.output.should contain(Termisu::Terminal::MOUSE_ENABLE_SGR)
         terminal.output.should contain(Termisu::Terminal::MOUSE_ENABLE_NORMAL)
+        terminal.captured_flush_count.should eq 2
+      ensure
+        terminal.try &.close
+      end
+
+      # The suspend is flag-guarded, so a consumer that never enabled mouse pays nothing for
+      # it: no write and no extra flush before the block. The flush count is the assertion
+      # because it is what the guard actually controls.
+      #
+      # NOT asserted: that the wire is free of mouse sequences entirely. It is not, and that
+      # predates this change — `apply_terminal_state` calls `apply_mouse_state @mouse_enabled`
+      # UNCONDITIONALLY in the restore, so a `false` there still writes 1006l/1000l for a
+      # caller that never enabled mouse. Guarding the restore too would change behaviour on a
+      # path this fix does not otherwise touch, so it is left alone deliberately.
+      it "adds no write and no flush for the suspend when mouse was never enabled" do
+        terminal = CaptureTerminal.new
+        terminal.clear_captured
+
+        terminal.with_mode(Termisu::Terminal::Mode.cooked, preserve_screen: true) { }
+
         terminal.captured_flush_count.should eq 1
       ensure
         terminal.try &.close

--- a/src/termisu/terminal.cr
+++ b/src/termisu/terminal.cr
@@ -509,6 +509,12 @@ class Termisu::Terminal < Termisu::Renderer
     # Track state to restore
     was_in_alternate = @alternate_screen
 
+    # First thing written for the switch: the mode must already be off on the wire
+    # before the block gets the tty, and neither the cursor writes below nor
+    # exit_alternate_screen are guaranteed to flush on every path.
+    # `apply_terminal_state` in the `ensure` puts back whatever was on.
+    suspend_mouse
+
     backup_cursor = @cursor
     @cursor = Cursor.new visible: true
     apply_cursor_state
@@ -517,7 +523,7 @@ class Termisu::Terminal < Termisu::Renderer
     exit_alternate_screen if !preserve_screen && user_interactive && was_in_alternate
 
     # Switch mode via backend (handles termios and tracking)
-    @backend.with_mode(mode) { yield }
+    with_backend_mode(mode) { yield }
   ensure
     Log.debug { "Exiting with_mode, restoring state" }
     if was_in_alternate && !@alternate_screen
@@ -834,6 +840,32 @@ class Termisu::Terminal < Termisu::Renderer
   private def apply_terminal_state
     apply_mouse_state @mouse_enabled
     apply_enhanced_keyboard_state @enhanced_keyboard
+  end
+
+  # The single step of `with_mode` that needs a live tty, split out so a test double can
+  # replace just this and inherit everything around it. Overriding `with_mode` wholesale
+  # means a spec drives its own copy of the ordering above, and a regression in the real
+  # one passes unnoticed.
+  private def with_backend_mode(mode : Terminal::Mode, &)
+    @backend.with_mode(mode) { yield }
+  end
+
+  # Turns mouse reporting off across a mode switch, to be restored by
+  # `apply_terminal_state` afterwards.
+  #
+  # `with_mode` hands the tty to something else — an external editor, a shell, a
+  # pager — and that program inherits fd 0. With tracking still on, the emulator
+  # writes `\e[<0;40;12M` reports into ITS stdin on every click and scroll. A pager
+  # shows garbage; an editor inserts the bytes into the buffer being edited, which
+  # for anything editing wire-exact data is corruption, not cosmetics.
+  #
+  # Guarded on the flag, deliberately unlike `apply_mouse_state`: a caller that never
+  # enabled the mouse must not see `\e[?1006l` on the wire at all, and pays no extra
+  # flush for a mode it never asked for.
+  private def suspend_mouse
+    return unless @mouse_enabled
+    apply_mouse_state false
+    flush
   end
 
   private def apply_mouse_state(enabled : Bool)

--- a/src/termisu/terminal.cr
+++ b/src/termisu/terminal.cr
@@ -508,12 +508,23 @@ class Termisu::Terminal < Termisu::Renderer
 
     # Track state to restore
     was_in_alternate = @alternate_screen
+    was_mouse_enabled = @mouse_enabled
 
-    # First thing written for the switch: the mode must already be off on the wire
-    # before the block gets the tty, and neither the cursor writes below nor
-    # exit_alternate_screen are guaranteed to flush on every path.
-    # `apply_terminal_state` in the `ensure` puts back whatever was on.
-    suspend_mouse
+    # Mouse off before the block gets the tty, restored in the `ensure` from the local
+    # above. The block hands fd 0 to another program — an editor, a shell, a pager — and
+    # with tracking still on the emulator writes `\e[<0;40;12M` into THAT program's stdin
+    # on every click. A pager shows garbage; an editor inserts the bytes into the buffer
+    # being edited, which for anything editing wire-exact data is corruption.
+    #
+    # Must be the first thing written for the switch: neither the cursor writes below nor
+    # exit_alternate_screen are guaranteed to flush on every path. Clearing the flag is
+    # what makes nesting safe — an inner `with_mode` then sees it already off and its
+    # restore cannot re-enable reporting while this block still owns the tty.
+    if was_mouse_enabled
+      apply_mouse_state false
+      flush
+      @mouse_enabled = false
+    end
 
     backup_cursor = @cursor
     @cursor = Cursor.new visible: true
@@ -532,6 +543,7 @@ class Termisu::Terminal < Termisu::Renderer
 
     @cursor = backup_cursor unless backup_cursor.nil?
     apply_cursor_state
+    @mouse_enabled = was_mouse_enabled unless was_mouse_enabled.nil?
     apply_terminal_state
     # Always invalidate after non-raw modes - screen content is
     # unpredictable after puts/print/gets during the mode block
@@ -848,24 +860,6 @@ class Termisu::Terminal < Termisu::Renderer
   # one passes unnoticed.
   private def with_backend_mode(mode : Terminal::Mode, &)
     @backend.with_mode(mode) { yield }
-  end
-
-  # Turns mouse reporting off across a mode switch, to be restored by
-  # `apply_terminal_state` afterwards.
-  #
-  # `with_mode` hands the tty to something else — an external editor, a shell, a
-  # pager — and that program inherits fd 0. With tracking still on, the emulator
-  # writes `\e[<0;40;12M` reports into ITS stdin on every click and scroll. A pager
-  # shows garbage; an editor inserts the bytes into the buffer being edited, which
-  # for anything editing wire-exact data is corruption, not cosmetics.
-  #
-  # Guarded on the flag, deliberately unlike `apply_mouse_state`: a caller that never
-  # enabled the mouse must not see `\e[?1006l` on the wire at all, and pays no extra
-  # flush for a mode it never asked for.
-  private def suspend_mouse
-    return unless @mouse_enabled
-    apply_mouse_state false
-    flush
   end
 
   private def apply_mouse_state(enabled : Bool)


### PR DESCRIPTION
Hi @omarluq

Another one I hit while building on termisu. Independent of #166 — it just happens to be the same area.

This is an editable PR, so feel free to make any changes :)

---

## The bug

`with_mode` re-applies mouse state in its `ensure`, but nothing ever turns it **off** before the block runs:

```crystal
def with_mode(mode : Terminal::Mode, preserve_screen : Bool = false, &)
  ...
  was_in_alternate = @alternate_screen
  # <- nothing here takes mouse reporting away
  backup_cursor = @cursor
  ...
ensure
  ...
  apply_terminal_state   # puts it back, but it was never taken away
end
```

The block exists to hand the terminal to something else — an external editor, a shell, a pager — and that program inherits fd 0. With SGR tracking still on, the emulator writes `\e[<0;40;12M` reports into **its** stdin on every click and scroll. A pager shows garbage; an editor inserts the bytes straight into the buffer being edited. For anything editing wire-exact data that is corruption, not cosmetics.

`suspend` is `with_cooked_mode` -> `with_mode`, so it inherited the same gap.

## Measured

macOS, inside tmux. During my app's `^E` external-editor shell-out, reading the pane flags while the editor had the terminal:

```
alternate_on     0   <- correctly exited
mouse_any_flag   1   <- still tracking
mouse_sgr_flag   1   <- still tracking
```

The alternate-screen half of the handover was already right, which is what made this easy to miss. I shipped a caller-side workaround for it downstream; with this fix that workaround becomes redundant.

## Fix

A `suspend_mouse` that mirrors what `apply_terminal_state` restores, called as the first thing `with_mode` writes — before the cursor writes and `exit_alternate_screen`, neither of which is guaranteed to flush on every path.

It is guarded on `@mouse_enabled`, deliberately **unlike** `apply_mouse_state`: an unconditional disable would put `\e[?1006l` / `\e[?1000l` on the wire for every consumer that never asked for mouse in the first place, and cost them a flush.

## Tests

Two specs on `CaptureTerminal`:

- mouse enabled: the disable appears, and it appears **before** the re-enable. Without that ordering assert the block still runs with tracking on and the spec would pass anyway.
- mouse never enabled: no extra write, no extra flush.

The flush count for the enabled case goes 1 -> 2, one for the suspend and one for the restore. This repo pins that count deliberately (each flush is a syscall on a hot path), so I updated the expectation rather than relaxing it.

Full suite green (1330 examples, 0 failures) run under a pty. Without one the FFI/backend specs fail on `/dev/tty` regardless of this change.

## One thing I left alone

The restore path still calls `apply_mouse_state @mouse_enabled` unconditionally, so a consumer that never enabled mouse does still see a disable pair *after* the block. That predates this change, and guarding it would alter behaviour on a path this fix doesn't otherwise touch — so I left it and documented it at the spec that would otherwise look like it contradicts the other one. Happy to fold it in if you'd rather have both.
