### PR TITLE
test: stop specs from swallowing failures, and pin the mouse-suspend assertion

### DIFF
--- a/spec/support/terminfo_helpers.cr
+++ b/spec/support/terminfo_helpers.cr
@@ -19,6 +19,17 @@ module TerminfoHelpers
     false
   end
 
+  # Whether *name*'s compiled entry uses the extended 32-bit number format
+  # (magic 542) rather than the legacy 16-bit one (282). Which one a system ships
+  # is a property of how its terminfo was compiled, so specs covering the extended
+  # reader have to check rather than assume.
+  def terminfo_db_extended?(name : String) : Bool
+    data = Termisu::Terminfo::Database.new(name).load
+    IO::Memory.new(data).read_bytes(Int16, IO::ByteFormat::LittleEndian) == 542
+  rescue
+    false
+  end
+
   # Whether `Termisu::Terminfo.new` succeeds for the ambient TERM.
   def terminfo_available? : Bool
     Termisu::Terminfo.new

--- a/spec/support/terminfo_helpers.cr
+++ b/spec/support/terminfo_helpers.cr
@@ -1,0 +1,29 @@
+# Availability probes for specs that need a real terminfo database.
+#
+# Crystal's spec DSL has no runtime skip: calling `pending` inside a running example
+# raises "Can't nest `it` or `pending`". A spec that depends on terminfo therefore has
+# to decide *when it is declared* whether to run, which is what these are for — call
+# them at `describe` level to pick `it` or `pending`.
+#
+# Deciding up front is also what keeps assertions out of a rescue. The alternative
+# shape, wrapping the body in `rescue -> pending`, cannot tell "no terminfo here" from
+# "this assertion just failed", so it reports a broken expectation as a skipped system.
+module TerminfoHelpers
+  extend self
+
+  # Whether the terminfo database *name* can be loaded on this system.
+  def terminfo_db_available?(name : String) : Bool
+    Termisu::Terminfo::Database.new(name).load
+    true
+  rescue
+    false
+  end
+
+  # Whether `Termisu::Terminfo.new` succeeds for the ambient TERM.
+  def terminfo_available? : Bool
+    Termisu::Terminfo.new
+    true
+  rescue
+    false
+  end
+end

--- a/spec/termisu/terminal_spec.cr
+++ b/spec/termisu/terminal_spec.cr
@@ -624,8 +624,17 @@ describe Termisu::Terminal do
         terminal = CaptureTerminal.new
         terminal.clear_captured
 
-        terminal.with_mode(Termisu::Terminal::Mode.cooked, preserve_screen: true) { }
+        during = ""
+        terminal.with_mode(Termisu::Terminal::Mode.cooked, preserve_screen: true) do
+          during = terminal.output
+        end
 
+        # Sampled inside the block, because the flush count alone does not pin this:
+        # a suspend that wrote the disables and skipped the flush would leave the count
+        # at 1 and pass. What must hold is that nothing was emitted for a mouse this
+        # caller never turned on.
+        during.should_not contain(Termisu::Terminal::MOUSE_DISABLE_SGR)
+        during.should_not contain(Termisu::Terminal::MOUSE_DISABLE_NORMAL)
         terminal.captured_flush_count.should eq 1
       ensure
         terminal.try &.close

--- a/spec/termisu/terminfo/database_spec.cr
+++ b/spec/termisu/terminfo/database_spec.cr
@@ -22,16 +22,15 @@ describe Termisu::Terminfo::Database do
         end
       end
 
-      it "returns Bytes when terminal found" do
-        # This test depends on system having xterm terminfo
-        # Skip if not available
-
-        db = Termisu::Terminfo::Database.new("xterm")
-        data = db.load
-        data.should be_a(Bytes)
-        data.size.should be > 0
-      rescue
-        pending "xterm terminfo not available on this system"
+      if TerminfoHelpers.terminfo_db_available?("xterm")
+        it "returns Bytes when terminal found" do
+          db = Termisu::Terminfo::Database.new("xterm")
+          data = db.load
+          data.should be_a(Bytes)
+          data.size.should be > 0
+        end
+      else
+        pending "returns Bytes when terminal found (no xterm terminfo on this system)"
       end
     end
 
@@ -113,51 +112,61 @@ describe Termisu::Terminfo::Database do
   end
 
   describe "data format" do
-    it "returns raw bytes from terminfo file" do
-      db = Termisu::Terminfo::Database.new("xterm")
-      data = db.load
-      data.should be_a(Bytes)
-      # Terminfo files have a magic number at start
-      data.size.should be >= 12 # Minimum header size
-    rescue
-      pending "xterm terminfo not available"
+    if TerminfoHelpers.terminfo_db_available?("xterm")
+      it "returns raw bytes from terminfo file" do
+        db = Termisu::Terminfo::Database.new("xterm")
+        data = db.load
+        data.should be_a(Bytes)
+        # Terminfo files have a magic number at start
+        data.size.should be >= 12 # Minimum header size
+      end
+    else
+      pending "returns raw bytes from terminfo file (no xterm terminfo on this system)"
     end
   end
 
   describe "multiple load calls" do
-    it "can load same terminal multiple times" do
-      db = Termisu::Terminfo::Database.new("xterm")
-      data1 = db.load
-      data2 = db.load
-      data1.should eq(data2)
-    rescue
-      pending "xterm terminfo not available"
+    if TerminfoHelpers.terminfo_db_available?("xterm")
+      it "can load same terminal multiple times" do
+        db = Termisu::Terminfo::Database.new("xterm")
+        data1 = db.load
+        data2 = db.load
+        data1.should eq(data2)
+      end
+    else
+      pending "can load same terminal multiple times (no xterm terminfo on this system)"
     end
   end
 
   describe "common terminals" do
-    it "can find linux terminal if available" do
-      db = Termisu::Terminfo::Database.new("linux")
-      data = db.load
-      data.should be_a(Bytes)
-    rescue
-      pending "linux terminfo not available"
+    if TerminfoHelpers.terminfo_db_available?("linux")
+      it "can find linux terminal" do
+        db = Termisu::Terminfo::Database.new("linux")
+        data = db.load
+        data.should be_a(Bytes)
+      end
+    else
+      pending "can find linux terminal (no linux terminfo on this system)"
     end
 
-    it "can find screen terminal if available" do
-      db = Termisu::Terminfo::Database.new("screen")
-      data = db.load
-      data.should be_a(Bytes)
-    rescue
-      pending "screen terminfo not available"
+    if TerminfoHelpers.terminfo_db_available?("screen")
+      it "can find screen terminal" do
+        db = Termisu::Terminfo::Database.new("screen")
+        data = db.load
+        data.should be_a(Bytes)
+      end
+    else
+      pending "can find screen terminal (no screen terminfo on this system)"
     end
 
-    it "can find tmux terminal if available" do
-      db = Termisu::Terminfo::Database.new("tmux")
-      data = db.load
-      data.should be_a(Bytes)
-    rescue
-      pending "tmux terminfo not available"
+    if TerminfoHelpers.terminfo_db_available?("tmux")
+      it "can find tmux terminal" do
+        db = Termisu::Terminfo::Database.new("tmux")
+        data = db.load
+        data.should be_a(Bytes)
+      end
+    else
+      pending "can find tmux terminal (no tmux terminfo on this system)"
     end
   end
 end

--- a/spec/termisu/terminfo/parser_spec.cr
+++ b/spec/termisu/terminfo/parser_spec.cr
@@ -396,25 +396,21 @@ describe Termisu::Terminfo::Parser do
   end
 
   describe "extended format handling" do
-    if TerminfoHelpers.terminfo_db_available?("xterm-256color")
+    # Gated on the host entry actually being extended, not just present. The magic
+    # check used to sit inside the example around its assertions, so on a machine
+    # whose xterm-256color is standard-format the example ran to completion having
+    # asserted nothing and still reported as a pass.
+    if TerminfoHelpers.terminfo_db_extended?("xterm-256color")
       it "correctly handles extended 32-bit format" do
-        db = Termisu::Terminfo::Database.new("xterm-256color")
-        data = db.load
+        data = Termisu::Terminfo::Database.new("xterm-256color").load
 
-        # Check magic number
-        io = IO::Memory.new(data)
-        magic = io.read_bytes(Int16, IO::ByteFormat::LittleEndian)
+        result = Termisu::Terminfo::Parser.new(data).parse(["clear", "bold"])
 
-        if magic == 542
-          parser = Termisu::Terminfo::Parser.new(data)
-          result = parser.parse(["clear", "bold"])
-
-          result.should be_a(Hash(String, String))
-          result.size.should be > 0
-        end
+        result.should be_a(Hash(String, String))
+        result.size.should be > 0
       end
     else
-      pending "extended 32-bit format handling (no xterm-256color terminfo on this system)"
+      pending "extended 32-bit format handling (no extended-format xterm-256color entry here)"
     end
   end
 

--- a/spec/termisu/terminfo/parser_spec.cr
+++ b/spec/termisu/terminfo/parser_spec.cr
@@ -296,62 +296,62 @@ describe Termisu::Terminfo::Parser do
   end
 
   describe "real terminfo data" do
-    it "can parse actual xterm-256color terminfo if available" do
-      db = Termisu::Terminfo::Database.new("xterm-256color")
-      data = db.load
-      parser = Termisu::Terminfo::Parser.new(data)
+    if TerminfoHelpers.terminfo_db_available?("xterm-256color")
+      it "can parse actual xterm-256color terminfo if available" do
+        db = Termisu::Terminfo::Database.new("xterm-256color")
+        data = db.load
+        parser = Termisu::Terminfo::Parser.new(data)
 
-      cap_names = ["clear", "civis", "cnorm", "bold", "smul"]
-      result = parser.parse(cap_names)
+        cap_names = ["clear", "civis", "cnorm", "bold", "smul"]
+        result = parser.parse(cap_names)
 
-      result.should be_a(Hash(String, String))
-      result.size.should be > 0
+        result.should be_a(Hash(String, String))
+        result.size.should be > 0
 
-      # Verify they're valid ANSI sequences
-      result.values.each do |value|
-        (value.starts_with?("\e") || value.starts_with?("\033")).should be_true
+        # Verify they're valid ANSI sequences
+        result.values.each do |value|
+          (value.starts_with?("\e") || value.starts_with?("\033")).should be_true
+        end
       end
-    rescue Termisu::ParseError
-      pending "xterm-256color terminfo parsing failed"
-    rescue
-      pending "xterm-256color terminfo not available"
+    else
+      pending "real xterm-256color terminfo parsing (no xterm-256color terminfo on this system)"
     end
 
-    it "correctly parses smcup/rmcup for xterm-256color" do
-      db = Termisu::Terminfo::Database.new("xterm-256color")
-      data = db.load
+    if TerminfoHelpers.terminfo_db_available?("xterm-256color")
+      it "correctly parses smcup/rmcup for xterm-256color" do
+        db = Termisu::Terminfo::Database.new("xterm-256color")
+        data = db.load
 
-      result = Termisu::Terminfo::Parser.parse(data, ["smcup", "rmcup"])
+        result = Termisu::Terminfo::Parser.parse(data, ["smcup", "rmcup"])
 
-      result["smcup"]?.should_not be_nil
-      result["rmcup"]?.should_not be_nil
-      result["smcup"].should contain("\e[?1049")
-      result["rmcup"].should contain("\e[?1049")
-    rescue Termisu::ParseError
-      pending "xterm-256color terminfo parsing failed"
-    rescue
-      pending "xterm-256color terminfo not available"
+        result["smcup"]?.should_not be_nil
+        result["rmcup"]?.should_not be_nil
+        result["smcup"].should contain("\e[?1049")
+        result["rmcup"].should contain("\e[?1049")
+      end
+    else
+      pending "smcup/rmcup parsing for xterm-256color (no xterm-256color terminfo on this system)"
     end
   end
 
   describe "required-only decode" do
-    it "is byte-identical to a full parse-all-then-filter decode for xterm-256color" do
-      data = Termisu::Terminfo::Database.new("xterm-256color").load
-      required = Termisu::Terminfo::Capabilities::REQUIRED_FUNCS +
-                 Termisu::Terminfo::Capabilities::REQUIRED_KEYS
+    if TerminfoHelpers.terminfo_db_available?("xterm-256color")
+      it "is byte-identical to a full parse-all-then-filter decode for xterm-256color" do
+        data = Termisu::Terminfo::Database.new("xterm-256color").load
+        required = Termisu::Terminfo::Capabilities::REQUIRED_FUNCS +
+                   Termisu::Terminfo::Capabilities::REQUIRED_KEYS
 
-      fast = Termisu::Terminfo::Parser.parse(data, required)
-      reference = reference_parse_all_then_filter(data, required)
+        fast = Termisu::Terminfo::Parser.parse(data, required)
+        reference = reference_parse_all_then_filter(data, required)
 
-      fast.size.should be > 0
-      fast.keys.should eq(reference.keys)
-      reference.each do |name, value|
-        fast[name].to_slice.should eq(value.to_slice)
+        fast.size.should be > 0
+        fast.keys.should eq(reference.keys)
+        reference.each do |name, value|
+          fast[name].to_slice.should eq(value.to_slice)
+        end
       end
-    rescue Termisu::ParseError
-      pending "xterm-256color terminfo parsing failed"
-    rescue
-      pending "xterm-256color terminfo not available"
+    else
+      pending "byte-identical required-only decode (no xterm-256color terminfo on this system)"
     end
 
     it "matches the reference decode on mock terminfo data" do
@@ -366,55 +366,55 @@ describe Termisu::Terminfo::Parser do
   end
 
   describe "integration with Capabilities" do
-    it "can parse all REQUIRED_FUNCS capabilities" do
-      db = Termisu::Terminfo::Database.new("xterm")
-      data = db.load
+    if TerminfoHelpers.terminfo_db_available?("xterm")
+      it "can parse all REQUIRED_FUNCS capabilities" do
+        db = Termisu::Terminfo::Database.new("xterm")
+        data = db.load
 
-      result = Termisu::Terminfo::Parser.parse(data, Termisu::Terminfo::Capabilities::REQUIRED_FUNCS)
-
-      result.should be_a(Hash(String, String))
-      result.size.should be > 0
-    rescue Termisu::ParseError
-      pending "xterm terminfo parsing failed"
-    rescue
-      pending "xterm terminfo not available"
-    end
-
-    it "can parse all REQUIRED_KEYS capabilities" do
-      db = Termisu::Terminfo::Database.new("xterm")
-      data = db.load
-
-      result = Termisu::Terminfo::Parser.parse(data, Termisu::Terminfo::Capabilities::REQUIRED_KEYS)
-
-      result.should be_a(Hash(String, String))
-      result.size.should be > 0
-    rescue Termisu::ParseError
-      pending "xterm terminfo parsing failed"
-    rescue
-      pending "xterm terminfo not available"
-    end
-  end
-
-  describe "extended format handling" do
-    it "correctly handles extended 32-bit format" do
-      db = Termisu::Terminfo::Database.new("xterm-256color")
-      data = db.load
-
-      # Check magic number
-      io = IO::Memory.new(data)
-      magic = io.read_bytes(Int16, IO::ByteFormat::LittleEndian)
-
-      if magic == 542
-        parser = Termisu::Terminfo::Parser.new(data)
-        result = parser.parse(["clear", "bold"])
+        result = Termisu::Terminfo::Parser.parse(data, Termisu::Terminfo::Capabilities::REQUIRED_FUNCS)
 
         result.should be_a(Hash(String, String))
         result.size.should be > 0
       end
-    rescue Termisu::ParseError
-      pending "xterm-256color terminfo parsing failed"
-    rescue
-      pending "xterm-256color terminfo not available"
+    else
+      pending "REQUIRED_FUNCS parsing (no xterm terminfo on this system)"
+    end
+
+    if TerminfoHelpers.terminfo_db_available?("xterm")
+      it "can parse all REQUIRED_KEYS capabilities" do
+        db = Termisu::Terminfo::Database.new("xterm")
+        data = db.load
+
+        result = Termisu::Terminfo::Parser.parse(data, Termisu::Terminfo::Capabilities::REQUIRED_KEYS)
+
+        result.should be_a(Hash(String, String))
+        result.size.should be > 0
+      end
+    else
+      pending "REQUIRED_KEYS parsing (no xterm terminfo on this system)"
+    end
+  end
+
+  describe "extended format handling" do
+    if TerminfoHelpers.terminfo_db_available?("xterm-256color")
+      it "correctly handles extended 32-bit format" do
+        db = Termisu::Terminfo::Database.new("xterm-256color")
+        data = db.load
+
+        # Check magic number
+        io = IO::Memory.new(data)
+        magic = io.read_bytes(Int16, IO::ByteFormat::LittleEndian)
+
+        if magic == 542
+          parser = Termisu::Terminfo::Parser.new(data)
+          result = parser.parse(["clear", "bold"])
+
+          result.should be_a(Hash(String, String))
+          result.size.should be > 0
+        end
+      end
+    else
+      pending "extended 32-bit format handling (no xterm-256color terminfo on this system)"
     end
   end
 

--- a/spec/termisu/terminfo_spec.cr
+++ b/spec/termisu/terminfo_spec.cr
@@ -1,5 +1,12 @@
 require "../spec_helper"
 
+# The accessor examples below are gated on `Terminfo.new` succeeding, and that check
+# runs when they are *declared* — before any example body can set `ENV["TERM"]`. With
+# TERM unset the whole group would silently go pending, so pin a default here instead
+# of inheriting whatever the invoking shell happens to export. Examples that care about
+# a specific TERM still set and restore it themselves.
+ENV["TERM"] ||= "xterm-256color"
+
 describe Termisu::Terminfo do
   describe "#initialize" do
     it "creates a Terminfo instance" do

--- a/spec/termisu/terminfo_spec.cr
+++ b/spec/termisu/terminfo_spec.cr
@@ -39,89 +39,113 @@ describe Termisu::Terminfo do
   end
 
   describe "sequence accessors" do
-    it "provides enter_ca_seq accessor" do
-      term = Termisu::Terminfo.new
-      term.enter_ca_seq.should be_a(String)
-    rescue
-      pending "Terminfo not available"
+    if TerminfoHelpers.terminfo_available?
+      it "provides enter_ca_seq accessor" do
+        term = Termisu::Terminfo.new
+        term.enter_ca_seq.should be_a(String)
+      end
+    else
+      pending "provides enter_ca_seq accessor (terminfo unavailable on this system)"
     end
 
-    it "provides exit_ca_seq accessor" do
-      term = Termisu::Terminfo.new
-      term.exit_ca_seq.should be_a(String)
-    rescue
-      pending "Terminfo not available"
+    if TerminfoHelpers.terminfo_available?
+      it "provides exit_ca_seq accessor" do
+        term = Termisu::Terminfo.new
+        term.exit_ca_seq.should be_a(String)
+      end
+    else
+      pending "provides exit_ca_seq accessor (terminfo unavailable on this system)"
     end
 
-    it "provides show_cursor_seq accessor" do
-      term = Termisu::Terminfo.new
-      term.show_cursor_seq.should be_a(String)
-    rescue
-      pending "Terminfo not available"
+    if TerminfoHelpers.terminfo_available?
+      it "provides show_cursor_seq accessor" do
+        term = Termisu::Terminfo.new
+        term.show_cursor_seq.should be_a(String)
+      end
+    else
+      pending "provides show_cursor_seq accessor (terminfo unavailable on this system)"
     end
 
-    it "provides hide_cursor_seq accessor" do
-      term = Termisu::Terminfo.new
-      term.hide_cursor_seq.should be_a(String)
-    rescue
-      pending "Terminfo not available"
+    if TerminfoHelpers.terminfo_available?
+      it "provides hide_cursor_seq accessor" do
+        term = Termisu::Terminfo.new
+        term.hide_cursor_seq.should be_a(String)
+      end
+    else
+      pending "provides hide_cursor_seq accessor (terminfo unavailable on this system)"
     end
 
-    it "provides clear_screen_seq accessor" do
-      term = Termisu::Terminfo.new
-      term.clear_screen_seq.should be_a(String)
-      term.clear_screen_seq.should_not be_empty
-    rescue
-      pending "Terminfo not available"
+    if TerminfoHelpers.terminfo_available?
+      it "provides clear_screen_seq accessor" do
+        term = Termisu::Terminfo.new
+        term.clear_screen_seq.should be_a(String)
+        term.clear_screen_seq.should_not be_empty
+      end
+    else
+      pending "provides clear_screen_seq accessor (terminfo unavailable on this system)"
     end
 
-    it "provides reset_attrs_seq accessor" do
-      term = Termisu::Terminfo.new
-      term.reset_attrs_seq.should be_a(String)
-    rescue
-      pending "Terminfo not available"
+    if TerminfoHelpers.terminfo_available?
+      it "provides reset_attrs_seq accessor" do
+        term = Termisu::Terminfo.new
+        term.reset_attrs_seq.should be_a(String)
+      end
+    else
+      pending "provides reset_attrs_seq accessor (terminfo unavailable on this system)"
     end
 
-    it "provides underline_seq accessor" do
-      term = Termisu::Terminfo.new
-      term.underline_seq.should be_a(String)
-    rescue
-      pending "Terminfo not available"
+    if TerminfoHelpers.terminfo_available?
+      it "provides underline_seq accessor" do
+        term = Termisu::Terminfo.new
+        term.underline_seq.should be_a(String)
+      end
+    else
+      pending "provides underline_seq accessor (terminfo unavailable on this system)"
     end
 
-    it "provides bold_seq accessor" do
-      term = Termisu::Terminfo.new
-      term.bold_seq.should be_a(String)
-    rescue
-      pending "Terminfo not available"
+    if TerminfoHelpers.terminfo_available?
+      it "provides bold_seq accessor" do
+        term = Termisu::Terminfo.new
+        term.bold_seq.should be_a(String)
+      end
+    else
+      pending "provides bold_seq accessor (terminfo unavailable on this system)"
     end
 
-    it "provides blink_seq accessor" do
-      term = Termisu::Terminfo.new
-      term.blink_seq.should be_a(String)
-    rescue
-      pending "Terminfo not available"
+    if TerminfoHelpers.terminfo_available?
+      it "provides blink_seq accessor" do
+        term = Termisu::Terminfo.new
+        term.blink_seq.should be_a(String)
+      end
+    else
+      pending "provides blink_seq accessor (terminfo unavailable on this system)"
     end
 
-    it "provides reverse_seq accessor" do
-      term = Termisu::Terminfo.new
-      term.reverse_seq.should be_a(String)
-    rescue
-      pending "Terminfo not available"
+    if TerminfoHelpers.terminfo_available?
+      it "provides reverse_seq accessor" do
+        term = Termisu::Terminfo.new
+        term.reverse_seq.should be_a(String)
+      end
+    else
+      pending "provides reverse_seq accessor (terminfo unavailable on this system)"
     end
 
-    it "provides enter_keypad_seq accessor" do
-      term = Termisu::Terminfo.new
-      term.enter_keypad_seq.should be_a(String)
-    rescue
-      pending "Terminfo not available"
+    if TerminfoHelpers.terminfo_available?
+      it "provides enter_keypad_seq accessor" do
+        term = Termisu::Terminfo.new
+        term.enter_keypad_seq.should be_a(String)
+      end
+    else
+      pending "provides enter_keypad_seq accessor (terminfo unavailable on this system)"
     end
 
-    it "provides exit_keypad_seq accessor" do
-      term = Termisu::Terminfo.new
-      term.exit_keypad_seq.should be_a(String)
-    rescue
-      pending "Terminfo not available"
+    if TerminfoHelpers.terminfo_available?
+      it "provides exit_keypad_seq accessor" do
+        term = Termisu::Terminfo.new
+        term.exit_keypad_seq.should be_a(String)
+      end
+    else
+      pending "provides exit_keypad_seq accessor (terminfo unavailable on this system)"
     end
   end
 
@@ -159,61 +183,71 @@ describe Termisu::Terminfo do
   end
 
   describe "capability array sizes" do
-    it "has 12 function capabilities" do
-      term = Termisu::Terminfo.new
-      # Verify all 12 accessors work
-      [
-        term.enter_ca_seq,
-        term.exit_ca_seq,
-        term.show_cursor_seq,
-        term.hide_cursor_seq,
-        term.clear_screen_seq,
-        term.reset_attrs_seq,
-        term.underline_seq,
-        term.bold_seq,
-        term.blink_seq,
-        term.reverse_seq,
-        term.enter_keypad_seq,
-        term.exit_keypad_seq,
-      ].size.should eq(12)
-    rescue
-      pending "Terminfo not available"
+    if TerminfoHelpers.terminfo_available?
+      it "has 12 function capabilities" do
+        term = Termisu::Terminfo.new
+        # Verify all 12 accessors work
+        [
+          term.enter_ca_seq,
+          term.exit_ca_seq,
+          term.show_cursor_seq,
+          term.hide_cursor_seq,
+          term.clear_screen_seq,
+          term.reset_attrs_seq,
+          term.underline_seq,
+          term.bold_seq,
+          term.blink_seq,
+          term.reverse_seq,
+          term.enter_keypad_seq,
+          term.exit_keypad_seq,
+        ].size.should eq(12)
+      end
+    else
+      pending "has 12 function capabilities (terminfo unavailable on this system)"
     end
   end
 
   describe "escape sequence format" do
-    it "returns ANSI escape sequences" do
-      term = Termisu::Terminfo.new
+    if TerminfoHelpers.terminfo_available?
+      it "returns ANSI escape sequences" do
+        term = Termisu::Terminfo.new
 
-      # Clear screen should have escape sequence
-      term.clear_screen_seq.should contain("\e")
-    rescue
-      pending "Terminfo not available"
+        # Clear screen should have escape sequence
+        term.clear_screen_seq.should contain("\e")
+      end
+    else
+      pending "returns ANSI escape sequences (terminfo unavailable on this system)"
     end
 
-    it "bold capability contains escape sequence" do
-      term = Termisu::Terminfo.new
-      term.bold_seq.should contain("\e")
-    rescue
-      pending "Terminfo not available"
+    if TerminfoHelpers.terminfo_available?
+      it "bold capability contains escape sequence" do
+        term = Termisu::Terminfo.new
+        term.bold_seq.should contain("\e")
+      end
+    else
+      pending "bold capability contains escape sequence (terminfo unavailable on this system)"
     end
   end
 
   describe "integration with subsystems" do
-    it "integrates with Database for loading" do
-      term = Termisu::Terminfo.new
-      # If we get here, Database integration worked
-      term.should be_a(Termisu::Terminfo)
-    rescue
-      pending "Terminfo database not available"
+    if TerminfoHelpers.terminfo_available?
+      it "integrates with Database for loading" do
+        term = Termisu::Terminfo.new
+        # If we get here, Database integration worked
+        term.should be_a(Termisu::Terminfo)
+      end
+    else
+      pending "integrates with Database for loading (terminfo unavailable on this system)"
     end
 
-    it "integrates with Parser for parsing" do
-      term = Termisu::Terminfo.new
-      # Parser should have extracted capabilities
-      term.clear_screen_seq.should be_a(String)
-    rescue
-      pending "Terminfo not available"
+    if TerminfoHelpers.terminfo_available?
+      it "integrates with Parser for parsing" do
+        term = Termisu::Terminfo.new
+        # Parser should have extracted capabilities
+        term.clear_screen_seq.should be_a(String)
+      end
+    else
+      pending "integrates with Parser for parsing (terminfo unavailable on this system)"
     end
 
     it "integrates with Builtin for fallback" do
@@ -229,12 +263,14 @@ describe Termisu::Terminfo do
       end
     end
 
-    it "integrates with Capabilities for indices" do
-      term = Termisu::Terminfo.new
-      # Capabilities indices should map correctly
-      term.should be_a(Termisu::Terminfo)
-    rescue
-      pending "Terminfo not available"
+    if TerminfoHelpers.terminfo_available?
+      it "integrates with Capabilities for indices" do
+        term = Termisu::Terminfo.new
+        # Capabilities indices should map correctly
+        term.should be_a(Termisu::Terminfo)
+      end
+    else
+      pending "integrates with Capabilities for indices (terminfo unavailable on this system)"
     end
   end
 

--- a/spec/termisu_spec.cr
+++ b/spec/termisu_spec.cr
@@ -1,28 +1,38 @@
 require "./spec_helper"
 
+# Whether this process has a usable controlling terminal.
+#
+# `File.exists?("/dev/tty")` is not enough: the node exists in CI containers and
+# sandboxes that have no controlling terminal, where opening it fails with ENXIO.
+# Opening it is what distinguishes the two, and it is what `Termisu.new` effectively
+# does — so this guard runs the spec below on exactly the machines where it is
+# meaningful, instead of skipping it wherever the node happens to exist.
+private def controlling_tty? : Bool
+  File.open("/dev/tty", "w", &.close)
+  true
+rescue
+  false
+end
+
 describe Termisu do
   it "has a version number" do
     Termisu::VERSION.should_not be_nil
   end
 
   describe ".new" do
-    it "initializes components without errors" do
-      # Note: Full Termisu.new initialization is tested in examples/demo.cr
-      # Unit tests focus on individual components to avoid alternate screen
-      # disruption during test runs
-
-      # Only test if TTY is not available to avoid spec output disruption
-      if !File.exists?("/dev/tty")
+    # Successful initialization is exercised in examples/demo.cr: constructing Termisu
+    # here would switch to the alternate screen and corrupt spec output. What is worth
+    # asserting in-suite is the failure path, and that needs a machine without a
+    # controlling terminal — so the guard is applied when the spec is declared rather
+    # than swallowed at runtime.
+    if controlling_tty?
+      pending "raises IO::Error without a controlling TTY (this process has one)"
+    else
+      it "raises IO::Error without a controlling TTY" do
         expect_raises(IO::Error) do
           Termisu.new
         end
-      else
-        # Skip actual initialization test locally - tested in demo
-        true.should be_true
       end
-    rescue ex
-      # Handle any other errors
-      true.should be_true
     end
   end
 


### PR DESCRIPTION
Two spec-integrity fixes. No production code changes.

## 1. Mouse-suspend spec asserted only the flush count

Follow-up to a CodeRabbit out-of-diff finding on #167. The spec named "adds no
write and no flush for the suspend when mouse was never enabled" only checked
`captured_flush_count == 1`, so it passed for a regression that emitted the
disable sequences before `yield` and skipped the flush — the ensure's own flush
kept the count at 1.

Verified by injecting exactly that regression: the old spec passed, the new one
fails. It now samples the wire inside the block.

## 2. 36 specs swallowed failures as "terminfo unavailable"

Examples across `terminfo_spec`, `terminfo/database_spec`, `terminfo/parser_spec`
and `termisu_spec` wrapped their assertions in a bare `rescue` whose handler
called `pending`. Two independent defects:

- **`pending` inside a running example is invalid** — it raises ``Can't nest `it`
  or `pending` ``. The intended "skip when terminfo is unavailable" never worked;
  on such a machine these specs *errored*, naming neither terminfo nor the real
  cause.
- **The rescue enclosed the assertions**, so a failed expectation was reported as
  an unavailable system rather than a failure.

Fixed by deciding availability when the spec is *declared* — where `pending` is
legal — leaving example bodies free of any rescue. A small `TerminfoHelpers`
support module provides the two predicates (18 and 12 call sites).

`termisu_spec`'s `.new` example was additionally vacuous: both branches asserted
`true.should be_true` and the rescue swallowed everything, so it could not fail on
any machine. It now asserts the one thing worth asserting — that `Termisu.new`
raises `IO::Error` without a controlling TTY — guarded on actually *opening*
`/dev/tty` rather than the node existing, so it runs in CI instead of being
skipped there.

## Verification

- **Assertions can fail again**: breaking one in a throwaway copy of each file
  produces a real failure; previously swallowed.
- **The skip path works for the first time**: in a bwrap sandbox with
  `/usr/share/terminfo` and `/lib/terminfo` hidden, this branch reports
  `218 examples, 0 failures, 0 errors, 12 pending`. `main` in the identical
  environment errors out with the ``Can't nest`` cascade.
- Full suite `1253 examples, 0 failures, 1 pending` · ameba `157 inspected, 0 failures` · format clean.

The one remaining `rescue` in the touched files is inside the `controlling_tty?`
probe itself — an availability check containing no assertions, which is the shape
this change moves toward.
