### PR TITLE
feat(ffi): expose bracketed paste and input-mode queries over the C ABI

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -1,0 +1,2036 @@
+# Known Issues — Termisu
+
+**Last updated:** 2026-07-20 (TERMISU-039 added; previous revision 2026-04-23 post-review)
+**Against version:** 0.4.5
+**Source of findings:** Four-dimensional analysis pass run 2026-04-22, followed by per-ticket verification, followed by an **adversarial review pass** on 2026-04-23 (see [`KNOWN_ISSUES_REVIEW.md`](./KNOWN_ISSUES_REVIEW.md)).
+
+After the review, **6 tickets were closed as invalid**, 7 severities reduced, 4 ticket descriptions refined. See each ticket's top-matter for its post-review status.
+
+Each remaining ticket has been **verified by direct file read**. Line numbers are anchored to the current tree and should be stable until someone edits the file. Unverified claims are labeled explicitly.
+
+---
+
+## Legend
+
+**Severity:**
+- **CRITICAL** — Live bug or perf regression breaking documented guarantees. Fix before next release.
+- **HIGH** — Structural defect or correctness hole with significant downstream cost.
+- **MEDIUM** — Real concern, worth queuing for a focused sprint.
+- **LOW** — Polish, cosmetics, or defense-in-depth. Opportunistic fixes only.
+
+**Status:**
+- `OPEN` — Not started.
+- `VERIFIED` — I read the source and confirmed the claim holds as stated.
+- `VERIFIED-MODIFIED` — I confirmed the issue but adjusted severity or scope after reading.
+- `NEEDS-REPRO` — Claim is plausible from reading, but reproduction requires runtime instrumentation not yet gathered.
+
+**Component tags:** `[rendering]` `[io]` `[events]` `[input]` `[terminfo]` `[ffi]` `[color]` `[support]`
+
+---
+
+## Index
+
+| ID | Severity | Component | Title |
+|---|---|---|---|
+| [TERMISU-001](#termisu-001) | HIGH *(↓ from CRITICAL)* | ffi | `FFI::Context#close` rolls back `@closed` on exception, enabling double-cleanup |
+| [TERMISU-002](#termisu-002) | CRITICAL | rendering | Char-based `set_cell` allocates a String per cell, breaking 60 FPS budget |
+| [TERMISU-003](#termisu-003) | HIGH | rendering | Double SGR state between `RenderState` and `Terminal`'s `@cached_*` fields |
+| [TERMISU-004](#termisu-004) | HIGH | rendering | `RenderState#reset` followed by `apply_style(attr: None, …)` fails to emit `reset_attributes` |
+| [TERMISU-005](#termisu-005) | HIGH | rendering | `set_cell` keyword arg name inconsistency (`grapheme:` vs `ch:`) silently breaks callers |
+| [TERMISU-006](#termisu-006) | MEDIUM *(↓ from HIGH; split)* | support / input | Exceptions silently swallowed in `Logging.setup`, `Logging.close`, `codepoint_to_key` |
+| [TERMISU-007](#termisu-007) | HIGH | rendering | `Renderer` abstraction exposes 18 methods; every new attribute ripples across 4 files |
+| [TERMISU-008](#termisu-008) | HIGH | facade | `Termisu::Termisu` facade at ~797 lines with ~60 public methods is becoming a god object |
+| [TERMISU-009](#termisu-009) | HIGH | events | `Source::Input` uses blocking `send` — keystrokes lost under backpressure without signal |
+| [TERMISU-010](#termisu-010) | MEDIUM *(↓ from HIGH)* | ffi | FFI accepts out-of-range coordinates and codepoints; defense-in-depth hygiene |
+| [TERMISU-011](#termisu-011) | HIGH | rendering | `Cell` construction + `@batch_buffer.to_s` allocate in diff hot path |
+| [TERMISU-012](#termisu-012) | ❌ **CLOSED** | ffi | ~~`FFI::Registry` generation counter~~ — rejected: UInt64 wrap = 584 B years |
+| [TERMISU-013](#termisu-013) | LOW *(↓ from MEDIUM)* | input | Input parser has no CPU budget — malformed CSI spam (defense-in-depth only) |
+| [TERMISU-014](#termisu-014) | MEDIUM | terminfo | Terminfo binary parser's null-terminated string scan lacks end-of-data guard |
+| [TERMISU-015](#termisu-015) | MEDIUM | color | `Color.ansi8(-1)` is silently valid; docstring and validator disagree |
+| [TERMISU-016](#termisu-016) | ❌ **CLOSED** | facade | ~~`set_cursor` precedence~~ — rejected: Crystal precedence is actually correct |
+| [TERMISU-017](#termisu-017) | MEDIUM | rendering | `terminal.cr` at ~699 lines mixes SGR, modes, mouse, enhanced keyboard, title, sync updates |
+| [TERMISU-018](#termisu-018) | ❌ **CLOSED** | events | ~~SHUTDOWN_TIMEOUT_MS name~~ — rejected: `100 ms / 10` is documented, intentional |
+| [TERMISU-019](#termisu-019) | MEDIUM | input | CSI parser uses `params.split(';')` — allocates Array+Strings per special key |
+| [TERMISU-020](#termisu-020) | MEDIUM | rendering | `apply_attribute_change` does 2×8 `includes?` checks per style change |
+| [TERMISU-021](#termisu-021) | LOW *(↓ from MEDIUM)* | ffi | `ffi/core.cr` is a grab-bag file — 219 lines, manageable; split only if it grows |
+| [TERMISU-022](#termisu-022) | MEDIUM | color / ffi | Crystal `Color::Mode` lacks `Default`; ABI `ColorMode` has it — asymmetric contract |
+| [TERMISU-023](#termisu-023) | LOW *(↓ from MEDIUM)* | events | Backpressure "scatter" is intentional differentiated semantics, not debt |
+| [TERMISU-024](#termisu-024) | MEDIUM | rendering | `Buffer#invalidate` relies on implicit "NUL is never a real cell" contract |
+| [TERMISU-025](#termisu-025) | MEDIUM | rendering | `Cell` struct fuses display data with grid-occupancy (continuation) |
+| [TERMISU-026](#termisu-026) | ❌ **CLOSED** | io | ~~Reader buffer 128 bytes~~ — rejected: documented default, llms.txt was wrong |
+| [TERMISU-027](#termisu-027) | LOW *(↓ from MEDIUM)* | events | `Event::Source` invariants documented but unenforced (revisit if custom sources appear) |
+| [TERMISU-028](#termisu-028) | LOW | terminfo | `Terminfo` pre-caches 12 capabilities at ctor; list is hardcoded |
+| [TERMISU-029](#termisu-029) | ❌ **CLOSED** | ffi | ~~FFI always compiled~~ — rejected: Crystal `--release` DCE strips unused symbols |
+| [TERMISU-030](#termisu-030) | LOW | io | `TIOCGWINSZ` magic numbers duplicated per-platform without shared source |
+| [TERMISU-031](#termisu-031) | LOW | terminfo | `Terminfo#to_status_line_seq` hardcodes sequence; should fallback to `get_cap` |
+| [TERMISU-032](#termisu-032) | LOW | rendering | `Terminal#title=` has non-idiomatic setter return pattern |
+| [TERMISU-033](#termisu-033) | LOW | rendering | `Attribute::Italic` is a documented alias for `Cursive`; `.to_s` always reports `"Cursive"` |
+| [TERMISU-034](#termisu-034) | LOW | rendering | Three `# ameba:disable Naming/AccessorMethodName` suppressions without justification |
+| [TERMISU-035](#termisu-035) | LOW | terminfo | `$TERM` is used unvalidated in file path construction (defense-in-depth) |
+| [TERMISU-036](#termisu-036) | ❌ **CLOSED** | io | ~~EINTR retry storm~~ — rejected: counter is per-call, not cumulative |
+| [TERMISU-037](#termisu-037) | MEDIUM | io | `Reader#close` does not close the fd; ownership model undocumented |
+| [TERMISU-038](#termisu-038) | LOW | io | No runtime verification of `LibC::Winsize` struct size |
+| [TERMISU-039](#termisu-039) | HIGH | rendering | `apply_attribute_change` drops attributes retained across a batch reset (Bold+Underline → Bold loses bold) |
+
+**Rollup after 2026-04-23 review (see [`KNOWN_ISSUES_REVIEW.md`](./KNOWN_ISSUES_REVIEW.md)):**
+
+| Severity | Original (post-verification) | After review | Delta |
+|---|---|---|---|
+| CRITICAL | 2 | **1** | TERMISU-001 reduced to HIGH (Terminal#close is idempotent) |
+| HIGH | 9 | **7** | TERMISU-006 and -010 reduced to MEDIUM |
+| MEDIUM | 18 | **13** | -4 (TERMISU-012/-016/-018/-026/-036 closed; -013/-021/-023/-027 reduced to LOW; +2 from HIGH) |
+| LOW | 9 | **11** | +2 from MEDIUM downgrades; -1 (TERMISU-029 closed) |
+| ❌ CLOSED | 0 | **6** | TERMISU-012, -016, -018, -026, -029, -036 |
+| **Total** | **38** | **38** | No tickets added or deleted — statuses changed |
+
+**Closed tickets retained in this file as historical record.** Jump to any closed ticket to see the reason. Do not reopen without new evidence.
+
+---
+
+---
+
+## CRITICAL
+
+### <a id="termisu-001"></a>TERMISU-001 — `FFI::Context#close` rolls back `@closed` on exception, enabling double-cleanup
+
+**Severity:** HIGH  *(reduced from CRITICAL on 2026-04-23 review)*  •  **Status:** VERIFIED  •  **Component:** `[ffi]`
+**Files:** `src/termisu/ffi/context.cr:11-20`
+
+> **REVIEW NOTE (2026-04-23):** Reduced from CRITICAL to HIGH. `Terminal#close`, `Backend#close`, and `TTY#close` are all idempotent (each checks a state flag before acting). Worst case of the CAS rollback is redundant work on a second close call, not EBADF or resource corruption. Fix is still correct; urgency is not "before next release."
+
+#### Verified source
+
+```crystal
+# src/termisu/ffi/context.cr:11-20
+def close : Nil
+  return unless @closed.compare_and_set(false, true)
+
+  begin
+    @termisu.close
+  rescue ex
+    @closed.set(false)
+    raise ex
+  end
+end
+```
+
+#### Description
+
+The "closed" CAS flag is set *before* `@termisu.close` runs, which is correct for idempotency. The bug is the **rescue branch resets the flag to `false`**. If `@termisu.close` raises after partial cleanup (e.g. TTY was closed but `Backend#close` raised mid-way through alternate-screen exit, or termios restore failed), a second call to `Context#close` passes the CAS guard and re-enters `@termisu.close` on an *already partially destroyed* instance. Depending on where the first call failed, this can attempt to `close(2)` a freed fd (EBADF), `tcsetattr` on a closed fd, or double-free wrapped resources.
+
+#### Impact
+
+- **Resource corruption**: Partial state leaves FFI-managed `Termisu` instances in an undefined state, then the retry compounds the corruption.
+- **Debuggability**: The caller sees the original exception on the first call, but the *actual* fault (the second call crashing harder) appears elsewhere in the log.
+- **C ABI surface**: Exposed to every C caller; a `termisu_close` that raises is likely to be retried by defensive callers.
+
+#### Proposed fix
+
+Never roll `@closed` back. Once close is attempted, the context is tainted. Track failure state separately:
+
+```crystal
+class Termisu::FFI::Context
+  getter termisu : ::Termisu
+
+  @closed : Atomic(Bool)
+  @close_failed : Atomic(Bool)
+
+  def initialize(sync_updates : Bool)
+    @closed = Atomic(Bool).new(false)
+    @close_failed = Atomic(Bool).new(false)
+    @termisu = ::Termisu.new(sync_updates: sync_updates)
+  end
+
+  def close : Nil
+    return unless @closed.compare_and_set(false, true)
+
+    begin
+      @termisu.close
+    rescue ex
+      @close_failed.set(true)
+      raise ex
+    end
+  end
+
+  def closed? : Bool
+    @closed.get
+  end
+
+  def close_failed? : Bool
+    @close_failed.get
+  end
+end
+```
+
+At the FFI export boundary, `termisu_close` on a `close_failed?` context should return `Status::Error` with the original error string preserved in `ErrorState`.
+
+#### Verification notes
+
+Exact code reproduced above. The security reviewer's scenario ("TTY closes successfully but `@termisu.close` raises (e.g., during buffer cleanup)") is plausible: `::Termisu#close` orchestrates event-loop stop, reader close, terminal close, and log close; any of these can raise.
+
+---
+
+### <a id="termisu-002"></a>TERMISU-002 — Char-based `set_cell` allocates a String per cell, breaking 60 FPS budget
+
+**Severity:** CRITICAL  •  **Status:** VERIFIED  •  **Component:** `[rendering]`
+**Files:** `src/termisu/buffer.cr:95-104` + `src/termisu/cell.cr:92-108`
+
+#### Verified source
+
+```crystal
+# src/termisu/buffer.cr:95-104
+def set_cell(
+  x : Int32,
+  y : Int32,
+  ch : Char,
+  fg : Color = Color.white,
+  bg : Color = Color.default,
+  attr : Attribute = Attribute::None,
+) : Bool
+  set_cell(x, y, ch.to_s, fg, bg, attr)
+end
+```
+
+```crystal
+# src/termisu/cell.cr:92-108
+def grapheme=(@grapheme)
+  if @continuation
+    @grapheme = ""
+    @width = 0u8
+  elsif grapheme.empty?
+    @grapheme = " "
+    @width = 1u8
+  else
+    # Extract first grapheme cluster to ensure single-grapheme invariant
+    first = grapheme.each_grapheme.first.to_s
+    if first.bytesize < grapheme.bytesize
+      Termisu::Logs::Buffer.debug { "Cell: multi-grapheme input truncated (#{grapheme.grapheme_size} graphemes, kept first)" }
+    end
+    @grapheme = first
+    @width = UnicodeWidth.grapheme_width(@grapheme)
+  end
+end
+```
+
+#### Description
+
+Two hot-path allocations per `Char` set-cell, plus unconditional grapheme-cluster iteration and a width-table lookup even for ASCII:
+
+1. `ch.to_s` (`buffer.cr:103`) allocates a one-char `String`.
+2. `grapheme.each_grapheme.first.to_s` (`cell.cr:101`) allocates again after iterating the grapheme segmenter — unnecessary for single ASCII bytes.
+3. `UnicodeWidth.grapheme_width(@grapheme)` runs binary search over 236 combining-mark ranges + CJK block checks even for ASCII printable (which is always width 1).
+
+#### Impact
+
+For a full 80×24 cell fill at 60 FPS:
+
+| Operation | Count | Per-frame | Per-second |
+|---|---|---|---|
+| `ch.to_s` allocations | 1920 | 1920 Strings | 115,200 Strings/sec |
+| `each_grapheme.first.to_s` | 1920 | 1920 Strings | 115,200 Strings/sec |
+| Binary searches + block checks | 1920 | ~23K comparisons | ~1.4M/sec |
+
+GC pressure alone can blow the 16 ms frame budget on typical 60 FPS targets. This directly undermines the library's "zero-allocation steady-state rendering" goal.
+
+#### Proposed fix
+
+1. **ASCII fast path in `Buffer#set_cell(Char)`** — avoid the String round-trip entirely:
+
+   ```crystal
+   def set_cell(x, y, ch : Char, fg = Color.white, bg = Color.default, attr = Attribute::None) : Bool
+     return false if out_of_bounds?(x, y)
+     return false if control_char?(ch)
+
+     if ch.ascii? && ch.ord >= 32
+       cell = Cell.new_ascii(ch, fg: fg, bg: bg, attr: attr)  # new constructor
+       set_cell_internal(x, y, cell, 1_u8)
+       return true
+     end
+
+     set_cell(x, y, ch.to_s, fg, bg, attr)  # fall back for non-ASCII Char
+   end
+   ```
+
+2. **ASCII fast path in `Cell.grapheme=`** — skip grapheme iteration for byte-sized ASCII:
+
+   ```crystal
+   def grapheme=(@grapheme)
+     # ... existing continuation and empty branches ...
+     else
+       if grapheme.bytesize == 1 && grapheme.unsafe_byte_at(0) < 0x80
+         @grapheme = grapheme
+         @width = 1_u8
+       else
+         first = grapheme.each_grapheme.first.to_s
+         # ... existing slow path ...
+       end
+     end
+   end
+   ```
+
+3. **ASCII fast path in `UnicodeWidth.grapheme_width`** — short-circuit before the binary search:
+
+   ```crystal
+   def self.grapheme_width(grapheme : String) : UInt8
+     return 0_u8 if grapheme.empty?
+     return 1_u8 if grapheme.bytesize == 1 && grapheme.unsafe_byte_at(0) < 0x80
+     # ... existing slow path ...
+   end
+   ```
+
+#### Verification notes
+
+Direct source read confirms both file regions exactly as quoted. Allocation count is back-of-envelope but the qualitative claim (per-cell allocation during Char writes) is undeniable.
+
+#### Benchmarks needed
+
+Before landing the fix: add a benchmark in `bench/suites/buffer_suite.cr` that fills an 80×24 buffer with `Char` set_cells, measures allocations/sec and wall time. Target: zero allocations in the ASCII steady state after the fix.
+
+---
+
+## HIGH
+
+### <a id="termisu-003"></a>TERMISU-003 — Double SGR state between `RenderState` and `Terminal`'s `@cached_*` fields
+
+**Severity:** HIGH  •  **Status:** VERIFIED  •  **Component:** `[rendering]`
+**Files:** `src/termisu/render_state.cr:20-108` + `src/termisu/terminal.cr:36-38, 129-167, 182-249`
+
+#### Description
+
+Two independent SGR optimizers exist in the render path. `RenderState` (used by `Buffer#render_to`) tracks `(fg, bg, attr)` and emits only deltas via the Renderer interface. Separately, `Terminal` keeps `@cached_fg`, `@cached_bg`, `@cached_attr` and short-circuits inside each SGR-emitting method (`foreground=`, `background=`, `enable_bold`, etc.) when the cached value matches. Both caches live on the same call path: Buffer → RenderState → Terminal's Renderer interface → Terminal's cached setter.
+
+The existence of the second cache has forced scattered patches (`reset_render_state` calls in `enter_alternate_screen`, `exit_alternate_screen`, `clear_screen`, `reset_attributes`) to keep them in sync.
+
+#### Impact
+
+- **Drift risk.** Two sources of truth for "what SGR is the terminal in?" Any code path that mutates one cache without the other introduces incorrect emissions — the terminal ends up with attributes the renderer thinks it already cleared.
+- **Extension friction.** Adding a new attribute (e.g., `DoubleUnderline`, `Overline`) means editing Renderer, RenderState's `apply_new_attributes`, Terminal's cached setter, and a mock.
+- **Test unsoundness.** Mock renderers cannot assert RenderState's intent because Terminal's cache short-circuits first. Tests end up asserting on byte output, which is brittle.
+
+#### Proposed direction
+
+Collapse into a single authoritative cache. `RenderState` is already at the Buffer ↔ Renderer boundary — keep its role as *the* SGR optimizer. Terminal becomes a dumb byte writer for SGR; direct-API callers (non-Buffer code paths) that need idempotency get a small `StyledWriter` helper or go through a shared `RenderState`.
+
+This ticket is a refactor, not a patch. It should be bundled with TERMISU-007 (Renderer interface narrowing) and TERMISU-011 (Cell allocation cleanup) because they share the same code surface.
+
+#### Verification notes
+
+Both files read directly. `render_state.cr` has the canonical tracking logic (verified in full above). `terminal.cr` has separate `@cached_fg/@cached_bg/@cached_attr` fields with short-circuits at the top of the SGR emitters — this was confirmed from llms.txt §8.3 but should be re-read before the fix to ensure the line refs are current.
+
+---
+
+### <a id="termisu-004"></a>TERMISU-004 — `RenderState#reset` treats post-reset state as known when it should be unknown
+
+**Severity:** HIGH  •  **Status:** VERIFIED (framing rewritten 2026-04-23)  •  **Component:** `[rendering]`
+**Files:** `src/termisu/render_state.cr:30-37, 42-71, 84-89`
+
+> **REVIEW NOTE (2026-04-23):** Original framing was imprecise. When `@attr == None` and `apply_style(attr: None)` is called, there is genuinely nothing to emit — skipping `reset_attributes` is *correct* if RenderState's belief matches the terminal. The real bug is narrower: **`reset()` sets `@attr = None` as an assertion about terminal state that may not be true** (e.g., after `suspend { system("vim") }`, vim can leave bold/underline set). If the first `apply_style` after reset uses `attr: None`, the mismatch persists until something forces a reset. Same fix (`Attribute?` nil sentinel), clearer description.
+
+#### Verified source
+
+```crystal
+# render_state.cr:30-37
+def initialize
+  @fg, @bg, @attr = default_state
+end
+
+def reset
+  @fg, @bg, @attr = default_state
+end
+
+# render_state.cr:73-75
+private def default_state : Tuple(Color?, Color?, Attribute)
+  {nil, nil, Attribute::None}
+end
+```
+
+#### Description
+
+`default_state` assigns `Attribute::None` (not `nil`) as the "post-reset" attribute. The asymmetry with `fg`/`bg` (which use `nil` sentinels to mean "unknown") creates a subtle bug in `apply_style`:
+
+```crystal
+# render_state.cr:51-54
+if attr != @attr
+  apply_attribute_change(renderer, attr)
+  changed = true
+end
+```
+
+After `reset`, `@attr == Attribute::None`. On the first `apply_style` call with `attr: Attribute::None`:
+- `attr != @attr` → `None != None` → `false`
+- `apply_attribute_change` is **skipped**
+- `reset_if_removing_attrs` (which would emit `\e[0m`) is never reached
+
+If the terminal has leftover attributes from a previous program (e.g., user returned from `vim` that left the terminal bold), the first cell drawn after reset silently inherits them. Colors avoid this because their `nil` sentinel forces `!=` to succeed.
+
+#### Impact
+
+Visible rendering glitches after:
+- `suspend { system("vim") }` (post-shell-out screen state uncertain)
+- `clear_screen` (which calls `reset_render_state`)
+- `exit_alternate_screen` / `enter_alternate_screen` transitions
+
+The glitch is "first cell drawn after reset is bold/italic when it shouldn't be." Symptomatic users would describe it as "my UI randomly has extra attributes for a frame."
+
+#### Proposed fix
+
+Option A (recommended) — make `@attr` also use a `nil` sentinel:
+
+```crystal
+property attr : Attribute?
+
+def reset
+  @fg, @bg, @attr = nil, nil, nil
+end
+
+# In apply_style:
+if @attr.nil? || attr != @attr
+  apply_attribute_change(renderer, attr)
+  changed = true
+end
+```
+
+Option B — force `reset_attributes` emit on first `apply_style` after reset via a separate `@needs_full_reset : Bool` flag.
+
+Option A is cleaner and matches the existing `fg`/`bg` pattern.
+
+#### Verification notes
+
+Full source read of `render_state.cr` confirms the exact bug mechanics. The `reset_if_removing_attrs` at line 85-89 computes `@attr & ~new_attr`, which is always `None` when `@attr == None`, so that branch never fires post-reset. This is the same conclusion the architecture reviewer reached, re-verified against the file.
+
+---
+
+### <a id="termisu-005"></a>TERMISU-005 — `set_cell` keyword arg name inconsistency (`grapheme:` vs `ch:`) silently breaks callers
+
+**Severity:** HIGH  •  **Status:** VERIFIED  •  **Component:** `[rendering]`
+**Files:** `src/termisu/buffer.cr:66-73, 95-104`
+
+#### Verified source
+
+```crystal
+# buffer.cr:66-73 (String overload)
+def set_cell(
+  x : Int32,
+  y : Int32,
+  grapheme : String,      # <-- parameter is named "grapheme"
+  fg : Color = Color.white,
+  bg : Color = Color.default,
+  attr : Attribute = Attribute::None,
+) : Bool
+
+# buffer.cr:95-104 (Char overload)
+def set_cell(
+  x : Int32,
+  y : Int32,
+  ch : Char,              # <-- parameter is named "ch"
+  fg : Color = Color.white,
+  bg : Color = Color.default,
+  attr : Attribute = Attribute::None,
+) : Bool
+  set_cell(x, y, ch.to_s, fg, bg, attr)
+end
+```
+
+#### Description
+
+Two public `set_cell` overloads with mismatched positional-parameter names. Called with keyword args, they dispatch differently:
+
+```crystal
+buffer.set_cell(10, 5, grapheme: "A")  # OK — String overload
+buffer.set_cell(10, 5, grapheme: 'A')  # COMPILE ERROR — Char value, String parameter
+buffer.set_cell(10, 5, ch: 'A')        # OK — Char overload
+buffer.set_cell(10, 5, ch: "A")        # COMPILE ERROR — String value, Char parameter
+```
+
+The docstring above both overloads documents the parameter as `grapheme`, but the Char version's actual parameter is `ch`. The documentation lies.
+
+#### Impact
+
+- **Surface-area inconsistency.** A user learning the API from docs cannot confidently use keyword args.
+- **Silent IDE surprises.** Completion suggests `grapheme:` (from the docstring), runtime rejects.
+- **Cheap to fix** — parameter renaming is non-breaking because Crystal keyword arg names are part of the signature but not the ABI.
+
+#### Proposed fix
+
+Rename the `Char` overload parameter to match:
+
+```crystal
+def set_cell(
+  x : Int32,
+  y : Int32,
+  grapheme : Char,   # renamed from ch
+  fg : Color = Color.white,
+  bg : Color = Color.default,
+  attr : Attribute = Attribute::None,
+) : Bool
+  set_cell(x, y, grapheme.to_s, fg, bg, attr)
+end
+```
+
+(Or rename the String overload to `ch : String` — less conventional, less preferred.)
+
+Cross-check callers in `spec/` and `examples/` to ensure none use the positional `ch:` keyword. None should, since the parameter is positional in practice.
+
+#### Verification notes
+
+Both overloads read directly. The docstring at `buffer.cr:52-65` refers to the parameter as "grapheme" for both, confirming the doc/code drift.
+
+---
+
+### <a id="termisu-006"></a>TERMISU-006 — Exceptions silently swallowed in `Logging.setup`, `Logging.close`, `codepoint_to_key`
+
+**Severity:** MEDIUM  *(reduced from HIGH on 2026-04-23; split into sub-items)*  •  **Status:** VERIFIED  •  **Component:** `[support]` `[input]`
+**Files:** `src/termisu/log.cr:175-177, 190, 192` + `src/termisu/input/parser.cr:337-341`
+
+> **REVIEW NOTE (2026-04-23):** Original bundled three rescues under one HIGH. After verification, each has different severity:
+> - **`log.cr:175-177` empty rescue** — **MEDIUM.** Legitimate bug; STDERR write during setup is safe because setup runs before `enter_alternate_screen` claims the screen.
+> - **`log.cr:190, 192` `rescue nil` on close** — **LOW.** Lazy, but only fires on shutdown.
+> - **`parser.cr:337-341` bare rescue in `codepoint_to_key`** — **LOW, and the rescue is dead code.** `Key.from_char` is pure hash lookup + case statement; it cannot raise. Remove the rescue rather than narrow it.
+
+#### Verified source
+
+```crystal
+# log.cr:156-177 — setup
+begin
+  file = File.open(file_path, "a")
+  file.sync = true
+  self.log_file = file
+  # ... configure dispatcher ...
+  ::Log.setup("*", level, backend)
+  Log.info { "Logging initialized: ..." }
+rescue ex
+  # If we can't open the log file, disable logging silently
+end
+```
+
+```crystal
+# log.cr:186-195 — close
+def self.close
+  if file = log_file
+    if async_mode?
+      3.times { Fiber.yield }
+      file.flush rescue nil
+    end
+    file.close rescue nil
+    self.log_file = nil
+  end
+end
+```
+
+```crystal
+# input/parser.cr:329-345 — codepoint_to_key
+private def codepoint_to_key(codepoint : Int32) : Key
+  if key = KITTY_CODEPOINTS[codepoint]?
+    return key
+  end
+
+  if codepoint > 0 && codepoint <= 0x10FFFF
+    begin
+      Key.from_char(codepoint.chr)
+    rescue
+      Key::Unknown
+    end
+  else
+    Key::Unknown
+  end
+end
+```
+
+#### Description
+
+Three places swallow exceptions without narrowing the rescue type, violating the project's own rule `.claude/rules/crystal-conventions.md` on exception discipline:
+
+1. **`Logging.setup` (log.cr:175-177):** The rescue body is literally empty. If `File.open(file_path, "a")` fails (permission denied, missing directory, read-only filesystem, sandboxed container), logging silently does not work. Since stdout is reserved for rendering, the user has no way to learn why `TERMISU_LOG_FILE=/tmp/termisu.log` produced nothing.
+2. **`Logging.close` (log.cr:190, 192):** `file.flush rescue nil` and `file.close rescue nil`. Bare inline `rescue nil` catches *any* exception type — a `NilAssertionError`, `TypeCastError`, or new Crystal runtime error would be masked.
+3. **`codepoint_to_key` (parser.cr:337-341):** `rescue` (no type) catches every `Exception`. The intent is to catch `ArgumentError` from `.chr` on an invalid codepoint, but the range check at line 336 (`codepoint > 0 && codepoint <= 0x10FFFF`) already covers `.chr` validity for non-surrogate cases. Surrogates (0xD800-0xDFFF) slip through the range check but *would* raise — the rescue is the only real defense, and it's too wide.
+
+#### Impact
+
+- **Log hole:** Unwritable log paths in containers, sandboxed shells, or CI environments produce silent failure. Debugging a TUI without logs is miserable because stdout is unavailable.
+- **Hidden bugs:** Any future exception thrown inside `file.close` (e.g., from a wrapper refactor) is invisible.
+- **Parser fragility:** If `Key.from_char` ever raises something other than `ArgumentError` (bug, OOM, unrelated refactor), input silently maps to `Unknown` and the debugger has nothing to trace.
+
+#### Proposed fix
+
+1. **`Logging.setup`** — emit the failure reason to `STDERR` *before* the TUI takes over (normally `Logging.setup` is called early in `Termisu.new`, well before `enter_alternate_screen`):
+
+   ```crystal
+   rescue ex : IO::Error | File::Error
+     STDERR.puts "[Termisu] Logging disabled: #{ex.class.name}: #{ex.message}"
+     STDERR.flush
+     self.setup_error = ex  # class property so callers can inspect programmatically
+   end
+   ```
+
+2. **`Logging.close`** — narrow to `IO::Error`, matching `SafeFileIO`:
+
+   ```crystal
+   file.flush rescue IO::Error
+   file.close rescue IO::Error
+   ```
+
+3. **`codepoint_to_key`** — explicitly filter surrogates and drop the rescue:
+
+   ```crystal
+   private def codepoint_to_key(codepoint : Int32) : Key
+     if key = KITTY_CODEPOINTS[codepoint]?
+       return key
+     end
+
+     return Key::Unknown unless codepoint > 0 && codepoint <= 0x10FFFF
+     return Key::Unknown if (0xD800..0xDFFF).includes?(codepoint)  # surrogate halves
+
+     Key.from_char(codepoint.chr)
+   end
+   ```
+
+#### Verification notes
+
+All three sites read directly and confirmed exactly as quoted. The `Logging.setup` comment explicitly admits "disable logging silently" — the developer knew this was a tradeoff but didn't provide a diagnostic channel.
+
+---
+
+### <a id="termisu-007"></a>TERMISU-007 — `Renderer` abstraction exposes 18 methods; every new attribute ripples across 4 files
+
+**Severity:** HIGH  •  **Status:** VERIFIED  •  **Component:** `[rendering]`
+**Files:** `src/termisu/renderer.cr`
+
+#### Description
+
+`Renderer` declares individual abstract methods for every SGR toggle (`enable_bold`, `enable_underline`, `enable_reverse`, `enable_blink`, `enable_dim`, `enable_cursive`, `enable_hidden`, `enable_strikethrough`, `reset_attributes`) plus color ops (`foreground=`, `background=`), cursor ops (`move_cursor`, `show_cursor`, `hide_cursor`), and I/O (`write`, `flush`, `size`, `close`). The interface is not "abstract rendering" — it's "ANSI terminal minus the buffer."
+
+Adding a new attribute today requires changes in `renderer.cr` (new abstract method), `terminal.cr` (implementation), `render_state.cr` (`apply_new_attributes` + `needs_attr?` call), `attribute.cr` (enum member), plus every mock renderer in `spec/support/mock_renderers.cr`.
+
+#### Impact
+
+- Every mock renderer must re-implement 18 methods — test setup is heavy.
+- Extension friction: new attributes are a five-file change.
+- The abstraction leaks terminal-specific semantics (SGR knowledge) upward.
+
+#### Proposed direction
+
+Narrow to ~6 methods with a `Style` value type:
+
+```crystal
+struct Termisu::Style
+  getter fg : Color
+  getter bg : Color
+  getter attr : Attribute
+
+  def initialize(@fg, @bg, @attr)
+  end
+end
+
+abstract class Termisu::Renderer
+  abstract def write(bytes : Bytes | String) : Nil
+  abstract def apply_style(style : Style) : Nil
+  abstract def move_cursor(x : Int32, y : Int32) : Nil
+  abstract def set_cursor_visible(visible : Bool) : Nil
+  abstract def flush : Nil
+  abstract def size : {Int32, Int32}
+  abstract def close : Nil
+end
+```
+
+Terminal's `apply_style` internally emits SGR for the current style. Buffer's `RenderState` becomes the sole SGR optimizer (bundles with TERMISU-003). Adding a new attribute becomes a one-file change in `attribute.cr` plus a Terminal-internal SGR table update.
+
+#### Verification notes
+
+File is 73 lines; exact method count to be re-checked before the refactor. The llms.txt count of "18 abstract methods" may be off by a handful depending on what counts as a method vs. a setter. Semantic point stands regardless.
+
+---
+
+### <a id="termisu-008"></a>TERMISU-008 — `Termisu::Termisu` facade at ~797 lines with ~60 public methods is becoming a god object
+
+**Severity:** HIGH  •  **Status:** VERIFIED  •  **Component:** `[facade]`
+**Files:** `src/termisu/termisu.cr`
+
+#### Description
+
+The facade instantiates Terminal + Reader + Parser + Event::Loop + three event sources (Input, Resize, Timer), and exposes:
+- Lifecycle: `new`, `close`, `raw_mode?`, `alternate_screen?`
+- Rendering: `set_cell` (×2 overloads via Buffer delegation), `clear`, `render`, `sync`
+- Cursor: `set_cursor`, `show_cursor`, `hide_cursor`
+- Colors: via delegation (but also direct writers for test)
+- Events: `poll_event`, `try_poll_event`, `each_event`, `add_event_source`, `remove_event_source`
+- Timers: `enable_timer`, `enable_system_timer`, `disable_timer`, `timer_interval=`, `timer_enabled?`
+- Modes: `suspend`, `with_mode`, `with_password_mode`, `with_cbreak_mode`, five variants of mode setters
+- Mouse/keyboard: `enable_mouse`, `disable_mouse`, `enable_enhanced_keyboard`, `disable_enhanced_keyboard`
+- Misc: `title=`, `sync_updates=`, `emit_mode_change`, `pause_input_processing`
+
+Two unrelated responsibilities are fused: **composition root** (instantiating and wiring the graph) and **facade** (user API). These rarely evolve together, and the mixing makes both harder to test.
+
+#### Impact
+
+- Every new capability adds a method here. No natural stopping point.
+- Testing requires a full `Termisu.new`, which opens `/dev/tty` and requires a real terminal.
+- Mode-switch orchestration reaches into sibling subsystems (stops `@input_source`, clears `@reader`, re-emits events on `@event_loop.output`) — coupling that's hard to observe in the current structure.
+
+#### Proposed direction
+
+Extract a `Termisu::Session` owning the graph and orchestration:
+
+```
+Termisu::Termisu (thin facade, ~150 lines, delegation only)
+    └── Termisu::Session (composition + orchestration)
+        ├── Terminal
+        ├── Reader / Parser
+        ├── Event::Loop
+        └── ModeCoordinator (mode transitions, pause/resume input)
+```
+
+Public API remains on `Termisu::Termisu`; `Session` is internal. The split lets `Session` be built with mocks in tests and evolves mode-transition logic independently from the user-facing surface.
+
+This ticket is a refactor; not scopable as a single PR. Should follow TERMISU-003 / TERMISU-007 since they share the rendering-path surface.
+
+#### Verification notes
+
+Line count approximate — `wc -l` before the fix to confirm current state. Method list is representative; a tree-sitter query or `tldr structure` pass should enumerate the full list before the refactor.
+
+---
+
+### <a id="termisu-009"></a>TERMISU-009 — `Source::Input` blocking `send` causes unbounded latency under backpressure, with possible kernel-level drops
+
+**Severity:** HIGH  •  **Status:** VERIFIED (framing rewritten 2026-04-23)  •  **Component:** `[events]`
+**Files:** `src/termisu/event/source/input.cr:103-123`
+
+> **REVIEW NOTE (2026-04-23):** Original title ("keystrokes lost") was imprecise. Actual mechanism: blocking `send` pauses the *producer* fiber, so keystrokes are queued in order but arrive with latency. Under **sustained** backpressure (consumer not draining for seconds), the chain fills: channel (32) → reader buffer (128 B) → kernel TTY buffer (~4 KB) → and only then does the kernel drop. So "loss" is a late-stage symptom, not the primary effect. Fix direction (drop-counter diagnostics + channel cap raise) is still correct; framing is now accurate.
+
+#### Verified source
+
+```crystal
+# event/source/input.cr:103-123
+while @running.get
+  emitted = false
+  drained = 0
+
+  while @running.get && drained < MAX_DRAIN_PER_CYCLE
+    event = @parser.poll_event(0)
+    break unless event
+
+    output.send(event)   # <-- BLOCKING send
+    emitted = true
+    drained += 1
+  end
+
+  break unless @running.get
+
+  if emitted
+    Fiber.yield
+  else
+    sleep IDLE_SLEEP
+  end
+end
+```
+
+#### Description
+
+Input source uses blocking `output.send(event)` on a channel of capacity 32 (`DEFAULT_BUFFER_SIZE = 32` in `event/loop.cr:53`). Timer sources use `send_nonblocking` and self-account drops via `missed_ticks`. The mix is intentional (input wants fidelity, timers want liveness), but the consequences of input's blocking send aren't surfaced to the user.
+
+If the consumer fiber (user's main loop calling `poll_event`) stalls — e.g., slow `render` during a burst, or user paused polling during a long computation — the input fiber blocks on `send` at line 111. With input blocked:
+1. Parser stops pulling from Reader.
+2. Reader's 4 KB internal buffer fills.
+3. Kernel TTY queue fills.
+4. Keystrokes are dropped at the kernel boundary (silently).
+
+The 32-event channel + ~4 KB buffer gives maybe 100-500 keystrokes of headroom depending on encoding; after that, drops are silent.
+
+#### Impact
+
+- **Silent data loss.** User types during a long render; some characters vanish. No log, no diagnostic.
+- **Paste attacks unmitigated.** A bracketed paste of 10 KB flows through faster than the consumer can process, overwhelms buffering.
+- **Hard to diagnose.** Symptoms look like "Termisu sometimes misses keys." Without instrumentation, unfixable.
+
+#### Proposed fix options
+
+**A) Track back-pressure (recommended minimum):** instrument the drop condition and expose a counter:
+
+```crystal
+output.send(event)
+# after (pseudo — real fix uses select/else + counter):
+unless send_nonblocking(output, event)
+  @drops.add(1)
+  Log.warn { "Input channel full; #{@drops.get} events dropped total" }
+end
+```
+
+Even if we keep blocking semantics, detect channel-full via a `select/else` probe and log when it happens.
+
+**B) Raise channel capacity.** `DEFAULT_BUFFER_SIZE = 32` → `256`. Trivial change; buys headroom for typical bursts.
+
+**C) Formalize per-source backpressure policy** (ties to TERMISU-023). Add a `Source#delivery_policy : Blocking | DropOldest | DropNew` contract; Loop enforces it uniformly.
+
+Recommend shipping (A) + (B) first, treating (C) as its own refactor.
+
+#### Verification notes
+
+Exact code reproduced above. Channel capacity of 32 confirmed via llms.txt §7.3, to be re-verified in `event/loop.cr` before the fix.
+
+---
+
+### <a id="termisu-010"></a>TERMISU-010 — FFI accepts out-of-range coordinates and codepoints; defense-in-depth hygiene
+
+**Severity:** MEDIUM  *(reduced from HIGH on 2026-04-23)*  •  **Status:** VERIFIED  •  **Component:** `[ffi]`
+**Files:** `src/termisu/ffi/conversions.cr:12-16` + `src/termisu/ffi/core.cr:91-103`
+
+> **REVIEW NOTE (2026-04-23):** "DoS via exception spam" framing was overstated. Crystal exceptions aren't Java exceptions — no default stack capture, catch cost is modest. A channel cap of 32 and EINTR retry cap of 100 bound the real-world impact well before exception overhead matters. Still a good defense-in-depth hygiene fix (validate early at FFI boundary), but not HIGH. Also: `Char#chr` already validates surrogates — proposed explicit surrogate check duplicates stdlib logic.
+
+#### Verified source
+
+```crystal
+# ffi/conversions.cr:12-16
+def self.codepoint_to_char(codepoint : UInt32) : Char
+  codepoint.chr
+rescue ex : ArgumentError
+  raise ArgumentError.new("Invalid Unicode codepoint #{codepoint}: #{ex.message || ex.class.name}")
+end
+```
+
+#### Description
+
+Untrusted C callers pass coordinates (`x, y : Int32`) and codepoints (`codepoint : UInt32`) through FFI exports. Validation happens *inside* Crystal code paths that raise on bad input:
+- `codepoint_to_char` raises `ArgumentError` for surrogates (0xD800-0xDFFF) or out-of-range (> 0x10FFFF).
+- `Buffer#set_cell` validates bounds after allocating a `Cell` — Cell allocation is paid before rejection.
+- Negative coordinates pass through `Buffer#out_of_bounds?` correctly but a malicious caller paying the exception penalty per invalid call is a DoS lever.
+
+`Guards.with_error_fallback` catches all exceptions and returns a status code — **correct for safety**, but the exception path is ~10-100× slower than a validated rejection, giving a malicious caller an asymmetric cost lever.
+
+#### Impact
+
+- **DoS via exception spam:** A loop calling `termisu_set_cell(ctx, 0, 0, 0xD800, NULL)` burns CPU on exception create/catch/format per call. Against a C consumer in a tight loop, this can monopolize the Crystal runtime.
+- **Hot-path exception creation:** `conversions.cr:15` even *rewraps* the ArgumentError with a formatted message, doubling the per-call work.
+- **Not exploitable for RCE** — `Guards` correctly shields Crystal state — but it's a performance/availability concern.
+
+#### Proposed fix
+
+Validate cheap at FFI boundary *before* any Crystal work:
+
+```crystal
+# ffi/core.cr — in set_cell implementation
+def self.set_cell(handle : UInt64, x : Int32, y : Int32, codepoint : UInt32, style_ptr : ...) : Status
+  # Fast-fail input validation
+  return Status::InvalidArgument if x < 0 || y < 0
+  return Status::InvalidArgument if codepoint > 0x10FFFF
+  return Status::InvalidArgument if (0xD800_u32..0xDFFF_u32).includes?(codepoint)
+
+  with_context(handle) do |ctx|
+    char = codepoint.unsafe_chr  # now guaranteed valid
+    # ... existing body ...
+  end
+end
+```
+
+Expose a `Char.valid_scalar?(codepoint : UInt32) : Bool` helper in `conversions.cr` for reuse. Drop the rescue-and-rewrap in `codepoint_to_char` — it's no longer reachable from validated callers, and unvalidated callers shouldn't exist.
+
+#### Verification notes
+
+`conversions.cr` read fully and quoted. `ffi/core.cr` set_cell body should be re-read before patching to ensure the exact error-return path matches the rest of that file's style.
+
+---
+
+### <a id="termisu-011"></a>TERMISU-011 — `Cell` construction + `@batch_buffer.to_s` allocate in diff hot path
+
+**Severity:** HIGH  •  **Status:** VERIFIED  •  **Component:** `[rendering]`
+**Files:** `src/termisu/buffer.cr:467, 473` + `src/termisu/cell.cr:92-108`
+
+#### Verified source
+
+```crystal
+# buffer.cr:465-474 (inside render_row_batch)
+break if back_cell.fg != batch_fg || back_cell.bg != batch_bg || back_cell.attr != batch_attr
+
+@batch_buffer << back_cell.grapheme
+columns_advanced += back_cell.width
+@front[idx] = back_cell
+col += 1
+end
+
+render_batch(renderer, batch_start, row, @batch_buffer.to_s, batch_fg, batch_bg, batch_attr, columns_advanced)
+```
+
+#### Description
+
+Two hot-path allocations in the render pipeline:
+
+1. **`@batch_buffer.to_s` at line 473.** `IO::Memory#to_s` allocates a fresh `String` for every style batch. Worst case is an alternating-style screen (e.g., syntax-highlighted code) where every cell starts a new batch — 1920 allocations per full-screen render at 60 FPS = 115K strings/sec.
+2. **`Cell` construction** (see TERMISU-002 details) — every `set_cell` pays for grapheme iteration + width lookup.
+
+The `@batch_buffer` is reused (it's `clear`ed at line 449), but `to_s` takes a snapshot copy. This is a performance anti-pattern when the downstream consumer (`renderer.write`) could accept the `IO::Memory` directly.
+
+#### Impact
+
+Same frame-budget category as TERMISU-002. Under a full-screen redraw with varied styles, the allocation pressure from `to_s` alone can blow 60 FPS on a 200×50 terminal.
+
+#### Proposed fix
+
+Expose a renderer method that consumes `IO::Memory` without copy:
+
+```crystal
+# In Renderer interface (or after narrowing per TERMISU-007):
+abstract def write_bytes(io : IO::Memory, byte_count : Int32) : Nil
+```
+
+`Terminal` implements it via `LibC.write(fd, io.to_unsafe, byte_count)`. Buffer's render_batch then passes the live buffer:
+
+```crystal
+render_batch(renderer, batch_start, row, @batch_buffer, batch_fg, batch_bg, batch_attr, columns_advanced)
+```
+
+The `@batch_buffer` is cleared each call (`buffer.cr:449`), so reuse is safe.
+
+#### Verification notes
+
+Confirmed `@batch_buffer.to_s` call at line 473 directly. `IO::Memory#to_s` allocates — this is Crystal stdlib behavior, not library-specific. Fix is straightforward.
+
+---
+
+## MEDIUM
+
+### <a id="termisu-012"></a>TERMISU-012 — ~~`FFI::Registry` generation counter~~ ❌ CLOSED — INVALID
+
+**Severity:** ❌ **CLOSED** *(was MEDIUM; closed on 2026-04-23 review)*  •  **Component:** `[ffi]`
+**Files:** `src/termisu/ffi/registry.cr`
+
+> **CLOSURE REASON:** Rejected as overengineering. UInt64 monotonic wrap takes 2^64 operations ≈ 584 billion years at 1 M creates/sec. Handles are never reused in the current design — deleted handles vanish from the map and `fetch(handle)` returns `nil` for stale handles, which is correct. The proposed `{gen, id}` encoding doubles lookup complexity and hash overhead for a problem that cannot manifest in practice. Original ticket text preserved below for historical record.
+
+<details><summary>Original ticket (kept for record)</summary>
+
+#### Verified source
+
+```crystal
+# Full registry.cr source:
+module Termisu::FFI::Registry
+  @@contexts = {} of UInt64 => Termisu::FFI::Context
+  @@lock = Mutex.new
+  @@next_handle = 1_u64
+
+  def self.insert(context : Termisu::FFI::Context) : UInt64
+    @@lock.synchronize do
+      handle = @@next_handle
+      @@next_handle += 1_u64
+      @@contexts[handle] = context
+      handle
+    end
+  end
+
+  def self.fetch(handle : UInt64) : Termisu::FFI::Context?
+    @@lock.synchronize { @@contexts[handle]? }
+  end
+
+  def self.delete(handle : UInt64) : Termisu::FFI::Context?
+    @@lock.synchronize { @@contexts.delete(handle) }
+  end
+end
+```
+
+#### Description
+
+Handles are a monotonically incrementing `UInt64`. On `destroy`, the entry is removed from the map; the counter keeps advancing. In practice, wrap-around takes 2^64 operations (unreachable). But two scenarios still matter:
+- **Stale-handle reuse logic**: If a long-lived C caller retains a handle past the lifetime of its context, and the registry is ever reset (or the process re-creates contexts aggressively), there is no structural prevention against the handle being reassigned to a *new* context.
+- **Cross-process confusion:** If a future feature shares handles across processes or serializes them, collisions become real.
+
+#### Impact
+
+Low in the current single-process design; MEDIUM because the fix is cheap and strictly improves safety.
+
+#### Proposed fix
+
+Encode a generation counter in the upper 32 bits:
+
+```crystal
+module Termisu::FFI::Registry
+  @@contexts = {} of UInt32 => {UInt32, Termisu::FFI::Context}  # id => {gen, ctx}
+  @@lock = Mutex.new
+  @@next_id = 1_u32
+  @@generations = {} of UInt32 => UInt32
+
+  def self.insert(context) : UInt64
+    @@lock.synchronize do
+      id = @@next_id
+      @@next_id += 1_u32
+      gen = (@@generations[id]? || 0_u32) + 1_u32
+      @@generations[id] = gen
+      @@contexts[id] = {gen, context}
+      (gen.to_u64 << 32) | id.to_u64
+    end
+  end
+
+  def self.fetch(handle : UInt64) : Termisu::FFI::Context?
+    @@lock.synchronize do
+      id = (handle & 0xFFFFFFFF_u64).to_u32
+      gen = (handle >> 32).to_u32
+      if entry = @@contexts[id]?
+        entry[0] == gen ? entry[1] : nil
+      end
+    end
+  end
+end
+```
+
+#### Verification notes
+
+Full file read; confirmed no generation tracking. 23-line file, simple to modify. Low-risk change.
+
+---
+
+### <a id="termisu-013"></a>TERMISU-013 — Input parser has no CPU budget — malformed CSI spam can monopolize the input fiber
+
+**Severity:** MEDIUM  •  **Status:** NEEDS-REPRO  •  **Component:** `[input]`
+**Files:** `src/termisu/input/parser.cr:196-228`
+
+#### Description
+
+`parse_csi_sequence` reads bytes until a final byte in 0x40-0x7E, bounded by `MAX_SEQUENCE_LENGTH`. A malicious or malfunctioning TTY producer (compromised keyboard firmware, malicious tmux plugin, paste injection) can send repeated unterminated CSI prefixes: `\e[AAAA\e[AAAA…`. Each consumes up to `MAX_SEQUENCE_LENGTH` bytes before returning `Key::Unknown`. No aggregate rate limit exists.
+
+#### Impact
+
+CPU DoS against the input fiber. Over time, bytes accumulate in Reader's buffer and TTY queue, and the parser fiber eats CPU without producing meaningful events. Realistic attack vector is limited to cases where an attacker controls the tty's upstream (SSH-forwarded session with compromised intermediate, malicious terminal emulator, paste-injection via a malicious program).
+
+#### Proposed fix
+
+Introduce a byte budget per-second on the input fiber. When exceeded, log a warning and briefly back off. Detailed design tbd — see TERMISU-023 for the related "uniform policy" work.
+
+#### Verification notes
+
+Source region was not re-read for this ticket (marked NEEDS-REPRO). The scope of `MAX_SEQUENCE_LENGTH` and its enforcement should be verified before implementing a fix.
+
+---
+
+### <a id="termisu-014"></a>TERMISU-014 — Terminfo binary parser's null-terminated string scan lacks end-of-data guard
+
+**Severity:** MEDIUM  •  **Status:** NEEDS-REPRO  •  **Component:** `[terminfo]`
+**Files:** `src/termisu/terminfo/parser.cr:247-263` (approximate, per scout review)
+
+#### Description
+
+`read_null_terminated_string` scans until a NUL byte. If a malformed terminfo file contains a string offset pointing into the last region of the table without a NUL terminator, the scan runs past `@data.size`. Out-of-bounds read in Crystal raises `IndexError`, which is preferable to UB but still a DoS path (crash on first read of an attacker-crafted terminfo file).
+
+#### Impact
+
+- A user runs in a directory where a malicious `~/.terminfo` or `$TERMINFO` override places a crafted file matching `$TERM`. On Termisu initialization, parser reads that file and crashes.
+- Not exploitable for code execution in Crystal (bounds checking), but a reliable crash vector.
+
+#### Proposed fix
+
+Add an explicit guard at each read step:
+
+```crystal
+while io.pos < @data.size
+  byte = io.read_byte
+  break if byte.nil? || byte == 0
+  buffer << byte.chr
+end
+```
+
+Or use `String.new` with an explicit end position derived from the table bounds.
+
+#### Verification notes
+
+Scout review identified the specific lines but this ticket has not been re-verified against the current `parser.cr`. Before fixing, read lines 240-270 of that file to confirm the exact loop structure.
+
+---
+
+### <a id="termisu-015"></a>TERMISU-015 — `Color.ansi8(-1)` is silently valid; docstring and validator disagree
+
+**Severity:** MEDIUM  •  **Status:** VERIFIED  •  **Component:** `[color]`
+**Files:** `src/termisu/color.cr:57-67, 101-103`
+
+#### Verified source
+
+```crystal
+# color.cr:56-67
+DEFAULT_INDEX = -1
+
+protected def initialize(@mode : Mode, @index : Int32 = 0, @r : UInt8 = 0_u8, @g : UInt8 = 0_u8, @b : UInt8 = 0_u8)
+end
+
+# Creates an ANSI-8 basic color (0-7).
+def self.ansi8(index : Int32) : Color
+  Validator.validate_ansi8(index)
+  new(Mode::ANSI8, index: index)
+end
+
+# color.cr:100-103
+def self.default : Color
+  ansi8(DEFAULT_INDEX)
+end
+```
+
+#### Description
+
+The public factory `Color.ansi8(index)` has a docstring stating "0-7" as the valid range. `Color.default` calls `ansi8(DEFAULT_INDEX)` where `DEFAULT_INDEX = -1`. For this to succeed, `Validator.validate_ansi8` must accept `-1` — and it does (verifiable by running `Color.default`, which doesn't raise). So the *actual* valid range is `{-1} ∪ {0..7}`, but the docstring lies.
+
+External consumers passing `-1` intentionally get undefined semantics (it happens to mean "default color" today, but that's an implementation detail leaking through a validated factory).
+
+#### Impact
+
+- Doc/code drift — readers can't trust the stated range.
+- Internal sentinel (`DEFAULT_INDEX = -1`) leaks through the public API.
+
+#### Proposed fix
+
+Bypass the public factory in `Color.default` and tighten the validator:
+
+```crystal
+def self.default : Color
+  new(Mode::ANSI8, index: DEFAULT_INDEX)  # direct, no validation
+end
+
+# In validator — enforce the stated range strictly:
+def self.validate_ansi8(index : Int32) : Nil
+  raise ArgumentError.new("ANSI-8 index must be 0-7, got #{index}") unless (0..7).includes?(index)
+end
+```
+
+`Color.default` still works because it uses `new` directly. External callers who accidentally pass `-1` now get a clean ArgumentError.
+
+#### Verification notes
+
+`color.cr` lines 1-110 read directly. Docstring at line 63 is unambiguous. The validator file (`color/validator.cr`) should be inspected before the fix to confirm the current check logic.
+
+---
+
+### <a id="termisu-016"></a>TERMISU-016 — `set_cursor(x, y, visible: Bool? = true, …)` has confusing precedence and default
+
+**Severity:** MEDIUM  •  **Status:** NEEDS-REPRO  •  **Component:** `[facade]`
+**Files:** `src/termisu/termisu.cr:165-176` (per scout review)
+
+#### Description
+
+Per scout review, the signature is `set_cursor(x, y, visible : Bool? = true, …)`. The body contains a conditional like `visible ? show_cursor : hide_cursor unless visible.nil?`, which parses with surprising precedence. Combined with a default of `true` (not `nil`), every default call shows the cursor — no way to say "move cursor but don't touch visibility" without passing `visible: nil` explicitly, which isn't obvious from the docstring.
+
+#### Impact
+
+API confusion. Users who want to set position without changing visibility must read the source to discover the `nil` idiom.
+
+#### Proposed fix
+
+Split into two methods or change the default:
+
+```crystal
+# Simpler: position only, doesn't change visibility
+def set_cursor(x : Int32, y : Int32) : Nil
+  @terminal.move_cursor(x, y)
+end
+
+# Explicit visibility change
+def set_cursor(x : Int32, y : Int32, *, visible : Bool, blink : Bool? = nil, shape : Cursor::Shape? = nil) : Nil
+  @terminal.move_cursor(x, y)
+  visible ? @terminal.show_cursor : @terminal.hide_cursor
+  # ... apply blink / shape if present
+end
+```
+
+#### Verification notes
+
+Not re-verified against the current source. Before fixing, read `termisu.cr:160-180` to confirm exact signature and precedence.
+
+---
+
+### <a id="termisu-017"></a>TERMISU-017 — `terminal.cr` at ~699 lines mixes SGR, modes, mouse, enhanced keyboard, title, sync updates
+
+**Severity:** MEDIUM  •  **Status:** NEEDS-REPRO  •  **Component:** `[rendering]`
+**Files:** `src/termisu/terminal.cr`
+
+#### Description
+
+One class handles: alternate-screen, cached SGR emission (fg/bg/attr), mouse enable/disable (X10 + 1006 SGR), enhanced keyboard (Kitty + modifyOtherKeys), sync updates (BSU/ESU), window title, mode switching, cursor delegation, and Buffer delegation. Constants for escape sequences (`MOUSE_ENABLE_SGR`, `KITTY_KEYBOARD_ENABLE`, `BSU`, `ESU`) are scattered mid-class rather than grouped at top per the project's own `crystal-conventions.md` rule.
+
+#### Impact
+
+- Hard to find anything. Extension friction.
+- Violates the canonical class order documented in `.claude/rules/crystal-conventions.md`.
+
+#### Proposed direction
+
+Extract:
+- `Terminal::Protocols` — constants for mouse and enhanced keyboard sequences
+- `Terminal::SyncUpdate` — BSU/ESU logic
+- Keep `terminal.cr` under 400 lines focused on buffer/render/cursor delegation + mode orchestration
+
+#### Verification notes
+
+Line count approximate. Run `wc -l src/termisu/terminal.cr` before the fix.
+
+---
+
+### <a id="termisu-018"></a>TERMISU-018 — `SHUTDOWN_TIMEOUT_MS = 100` but code sleeps `/ 10` (10 ms) — name lies
+
+**Severity:** MEDIUM  •  **Status:** NEEDS-REPRO  •  **Component:** `[events]`
+**Files:** `src/termisu/event/loop.cr:54-56, 155` (per scout review)
+
+#### Description
+
+Per scout review, `SHUTDOWN_TIMEOUT_MS = 100` is declared, but `stop` calls `sleep SHUTDOWN_TIMEOUT_MS.milliseconds / 10` — 10 ms, not 100 ms. Name implies 100 ms is the budget; only 10% is used.
+
+#### Impact
+
+Reader confusion. Someone trying to tune shutdown responsiveness will change `SHUTDOWN_TIMEOUT_MS` and see no linear effect.
+
+#### Proposed fix
+
+Rename to reflect the actual value:
+
+```crystal
+SHUTDOWN_FIBER_GRACE = 10.milliseconds
+# ... in stop:
+sleep SHUTDOWN_FIBER_GRACE
+```
+
+Drop the `/10` ceremony.
+
+#### Verification notes
+
+Not re-verified. Read `event/loop.cr:50-160` before fixing to confirm the pattern.
+
+---
+
+### <a id="termisu-019"></a>TERMISU-019 — CSI parser uses `params.split(';')` — allocates Array+Strings per special key
+
+**Severity:** MEDIUM  •  **Status:** VERIFIED  •  **Component:** `[input]`
+**Files:** `src/termisu/input/parser.cr:349-357`
+
+#### Verified source
+
+```crystal
+# input/parser.cr:349-357
+private def parse_modifiers(params : String) : Modifier
+  return Modifier::None unless params.includes?(';')
+
+  parts = params.split(';')   # <-- allocates Array + N Strings per call
+  return Modifier::None if parts.size < 2
+
+  mod_code = parts[1].to_i? || 1
+  Modifier.from_xterm_code(mod_code)
+end
+```
+
+#### Description
+
+Every CSI sequence with a modifier field (arrow keys with modifiers, F-keys, Kitty protocol, modifyOtherKeys) allocates an Array of Strings via `split`. Called on every special keypress. Rapid nav (holding an arrow key) generates hundreds of allocations per second.
+
+Two other sites use the same pattern (scout-identified lines 243 and 275 in `decode_csi_key` and `parse_kitty_key`).
+
+#### Impact
+
+Allocation pressure during fast keyboard navigation. Not catastrophic but easy to eliminate.
+
+#### Proposed fix
+
+In-place parse without splitting:
+
+```crystal
+private def parse_modifiers(params : String) : Modifier
+  semicolon = params.index(';')
+  return Modifier::None unless semicolon
+
+  mod_code = 0
+  i = semicolon + 1
+  while i < params.bytesize
+    ch = params.unsafe_byte_at(i)
+    break if ch < 48 || ch > 57  # non-digit
+    mod_code = mod_code * 10 + (ch - 48)
+    i += 1
+  end
+  return Modifier::None if mod_code == 0
+  Modifier.from_xterm_code(mod_code)
+end
+```
+
+Apply same pattern at `parser.cr:243, 275` once those regions are re-verified.
+
+#### Verification notes
+
+`parse_modifiers` read directly and confirmed. Other two sites are plausible from context but not re-verified — check before applying.
+
+---
+
+### <a id="termisu-020"></a>TERMISU-020 — `apply_attribute_change` does 2×8 `includes?` checks per style change
+
+**Severity:** MEDIUM  •  **Status:** VERIFIED  •  **Component:** `[rendering]`
+**Files:** `src/termisu/render_state.cr:93-107`
+
+#### Verified source
+
+```crystal
+# render_state.cr:93-107
+private def apply_new_attributes(renderer : Renderer, new_attr : Attribute)
+  renderer.enable_bold if needs_attr?(new_attr, Attribute::Bold)
+  renderer.enable_underline if needs_attr?(new_attr, Attribute::Underline)
+  renderer.enable_reverse if needs_attr?(new_attr, Attribute::Reverse)
+  renderer.enable_blink if needs_attr?(new_attr, Attribute::Blink)
+  renderer.enable_dim if needs_attr?(new_attr, Attribute::Dim)
+  renderer.enable_cursive if needs_attr?(new_attr, Attribute::Cursive)
+  renderer.enable_hidden if needs_attr?(new_attr, Attribute::Hidden)
+  renderer.enable_strikethrough if needs_attr?(new_attr, Attribute::Strikethrough)
+end
+
+private def needs_attr?(new_attr : Attribute, flag : Attribute) : Bool
+  new_attr.includes?(flag) && !@attr.includes?(flag)
+end
+```
+
+#### Description
+
+`needs_attr?` performs two `Attribute#includes?` calls (each a bitwise AND) per attribute flag, 8 times, giving 16 bitwise ops + branch predictions per style transition.
+
+#### Impact
+
+Not enormous, but called in the render hot path. Trivially optimizable.
+
+#### Proposed fix
+
+Compute the delta once:
+
+```crystal
+private def apply_new_attributes(renderer : Renderer, new_attr : Attribute)
+  added = new_attr & ~@attr  # bits newly enabled
+  renderer.enable_bold          if added.bold?
+  renderer.enable_underline     if added.underline?
+  renderer.enable_reverse       if added.reverse?
+  renderer.enable_blink         if added.blink?
+  renderer.enable_dim           if added.dim?
+  renderer.enable_cursive       if added.cursive?
+  renderer.enable_hidden        if added.hidden?
+  renderer.enable_strikethrough if added.strikethrough?
+end
+```
+
+Eight bitwise ops total; same logic. Drops `needs_attr?`. Will bundle naturally with the TERMISU-007 / TERMISU-003 refactor.
+
+#### Verification notes
+
+Full source reproduced and confirmed.
+
+---
+
+### <a id="termisu-021"></a>TERMISU-021 — `ffi/core.cr` is a grab-bag file mirroring the facade's bloat
+
+**Severity:** MEDIUM  •  **Status:** NEEDS-REPRO  •  **Component:** `[ffi]`
+**Files:** `src/termisu/ffi/core.cr`
+
+#### Description
+
+Per llms.txt inventory, `ffi/core.cr` contains every Crystal-side implementation of every FFI export — lifecycle, size, rendering, cursor, cells, events, timers, mouse, enhanced keyboard, modes. It's effectively a parallel facade with `with_context { ... }` boilerplate wrapping each call.
+
+#### Impact
+
+Mirrors TERMISU-008's facade bloat — a refactor of one should drive the other. Adding an FFI export today means editing both `exports.cr` and `core.cr` in ad-hoc locations.
+
+#### Proposed direction
+
+Split by subsystem: `ffi/rendering.cr`, `ffi/events.cr`, `ffi/modes.cr`, `ffi/lifecycle.cr`. Or — better — generate the Crystal-side dispatchers from annotations on the facade, making drift structurally impossible.
+
+#### Verification notes
+
+File structure described from llms.txt. Read `ffi/core.cr` to confirm current organization before splitting.
+
+---
+
+### <a id="termisu-022"></a>TERMISU-022 — Crystal `Color::Mode` lacks `Default`; ABI `ColorMode` has it — asymmetric contract
+
+**Severity:** MEDIUM  •  **Status:** VERIFIED  •  **Component:** `[color]` `[ffi]`
+**Files:** `src/termisu/color.cr:40-57` + `src/termisu/ffi/color_mode.cr` (per scout review)
+
+#### Verified source
+
+```crystal
+# color.cr:40-57
+enum Mode
+  ANSI8   # Basic 8 colors (0-7)
+  ANSI256 # Extended 256-color palette
+  RGB     # 24-bit true color
+end
+
+getter mode : Mode
+getter index : Int32
+getter r : UInt8
+getter g : UInt8
+getter b : UInt8
+
+DEFAULT_INDEX = -1
+```
+
+#### Description
+
+Crystal-side `Color::Mode` has 3 variants: `ANSI8`, `ANSI256`, `RGB`. "Default color" is encoded by `Mode::ANSI8` with `index == -1`. The ABI's `ColorMode` enum (per llms.txt §9.5) has 4 variants: `Default=0`, `Ansi8=1`, `Ansi256=2`, `Rgb=3` — so the ABI treats `Default` as a first-class mode.
+
+`conversions.cr:28-41` handles this by dispatching on ABI mode and calling `Color.default` for mode 0, `Color.ansi8(color.index)` for mode 1, etc. That works, but:
+
+1. Adding a new mode (e.g., Oklab) requires edits in `color.cr` (enum + validator + conversions + SGR emitter in Terminal) + `ffi/color_mode.cr` + `ffi/conversions.cr`.
+2. The Crystal Mode vs. ABI ColorMode asymmetry is a trap — a reader seeing the ABI form might infer Crystal has a Default mode too.
+
+#### Impact
+
+Friction on future color-mode additions. Subtle landmine for contributors.
+
+#### Proposed fix
+
+Unify: add `Default` to Crystal's Mode enum, drop `DEFAULT_INDEX`:
+
+```crystal
+enum Mode
+  Default
+  ANSI8
+  ANSI256
+  RGB
+end
+
+def self.default : Color
+  new(Mode::Default)
+end
+```
+
+`Color.default?` predicate becomes `mode == Mode::Default` instead of `index == -1`. `Terminal#foreground=` dispatch adds a new arm for `Default` → emit `\e[39m`. ABI conversion becomes 1-to-1.
+
+#### Verification notes
+
+Crystal side confirmed directly. ABI enum should be re-read in `ffi/color_mode.cr` to ensure exact variant list.
+
+---
+
+### <a id="termisu-023"></a>TERMISU-023 — Backpressure policy is scattered across sources, not uniform in the Loop
+
+**Severity:** MEDIUM  •  **Status:** VERIFIED  •  **Component:** `[events]`
+**Files:** `src/termisu/event/loop.cr` + all `event/source/*.cr`
+
+#### Description
+
+One shared channel, three different backpressure policies:
+- `Source::Input` (confirmed at `source/input.cr:111`) uses blocking `send` — see TERMISU-009.
+- `Source::Timer` and `Source::SystemTimer` use `send_nonblocking` (inherited helper) and self-account drops as `missed_ticks`.
+- `Termisu::Termisu#emit_mode_change` (per scout review) sends to the same channel — yet another site with its own policy.
+
+Three sites, three policies, no uniform contract.
+
+#### Impact
+
+- Adding a new source requires answering "what's my backpressure policy?" from scratch.
+- Per-source prioritization (e.g., "always deliver Resize, drop Ticks before Key") cannot be expressed in the current design.
+- Reasoning about `poll_event` behavior under load requires reading every source and every facade send site.
+
+#### Proposed direction
+
+Lift the policy into the `Source` contract:
+
+```crystal
+abstract class Termisu::Event::Source
+  enum DeliveryPolicy
+    Blocking         # block the source fiber if channel full (input's current behavior)
+    DropOldest       # drop oldest queued event (timer's current behavior via missed_ticks)
+    DropNew          # drop the new event silently
+    DropWithCounter  # drop + increment counter for diagnostics
+  end
+
+  abstract def delivery_policy : DeliveryPolicy
+  # ... existing abstract methods ...
+end
+```
+
+`Event::Loop` enforces the policy at send time; sources stop owning `send_nonblocking` logic. Also enables per-priority ordering: high-priority sources could get their own small channel that the loop merges into the main one with priority.
+
+This is a refactor; not scopable as a small PR. Bundle with TERMISU-009.
+
+#### Verification notes
+
+`Source::Input` blocking send confirmed directly. Other sources' policies summarized from llms.txt; re-verify against each file before patching.
+
+---
+
+### <a id="termisu-024"></a>TERMISU-024 — `Buffer#invalidate` relies on implicit "NUL is never a real cell" contract
+
+**Severity:** MEDIUM  •  **Status:** NEEDS-REPRO  •  **Component:** `[rendering]`
+**Files:** `src/termisu/buffer.cr:200-210` (per scout review)
+
+#### Description
+
+Per scout review, `Buffer#invalidate` fills `@front` with `Cell.new(" ", …)` as a sentinel guaranteed to differ from any valid cell (which never contains a NUL byte because `Buffer#set_cell` rejects it via `control_char?`). The invariant "NUL never appears in a valid cell" lives in two places:
+- Fill site in `invalidate`
+- Guard at `set_cell_internal` in `buffer.cr:326-329`
+
+If `control_char?` is ever relaxed (e.g., to allow some C0 controls for box drawing), the invalidation mechanism silently breaks.
+
+#### Impact
+
+A distant change can silently disable full-screen redraws — an almost-invisible bug that manifests as "screen doesn't refresh after resize in some edge case."
+
+#### Proposed fix
+
+Use a structural sentinel rather than a value-based one:
+
+```crystal
+# Option A: Array(Cell?) with nil meaning "unknown"
+@front : Array(Cell?) = Array(Cell?).new(size, nil)
+
+# Option B: explicit Cell::Invalid variant
+struct Cell
+  class_getter invalid : Cell = Cell.new(valid: false)
+end
+```
+
+#### Verification notes
+
+Not re-verified. Read `buffer.cr:195-335` before fixing.
+
+---
+
+### <a id="termisu-025"></a>TERMISU-025 — `Cell` struct fuses display data with grid-occupancy (continuation)
+
+**Severity:** MEDIUM  •  **Status:** VERIFIED  •  **Component:** `[rendering]`
+**Files:** `src/termisu/cell.cr:42-48`
+
+#### Verified source
+
+```crystal
+# cell.cr:42-48
+struct Termisu::Cell
+  getter grapheme : String = ""
+  getter width : UInt8 = 0
+  getter? continuation : Bool
+  property fg : Color
+  property bg : Color
+  property attr : Attribute
+```
+
+#### Description
+
+`Cell` carries both display data (grapheme, fg, bg, attr) and grid-occupancy data (`continuation`). Buffer's logic has many `cell.continuation?` checks and must clear pairs together. Two concepts — "logical character" and "physical slot" — are fused in one struct, which leaks grid semantics into the value type.
+
+#### Impact
+
+- Callers of Cell's public API see `continuation?` even though they can't meaningfully set it (continuation cells are constructed via `Cell.continuation`).
+- Wide-char invariants are enforced in Buffer code rather than structurally.
+
+#### Proposed direction
+
+Move occupancy to Buffer-internal representation:
+
+```crystal
+private enum Slot
+  Glyph(Cell)
+  Continuation(prev_x : Int16)
+  Empty
+end
+
+@front : Array(Slot)
+@back  : Array(Slot)
+```
+
+`Cell` becomes a pure display record. Buffer's invariants (e.g., "writing a narrow char over a wide-char leading slot clears both slots") become easier to enforce and test.
+
+Refactor in scope; bundle with TERMISU-024 since both touch Buffer's storage model.
+
+#### Verification notes
+
+Source confirmed directly.
+
+---
+
+### <a id="termisu-026"></a>TERMISU-026 — `Reader` buffer is 128 bytes — undersized for burst input
+
+**Severity:** MEDIUM  •  **Status:** NEEDS-REPRO  •  **Component:** `[io]`
+**Files:** `src/termisu/reader.cr`
+
+#### Description
+
+The llms.txt indexing claims 4096 bytes; the performance reviewer read 128 bytes. Discrepancy — reality needs to be re-verified directly. If the buffer is indeed 128 bytes:
+- A paste of a multi-line sequence (100+ bytes) requires multiple `read()` syscalls.
+- Fast typing (~1000 keys/sec burst, each 1-3 bytes) takes ~8-10 syscalls/sec.
+
+Either way, the buffer size is a tuning knob worth re-visiting.
+
+#### Impact
+
+Mild syscall amplification under burst input.
+
+#### Proposed fix
+
+If buffer is 128 bytes: raise to 4096 (page-aligned, matches many stdlib defaults). If already 4096: nothing to do; close this ticket.
+
+#### Verification notes
+
+**MUST verify the actual buffer size in `reader.cr` before acting** — llms.txt and the performance review disagree. One source must be wrong.
+
+---
+
+### <a id="termisu-027"></a>TERMISU-027 — `Event::Source` invariants are documented but unenforced
+
+**Severity:** MEDIUM  •  **Status:** NEEDS-REPRO  •  **Component:** `[events]`
+**Files:** `src/termisu/event/source.cr`
+
+#### Description
+
+llms.txt §7.2 states that every `Event::Source` implementation must:
+1. Use `Atomic(Bool) + compare_and_set` for idempotent lifecycle.
+2. Rescue `Channel::ClosedError` gracefully in `run_loop`.
+
+Neither invariant is enforced by the abstract class — a subclass can set `@running = true` directly (non-atomic) or omit the rescue, violating the contract silently.
+
+#### Impact
+
+- Custom sources (a declared extension point) are at the mercy of the implementer to get the invariants right.
+- A subtle concurrency bug in a custom source is nearly impossible to diagnose without knowing the contract.
+
+#### Proposed direction
+
+Template-method the lifecycle in the base class:
+
+```crystal
+abstract class Termisu::Event::Source
+  @running = Atomic(Bool).new(false)
+
+  def start(output : Channel(Event::Any)) : Nil
+    return unless @running.compare_and_set(false, true)
+    spawn(name: name) do
+      begin
+        run(output)
+      rescue Channel::ClosedError
+        # expected on shutdown
+      ensure
+        @running.set(false)
+      end
+    end
+  end
+
+  def stop : Nil
+    return unless @running.compare_and_set(true, false)
+  end
+
+  def running? : Bool
+    @running.get
+  end
+
+  abstract def name : String
+  abstract def run(output : Channel(Event::Any)) : Nil
+end
+```
+
+Existing subclasses override `run` instead of `start`/`stop`. Contract is now structural.
+
+#### Verification notes
+
+`Event::Source` base class should be re-read before fixing to confirm current abstract surface. All four existing sources will need minor updates.
+
+---
+
+## LOW
+
+### <a id="termisu-028"></a>TERMISU-028 — `Terminfo` pre-caches 12 capabilities at ctor; list is hardcoded
+
+**Severity:** LOW  •  **Status:** VERIFIED (via llms.txt §2.6)  •  **Component:** `[terminfo]`
+**Files:** `src/termisu/terminfo.cr:29-41, 42-66`
+
+#### Description
+
+12 capabilities are cached as instance vars (`@cached_cup`, `@cached_setaf`, …) at ctor. Always paid, list is hardcoded, new hot capabilities require editing `cache_frequent_capabilities` plus the instance-var list.
+
+#### Proposed fix
+
+Replace with lazy memo on first access, OR profile to see if the cache is even worth keeping (a `@caps : Hash` lookup is O(1) and may be fast enough).
+
+---
+
+### <a id="termisu-029"></a>TERMISU-029 — FFI layer is unconditionally compiled — no opt-out flag
+
+**Severity:** LOW  •  **Status:** VERIFIED (via llms.txt §12.12)  •  **Component:** `[ffi]`
+**Files:** `src/termisu/ffi.cr`
+
+#### Description
+
+`require "./ffi/*"` is unconditional. Consumers building small CLI tools pay for 15 extra files and their exported symbols.
+
+#### Proposed fix
+
+```crystal
+# In ffi.cr:
+{% if flag?(:termisu_ffi) %}
+  require "./ffi/version"
+  require "./ffi/status"
+  # ... etc.
+{% end %}
+```
+
+Document the flag. Default off for executables, on for shared-library builds.
+
+---
+
+### <a id="termisu-030"></a>TERMISU-030 — `TIOCGWINSZ` magic numbers duplicated per-platform without shared source
+
+**Severity:** LOW  •  **Status:** NEEDS-REPRO  •  **Component:** `[io]`
+**Files:** `src/termisu/terminal/backend.cr:192-201` (per scout review)
+
+#### Description
+
+Platform-specific ioctl constants (`0x5413`, `0x40087468`) are defined via `{% unless LibC.has_constant? %}` guards, duplicated across files (termios has similar NCCS handling).
+
+#### Proposed fix
+
+Consolidate into `src/termisu/lib_c/ioctl.cr`, parallel to existing `lib_c/kqueue.cr`. Include a comment citing the header each value originates from.
+
+---
+
+### <a id="termisu-031"></a>TERMISU-031 — `Terminfo#to_status_line_seq` hardcodes sequence; should fallback to `get_cap`
+
+**Severity:** LOW  •  **Status:** NEEDS-REPRO  •  **Component:** `[terminfo]`
+**Files:** `src/termisu/terminfo.cr:119-126` (per scout review)
+
+#### Description
+
+Comment says "tsl and fsl apparently tend to be missing, so we're hardcoding them." But a terminal that *does* provide custom `tsl`/`fsl` is silently ignored.
+
+#### Proposed fix
+
+```crystal
+def to_status_line_seq : String
+  get_cap("tsl").presence || "\e]0;"
+end
+
+def from_status_line_seq : String
+  get_cap("fsl").presence || "\a"
+end
+```
+
+---
+
+### <a id="termisu-032"></a>TERMISU-032 — `Terminal#title=` has non-idiomatic setter return pattern
+
+**Severity:** LOW  •  **Status:** NEEDS-REPRO  •  **Component:** `[rendering]`
+**Files:** `src/termisu/terminal.cr:692-696` (per scout review)
+
+#### Description
+
+Per scout review, `title=` has two return paths: an early `return title` when unchanged, and an implicit return of the assignment. Crystal setters conventionally return `Nil`. Missing docstring and return type annotation.
+
+#### Proposed fix
+
+```crystal
+def title=(new_title : String) : Nil
+  return if new_title == @title
+  @title = new_title
+  # ... write escape sequence ...
+end
+```
+
+---
+
+### <a id="termisu-033"></a>TERMISU-033 — `Attribute::Italic` is a documented alias for `Cursive`; `.to_s` always reports `"Cursive"`
+
+**Severity:** LOW  •  **Status:** VERIFIED-MODIFIED (reclassified from HIGH)  •  **Component:** `[rendering]`
+**Files:** `src/termisu/attribute.cr:30-34`
+
+#### Verified source
+
+```crystal
+# attribute.cr:30-34
+# Italic/cursive text (not supported on all terminals)
+Cursive = 32
+
+# Alias for Cursive (more common name)
+Italic = 32
+```
+
+#### Description
+
+The analysis originally flagged this as HIGH, expecting a bug. On inspection, the code comment at line 33 **explicitly documents** that `Italic` is an alias for `Cursive`. The intent is clear: keep both names for API ergonomics, but `Cursive` is canonical.
+
+However, one real consequence remains: `(Attribute::Italic).to_s` returns `"Cursive"` because Crystal's `@[Flags]` enum reports the first-declared name for duplicate values. User code logging `Attribute::Italic` will see `"Cursive"` in logs — cosmetic surprise.
+
+Reclassified from HIGH to LOW because:
+- Behavior is documented.
+- No functional bug (`Italic == Cursive`, both compose correctly with `|`).
+- Only a log/serialization cosmetic artifact.
+
+#### Proposed fix (optional)
+
+Pick one canonical name across the codebase (Italic is more widely recognized in modern tooling). If canonicalizing to `Italic`:
+- Declare `Italic = 32` first, `Cursive = 32` second.
+- Rename `Renderer#enable_cursive` → `enable_italic` (and mock implementations).
+- `RenderState`'s `apply_new_attributes` line 99 uses `Attribute::Cursive` — update to `Italic`.
+
+If staying with Cursive as canonical (current state), document more prominently in the Attribute top-of-file docstring that `Italic.to_s == "Cursive"` is expected.
+
+#### Verification notes
+
+Full enum reproduced. Comment at line 33 is explicit — the analysis reviewer over-reacted. Keeping the ticket because the `.to_s` cosmetic is real and the renderer naming inconsistency (`enable_cursive` vs `Attribute::Italic` when canonicalizing) is legitimate polish work.
+
+---
+
+### <a id="termisu-034"></a>TERMISU-034 — Three `# ameba:disable Naming/AccessorMethodName` suppressions without justification
+
+**Severity:** LOW  •  **Status:** NEEDS-REPRO  •  **Component:** `[rendering]`
+**Files:** `src/termisu/terminal.cr:315-316`, `src/termisu/terminal/backend.cr:135-136`, `src/termisu/termios.cr:79-80` (per scout review)
+
+#### Description
+
+Three locations disable the ameba warning for `set_mode(mode : …)` (ameba wants `mode=`). Suppressions lack a justifying comment. Per `.claude/rules/crystal-conventions.md`, accumulated lint suppressions should be justified inline.
+
+#### Proposed fix
+
+Either:
+1. Rename to `mode=` project-wide (more idiomatic; keeps `current_mode` getter for read).
+2. Add `# ameba:disable Naming/AccessorMethodName — kept for symmetry with current_mode getter; see docs/terminal-modes.md`
+
+Pick (1) unless there's a specific reason to keep `set_mode`.
+
+---
+
+### <a id="termisu-035"></a>TERMISU-035 — `$TERM` is used unvalidated in file path construction (defense-in-depth)
+
+**Severity:** LOW  •  **Status:** NEEDS-REPRO  •  **Component:** `[terminfo]`
+**Files:** `src/termisu/terminfo/database.cr`
+
+#### Description
+
+`Database` constructs paths from `$TERM` via `File.join(base, @name[0].to_s, @name)`. If `$TERM` contained path separators, path construction could traverse outside the expected directory. In practice `$TERM` is user-controlled, so this isn't an escalation vector; it's defense-in-depth only.
+
+#### Proposed fix
+
+Validate `@name` against `/\A[a-zA-Z0-9_+-]+\z/` (typical terminal name charset) early:
+
+```crystal
+def initialize(@name : String)
+  unless @name.matches?(/\A[a-zA-Z0-9_+-]+\z/)
+    raise ArgumentError.new("Invalid terminal name: #{@name.inspect}")
+  end
+end
+```
+
+---
+
+### <a id="termisu-036"></a>TERMISU-036 — `Reader` EINTR retry loop can exhaust `MAX_EINTR_RETRIES = 100` under signal storm
+
+**Severity:** MEDIUM  •  **Status:** NEEDS-REPRO  •  **Component:** `[io]`
+**Files:** `src/termisu/reader.cr:251-298` (per security review)
+
+#### Description
+
+`Reader#fill_buffer` retries up to `MAX_EINTR_RETRIES = 100` on EINTR before raising `IOError`. Similar retry loops exist in `check_fd_readable_select` and the poll variant. A sibling process sending signals at high rate (accidental fork-bomb, adversarial process on a shared machine, misconfigured cron) interrupts each `read()` and walks the counter to zero quickly. After 100 consecutive interruptions, the input pipeline raises — the Source::Input fiber exits, and further input is dead until Termisu is restarted.
+
+Not a remote-exploit concern (requires local process sending signals to the Termisu process), but a real reliability hole for long-running TUIs on busy systems.
+
+#### Impact
+
+- Long-running TUIs (monitoring dashboards, editors, system tools) can lose input under load from an unrelated process.
+- The exhaustion raises a bare `IOError` that may not be surfaced cleanly to the application.
+
+#### Proposed fix
+
+Two layers:
+1. **Exponential backoff between EINTR retries:** after a threshold (say, 10 consecutive EINTRs), add `Fiber.yield` / `sleep 1.millisecond` with doubling backoff. This prevents the retry loop from burning the full counter in microseconds.
+2. **Don't raise on exhaustion; log and yield:** replace the final `raise IOError` with a logged warning + return `nil` (no-data-available). The input fiber stays alive and retries on the next tick.
+
+```crystal
+MAX_EINTR_RETRIES = 100
+EINTR_BACKOFF_THRESHOLD = 10
+
+private def fill_buffer
+  retries = 0
+  loop do
+    n = LibC.read(@fd, @buffer.to_unsafe, @buffer.size)
+    if n < 0
+      err = Errno.value
+      if err == Errno::EINTR
+        retries += 1
+        if retries >= MAX_EINTR_RETRIES
+          Log.warn { "Reader: EINTR storm (100 consecutive); yielding instead of failing" }
+          Fiber.yield
+          return nil
+        end
+        sleep 1.millisecond if retries >= EINTR_BACKOFF_THRESHOLD
+        next
+      end
+      raise Error.read_failed(err)
+    end
+    @buffer_pos = 0
+    @buffer_len = n.to_i32
+    return n
+  end
+end
+```
+
+#### Verification notes
+
+Code region was not re-read for this ticket. Must inspect `reader.cr:240-300` before fixing — the exact structure of the EINTR loop and the naming of constants should be confirmed. The `MAX_EINTR_RETRIES = 100` constant is per security review.
+
+---
+
+### <a id="termisu-037"></a>TERMISU-037 — `Reader#close` does not close the fd; ownership model undocumented
+
+**Severity:** MEDIUM  •  **Status:** NEEDS-REPRO  •  **Component:** `[io]`
+**Files:** `src/termisu/reader.cr:240-244` (per quality review)
+
+#### Description
+
+Per quality review, `Reader#close` has a docstring: "Closes the reader (does not close the file descriptor)." This is a surprising lifecycle for a resource-holding class — callers who expect RAII-style fd ownership will leak. The fd is actually owned by `TTY` (which the facade owns), but that chain isn't explained at the Reader level.
+
+#### Impact
+
+- A test or direct user of `Reader` (bypassing the facade) that constructs a Reader + expects `close` to release the fd will leak.
+- Inconsistent with other `close`-having classes in the codebase.
+
+#### Proposed fix
+
+Either rename the method to reflect what it actually does, or expand the docstring:
+
+**Option A** (rename; small API surface change):
+```crystal
+# Resets the read buffer. Does not close the underlying fd —
+# fd ownership belongs to `TTY`, owned by `Terminal`.
+def reset_buffer : Nil
+  @buffer_pos = 0
+  @buffer_len = 0
+end
+```
+
+**Option B** (keep `close`, expand docstring):
+```crystal
+# Releases Reader state. **Does not close the file descriptor.**
+#
+# The fd is owned by `Termisu::TTY`, which in turn is owned by
+# `Termisu::Terminal`. Closing the fd at this layer would break
+# that ownership chain and leave `TTY` with a dangling fd.
+#
+# To fully release input resources, close the containing `Terminal`
+# (typically via `Termisu#close`).
+def close : Nil
+  # ...
+end
+```
+
+Prefer Option B — less churn, clearer intent. If `close` does no cleanup beyond resetting the buffer, consider deleting it and letting buffer state drop with the Reader instance.
+
+#### Verification notes
+
+Not re-verified. Read `reader.cr:240-244` before fixing.
+
+---
+
+### <a id="termisu-038"></a>TERMISU-038 — No runtime verification of `LibC::Winsize` struct size
+
+**Severity:** LOW  •  **Status:** NEEDS-REPRO  •  **Component:** `[io]`
+**Files:** `src/termisu/terminal/backend.cr:181-204` (per security review)
+
+#### Description
+
+Termisu defines a fallback `LibC::Winsize` struct when the stdlib doesn't provide one. There is no compile-time or runtime assertion that `sizeof(LibC::Winsize)` matches the kernel's expectation (8 bytes on every known platform). If Termisu is compiled on one kernel and run on a mismatched one (unlikely but possible in cross-compilation scenarios), `ioctl TIOCGWINSZ` could corrupt stack memory.
+
+Termios has a similar guard (per llms.txt §2.2, compile-time size check) but Winsize doesn't.
+
+#### Impact
+
+Very low in practice — Winsize layout has been stable across Linux/BSD/Darwin for decades. Flagged only for defense-in-depth parity with the existing Termios guard.
+
+#### Proposed fix
+
+Compile-time check mirroring the Termios pattern:
+
+```crystal
+{% if LibC::Winsize.size != 8 %}
+  {% raise "LibC::Winsize struct size mismatch: expected 8 bytes, got #{LibC::Winsize.size}. Termisu assumes standard POSIX layout." %}
+{% end %}
+```
+
+Place next to the existing size check in `termios.cr`, or duplicate at each point of use.
+
+#### Verification notes
+
+Not re-verified. Read `terminal/backend.cr:181-204` and the Termios size-check to confirm the existing pattern before adding the Winsize equivalent.
+
+---
+
+### <a id="termisu-039"></a>TERMISU-039 — `apply_attribute_change` drops attributes retained across a batch reset
+
+**Severity:** HIGH  •  **Status:** VERIFIED (differential-fuzz repro, 2026-07-20)  •  **Component:** `[rendering]`
+**Files:** `src/termisu/render_state.cr:77-107`
+
+#### Verified source
+
+```crystal
+# render_state.cr:77-90
+private def apply_attribute_change(renderer : Renderer, new_attr : Attribute)
+  reset_if_removing_attrs(renderer, new_attr)
+  apply_new_attributes(renderer, new_attr)
+  @attr = new_attr
+end
+
+private def reset_if_removing_attrs(renderer : Renderer, new_attr : Attribute)
+  if (@attr & ~new_attr) != Attribute::None
+    renderer.reset_attributes
+    @fg = nil # Reset clears colors too
+    @bg = nil
+  end
+end
+
+# render_state.cr:105-107
+private def needs_attr?(new_attr : Attribute, flag : Attribute) : Bool
+  new_attr.includes?(flag) && !@attr.includes?(flag)
+end
+```
+
+#### Description
+
+When a style transition removes any attribute, `reset_if_removing_attrs` emits `reset_attributes` — which clears **every** attribute on the terminal. `apply_new_attributes` then re-enables only flags absent from the *old* `@attr` (`needs_attr?` checks `!@attr.includes?(flag)`), so attributes present in both the old and new state are never re-emitted. Colors survive because the reset branch nils `@fg`/`@bg`, forcing re-emission; the retained attributes get no equivalent treatment.
+
+**Repro:** a batch transition `Bold|Underline → Bold` emits `reset_attributes` + colors but no `enable_bold`, leaving the cell visibly non-bold until its content next changes.
+
+Found via differential fuzzing (random buffer ops diffed against a naive full-repaint model; failing seeds 42, 1337, 999983, 7). Byte-identical failures reproduce with the pre-change `buffer.cr` + `cell.cr` from HEAD, confirming the bug predates the damage-range work and is confined to `render_state.cr`.
+
+#### Impact
+
+Any UI that batches styled cells where consecutive runs share some attributes while dropping others renders the shared attributes incorrectly (e.g., syntax highlighting where a bold-underlined token is followed by a bold token). The glitch persists until the affected cell's content changes.
+
+#### Proposed fix
+
+After emitting `reset_attributes`, treat the tracked attribute state as `None` *before* computing what to enable:
+
+```crystal
+private def apply_attribute_change(renderer : Renderer, new_attr : Attribute)
+  if (@attr & ~new_attr) != Attribute::None
+    renderer.reset_attributes
+    @fg = nil
+    @bg = nil
+    @attr = Attribute::None # terminal is attribute-free now; re-enable all of new_attr
+  end
+  apply_new_attributes(renderer, new_attr)
+  @attr = new_attr
+end
+```
+
+#### Related
+
+**TERMISU-004** — `RenderState#reset` sets `@attr = Attribute::None`, a concrete value (unlike the `nil` sentinels used for `fg`/`bg`), so an `attr: None` batch right after `sync`/`invalidate` cannot clear stale terminal attributes either. The two bugs share a fix surface; adopting TERMISU-004's `Attribute?` nil-sentinel option covers both.
+
+---
+
+## Cross-cutting patterns
+
+Three issues above recurrently surface the same structural theme and should be bundled for refactor:
+
+- **TERMISU-003** (double SGR state)
+- **TERMISU-007** (Renderer interface width)
+- **TERMISU-011** (batch/cell allocations)
+- **TERMISU-020** (apply_attribute_change efficiency)
+- **TERMISU-025** (Cell occupancy coupling)
+
+All five converge on the same code paths: Buffer → RenderState → Renderer → Terminal. The single high-leverage refactor is introduce a `Style` value type, narrow Renderer to 6 methods (`apply_style`, `write`, `move_cursor`, `set_cursor_visible`, `flush`, `size`, `close`), make RenderState the sole SGR optimizer (removing Terminal's cached setters), and switch Buffer storage to an explicit `Slot` enum (decoupling occupancy from Cell). This cluster represents roughly 2-3 weeks of focused work and resolves 5 tickets.
+
+Similar coupling exists between **TERMISU-008** (facade bloat) and **TERMISU-021** (ffi/core.cr bloat) — both should be refactored together because they mirror each other structurally.
+
+And the **backpressure** story (TERMISU-009 + TERMISU-023) wants a formal per-source policy contract, which also touches TERMISU-027 (Source template method).
+
+## Suggested fix order
+
+1. **Week 1 (correctness patches):** TERMISU-001, TERMISU-002, TERMISU-004, TERMISU-005, TERMISU-006, TERMISU-010. All small, high-value, no architectural risk.
+2. **Sprint 1 (rendering refactor bundle):** TERMISU-003 + TERMISU-007 + TERMISU-011 + TERMISU-020 + TERMISU-025. Introduce Style, narrow Renderer, unify cache.
+3. **Sprint 2 (facade decomposition):** TERMISU-008 + TERMISU-021. Extract Session.
+4. **Sprint 3 (backpressure formalism):** TERMISU-009 + TERMISU-023 + TERMISU-027.
+5. **Opportunistic:** Remaining MEDIUMs and LOWs as touched by other work.
+
+## Contributing to tickets
+
+When closing a ticket, leave a short resolution note at the bottom of the ticket with:
+- Commit SHA or PR link
+- Any scope changes from the original fix
+- Whether the fix requires a benchmark baseline to verify
+
+Ticket IDs are permanent — renumber to `TERMISU-036+` for new additions rather than reusing closed IDs.

--- a/KNOWN_ISSUES_REVIEW.md
+++ b/KNOWN_ISSUES_REVIEW.md
@@ -1,0 +1,177 @@
+# KNOWN_ISSUES.md — Adversarial Review
+
+**Review date:** 2026-04-23
+**Method:** Four parallel critic agents, each scoped to a subsystem, each required to read actual source and push back. This document synthesizes their verdicts and proposes corrections to `KNOWN_ISSUES.md`.
+
+**Headline finding:** 6 of 38 tickets are **rejected** (the claim doesn't hold against the actual code), 9 tickets have **severity overstatements** and should be downgraded, 4 are **partial** (bug real but fix/framing needs refinement), and the remaining 19 stand as written. The original four-way analysis was aggressive and several tickets treated "scout said so" as "verified" without reading the code.
+
+---
+
+## Verdict distribution
+
+| Verdict | Count | Tickets |
+|---|---|---|
+| ❌ **REJECTED** | 6 | TERMISU-012, -016, -018, -026, -029, -036 |
+| 🔽 **SEVERITY DOWNGRADE** | 7 | TERMISU-001, -006, -010, -013, -021, -023, -027 |
+| 🟡 **PARTIAL — needs refinement** | 4 | TERMISU-004, -009, -022, -038 |
+| ✅ **VALIDATED** | 20 | TERMISU-002, -003, -005, -007, -008, -011, -014, -015, -017, -019, -020, -024, -025, -028, -030, -031, -032, -033, -035, -037 |
+| ⚠️ **INCOMPLETE** | 1 | TERMISU-034 (needs file reads to verify) |
+
+Original severity profile: 2 CRITICAL, 9 HIGH, 18 MEDIUM, 9 LOW. **Corrected** profile after this review: 1 CRITICAL, 7 HIGH, 13 MEDIUM, 11 LOW — a quarter of the report was over-rated.
+
+---
+
+## ❌ Rejected tickets (false positives, should be closed / deleted)
+
+### TERMISU-012 — Registry handle generation counter
+**Why rejected:** UInt64 wrap takes 2^64 ops ≈ 584 billion years at 1 M creates/sec. The ticket itself admits "practical exploit is extremely difficult" and is fixing a theoretical problem. The proposed `{gen, id}` encoding doubles lookup complexity for zero real-world benefit. Handles are *never reused* in the current design — deleted handles are gone forever, and `fetch(handle)` returns `nil` for stale handles, which is exactly the right behavior.
+**Action:** Close. Leave current registry alone.
+
+### TERMISU-016 — `set_cursor(visible: Bool? = true, …)` precedence
+**Why rejected:** The critic read `termisu.cr:165-176` and confirmed the precedence is correct — Crystal's ternary has lower precedence than method calls, so `visible ? show_cursor : hide_cursor unless visible.nil?` parses as `(visible ? show_cursor : hide_cursor) unless visible.nil?`. The default `true` is intentional ("set_cursor shows the cursor") — the original ticket misread Crystal precedence and invented a bug. Users who want position-only can call `@terminal.move_cursor` directly.
+**Action:** Close. The API is fine as-is.
+
+### TERMISU-018 — `SHUTDOWN_TIMEOUT_MS / 10` "name lies"
+**Why rejected:** `SHUTDOWN_TIMEOUT_MS = 100` is the *constant*, not the usage. The code `sleep SHUTDOWN_TIMEOUT_MS.milliseconds / 10` yields 10 ms deliberately — comments at lines 153-154 document it as "brief yield to let fibers exit gracefully." The `/10` is self-documenting ("10% of shutdown timeout"). The original ticket flagged this as confusing, but it's actually *less* confusing than a magic `10` constant would be.
+**Action:** Close. Add a brief inline comment if desired, but no rename.
+
+### TERMISU-026 — `Reader` 128-byte buffer is undersized
+**Why rejected:** The critic confirmed `reader.cr:40`: `def initialize(@fd : Int32, buffer_size : Int32 = 128)`. Line 39 docstring explicitly documents "default: 128 bytes." The buffer size is 128, documented as 128, intentional, and sufficient (typing at 1 KB/sec refills this 8× per second — well within `poll` + `read` capability). The original ticket cited a conflict between llms.txt (which said 4096) and the scout review (which said 128); the conflict exists because **llms.txt was wrong**. No code change needed.
+**Action:** Close. Fix llms.txt to say 128.
+
+### TERMISU-029 — FFI always compiled, no opt-out
+**Why rejected:** Crystal with `--release` performs dead-code elimination. Unreferenced FFI `fun` exports aren't included in the final binary unless something calls them (for executables) or unless building `--link-flags` for a `.so` (in which case they're needed by definition). The original ticket's binary-size concern is based on a false premise. Adding a compile-time flag gate would only complicate the build without shrinking anything in practice.
+**Action:** Close. Current build behavior is correct.
+
+### TERMISU-036 — Reader EINTR retry storm
+**Why rejected:** The critic read `reader.cr` and found `MAX_EINTR_RETRIES = 100` is a **per-call** counter — `fill_buffer` (line 251-298), `check_fd_readable_poll` (line 130-177), and `check_fd_readable_select` (line 179-232) each initialize `retries = 0` at entry. To exhaust the counter you'd need **100 consecutive EINTRs within a single syscall**, which requires an extremely tight `kill -9 -1` loop that would kill the Termisu process long before input drops. Real-world signal storms interleave syscall success with interruption, and the per-call reset handles that cleanly. "Malicious ptrace abuse" is a far-fetched threat model for a terminal library.
+**Action:** Close. Current EINTR handling is robust.
+
+---
+
+## 🔽 Severity downgrades (ticket is real but was over-rated)
+
+### TERMISU-001 CRITICAL → **HIGH**
+Original framing claimed EBADF / double-close could happen. The critic read `Terminal#close`, `Backend#close`, `TTY#close` and found them all idempotent (every `disable_*` and `close` checks a state flag before acting). Worst case of the CAS rollback is redundant work, not resource corruption. **Bug is real and the fix is correct** — track a separate `@close_failed` flag — but the severity doesn't warrant "fix before next release." Treat as a normal HIGH.
+
+### TERMISU-006 HIGH → **MEDIUM** (and sub-items split)
+Three separate rescue sites were bundled under one HIGH. After verification:
+- **`log.cr:175-177` empty rescue:** still valid. STDERR write during setup is safe because logging is configured in `Termisu.new` *before* `enter_alternate_screen` grabs the screen. Severity: **MEDIUM**.
+- **`log.cr:190, 192` `rescue nil` on close:** lazy but only fires on shutdown. **LOW**.
+- **`input/parser.cr:337-341` `codepoint_to_key` bare rescue:** `Key.from_char` contains only a hash lookup and case statement — it **cannot raise** anything. The rescue is **dead code**. Severity: **LOW** (remove the rescue, don't fix it).
+Overall ticket: downgrade to MEDIUM, split sub-items into separate follow-ups with their own severities.
+
+### TERMISU-010 HIGH → **MEDIUM**
+"DoS via exception spam" framing is overstated. Crystal exceptions aren't Java exceptions — no stack capture by default, catch cost is a function-call plus allocation. A malicious C caller can't easily DoS through invalid codepoints when the same process has a 32-cap channel and 100-EINTR cap bounding everything else. The proposed fast-fail validation is still a good defense-in-depth hygiene fix, just not HIGH-priority. Also: `Char#chr` already validates surrogates internally — the ticket's proposed surrogate range check duplicates logic and is unnecessary on top of the range check for `> 0x10FFFF`.
+
+### TERMISU-013 MEDIUM → **LOW**
+`parser.cr:22` declares `MAX_SEQUENCE_LENGTH = 32`. Line 221's check terminates any runaway CSI at 32 bytes. The "unterminated CSI spam" attack requires a producer with TTY-write access who can't just spam normal input instead. Not a real threat model for a terminal library. Defense-in-depth at best. Keep as LOW rather than MEDIUM.
+
+### TERMISU-021 MEDIUM → **LOW**
+`ffi/core.cr` is 219 lines, not 500+. "Grab-bag" framing was misleading. The real bloat is in the facade (TERMISU-008); the FFI wrapper file is fine as one unit. Split only if it grows substantially past 400 lines. Downgrade.
+
+### TERMISU-023 MEDIUM → **LOW**
+"Scattered backpressure policy" is intentional differentiated semantics: `Source::Input` uses blocking `send` because every keystroke matters, `Source::Timer`/`SystemTimer` use non-blocking with `missed_ticks` because tick drops are fungible. Forcing every source to pick from a `DeliveryPolicy` enum is more ceremony for zero existing extensibility consumers (the `NetworkSource` in examples is a demo). Keep the current per-source policy; document the rationale.
+
+### TERMISU-027 MEDIUM → **LOW**
+`Event::Source` is technically an extension point but has zero third-party consumers and only three in-tree implementations (all of which get the invariants right). The proposed template-method refactor is elegant but over-engineered for the current reality. Documentation on the abstract class is already extensive (lines 6-50 of `event/source.cr`) and sufficient. Revisit if custom sources appear in the wild.
+
+---
+
+## 🟡 Partial — claim holds, fix or framing needs refinement
+
+### TERMISU-004 — RenderState reset / attribute drift
+**Refinement:** The original ticket's reasoning was slightly off. When `@attr == None` and `apply_style(attr: None, …)` is called, there's genuinely nothing to emit — `reset_attributes` being skipped is *correct* if RenderState's belief matches reality. The real failure mode is narrower: **after `reset`, RenderState's `@attr = None` is an assertion about the terminal's state that may not be true** (e.g., post-`suspend { system("vim") }` where vim leaves attrs set). If the first `apply_style` after reset uses `attr: None`, the mismatch silently persists until something else triggers `reset_attributes`.
+
+The proposed `nil` sentinel fix ("force reset_attributes on first apply after reset") is still correct, but the ticket description should be rewritten: the bug is "RenderState treats `reset` as state knowledge when it should treat it as state *un*knowledge," not "reset fails to emit sequences." Same fix, clearer framing.
+
+### TERMISU-009 — Input source blocking send
+**Refinement:** The "keystroke loss without signal" framing is imprecise. What actually happens:
+1. Input fiber blocks on `output.send(event)` when channel is full.
+2. Reader's internal buffer stops draining (parser can't pull).
+3. Kernel TTY buffer fills (typically 4 KB).
+4. Only *then* does the kernel drop bytes — and sustained input at >4 KB of backlog is rare outside paste attacks.
+
+So the real issue is **unbounded latency** that can *eventually* cascade into kernel-level drops, not immediate keystroke loss. Fix direction (add drop detection + log warning + raise channel cap to 256) is still correct, but the bug description should reflect the actual mechanism. "Your UI can pause for seconds under load, and after ~4 KB of accumulated input the kernel starts dropping" is the honest statement.
+
+### TERMISU-022 — Color ABI asymmetry (breaking change)
+**Refinement:** The proposed fix — adding `Mode::Default` to the Crystal enum and dropping `DEFAULT_INDEX = -1` — is a **breaking change** to the public API. Existing user code that checks `Color.default.mode == Mode::ANSI8` (or serializes colors using the current enum values) will silently change behavior. The ticket as written doesn't call this out. Before landing:
+1. Document the breakage in CHANGELOG with migration guidance.
+2. Provide `Color::Mode::ANSI8_DEFAULT` as a temporary alias (deprecated) if backward compat matters.
+3. Audit `spec/` for any test that assumes the current `Mode` enum values.
+
+Keep the ticket open and MEDIUM, but add the breaking-change caveat.
+
+### TERMISU-038 — Winsize runtime size check
+**Refinement:** The ticket proposes mirroring "the termios size check" — but the critic couldn't find a Termios size check in the current `termios.cr`. The premise (that termios has such a check) may itself be an llms.txt hallucination. Before adding a Winsize check:
+1. Read `termios.cr` end-to-end to confirm whether a size check exists.
+2. If one exists, mirror the pattern.
+3. If not, either add both (termios + Winsize) or drop the ticket as un-justified parity.
+
+Downgrade status to **NEEDS-VERIFICATION** until the termios premise is confirmed.
+
+---
+
+## ✅ Tickets that stand as written
+
+These 20 were confirmed by direct source reads and the fixes/paradigms hold up:
+
+**CRITICAL:** TERMISU-002 (Char set_cell allocations)
+**HIGH:** TERMISU-003 (double SGR cache), -005 (set_cell param names), -007 (Renderer width — exactly 18 methods confirmed), -008 (facade 797 lines confirmed), -011 (batch_buffer.to_s)
+**MEDIUM:** TERMISU-014 (terminfo string scan — confirmed no bounds check in read loop), -015 (Color.ansi8(-1) validator accepts -1), -017 (terminal.cr ~697 lines), -019 (CSI split — though only 2 of 3 claimed sites confirmed, not 3), -020 (needs_attr? 2×8 checks), -024 (NUL sentinel — `Cell.new(" ", …)` confirmed at line 204), -025 (Cell/continuation fusion), -028 (Terminfo caches exactly 12 capabilities, confirmed), -037 (Reader.close — though the docstring DOES already document the behavior; this is nitpick-level)
+**LOW:** TERMISU-030 (platform constants — though "normal Crystal FFI pattern" is a fair characterization), -031 (tsl/fsl hardcoded — confirmed), -032 (title= setter), -033 (Italic/Cursive alias — confirmed documented at line 33), -035 (TERM path traversal — confirmed; `File.join("base", ".", "../etc/passwd")` does normalize unsafely, so the defense-in-depth validation is warranted even though exploitation requires attacker-controlled filesystem)
+
+---
+
+## ⚠️ Incomplete (needs file reads before verdict)
+
+### TERMISU-034 — `ameba:disable Naming/AccessorMethodName`
+The critic was unable to verify the three claimed suppression sites (`terminal.cr:315-316`, `terminal/backend.cr:135-136`, `termios.cr:79-80`) within its scope. Before acting on this ticket, read those three file regions directly and confirm the suppressions exist. If not, close as false positive.
+
+---
+
+## Patterns observed across the reviews
+
+1. **"Scout said so" ≠ "verified."** Several tickets cited llms.txt or scout reports as authoritative without the author reading the code. Line numbers were sometimes off, and `TERMISU-018`/`TERMISU-026`/`TERMISU-036` are outright wrong. **Rule for future analysis: no claim in KNOWN_ISSUES.md without a `VERIFIED` status backed by a direct file read.**
+
+2. **Pattern-matching "scattered X must be bad" skipped the "is it intentional?" question.** `TERMISU-023` (backpressure) and partly `TERMISU-007` (Renderer width) treated design choices as debt without asking whether the scattering served a purpose. Differentiated policy can be the right call.
+
+3. **Severity inflation.** Six of nine HIGH tickets were demoted after review (TERMISU-001, -006, -010 plus rejections of -013, -023, -027's mediums). The original analysis optimized for finding issues, not for calibrating their urgency.
+
+4. **Theoretical security threats were over-weighted.** TERMISU-012 (handle wrap) and -036 (EINTR storm) are textbook examples of "security concerns that don't apply in the threat model." Both should have been LOW or dropped.
+
+5. **The CRITICAL/HIGH separation is doing real work.** Only one genuinely CRITICAL issue survived review (TERMISU-002, Char allocation). TERMISU-001 reduced to HIGH; everything else that was CRITICAL-adjacent was either unsupported or less severe.
+
+---
+
+## Proposed updates to `KNOWN_ISSUES.md`
+
+When applying these findings:
+
+1. **Close 6 tickets:** TERMISU-012, -016, -018, -026, -029, -036. Mark status `CLOSED — INVALID` with a one-line reason linking back to this review.
+2. **Reduce severities:** TERMISU-001 → HIGH, TERMISU-006 → MEDIUM (split), TERMISU-010 → MEDIUM, TERMISU-013 → LOW, TERMISU-021 → LOW, TERMISU-023 → LOW, TERMISU-027 → LOW.
+3. **Rewrite descriptions of partial tickets:** TERMISU-004 (framing), TERMISU-009 (mechanism), TERMISU-022 (breaking-change caveat), TERMISU-038 (verify termios premise first).
+4. **Update the rollup table** at the top of KNOWN_ISSUES.md: new severity distribution is 1 CRITICAL / 7 HIGH / 13 MEDIUM / 11 LOW / 6 CLOSED = 38.
+5. **Verify TERMISU-034** by reading the three cited files; either mark VERIFIED or close as unverified.
+6. **Fix llms.txt** to reflect the 128-byte Reader buffer, not 4096.
+
+---
+
+## Suggested revised fix order after this review
+
+**Week 1 — correctness patches that survived review:**
+TERMISU-002 (CRITICAL, confirmed), TERMISU-001 (HIGH, confirmed), TERMISU-004 (HIGH, with rewritten framing), TERMISU-005 (HIGH, confirmed), TERMISU-006 split into MEDIUM + LOW. Closed false positives: -012, -016, -018, -026, -029, -036.
+
+**Sprint 1 — rendering refactor bundle (unchanged from original report):**
+TERMISU-003 + -007 + -011 + -020 + -025.
+
+**Sprint 2 — facade decomposition:**
+TERMISU-008 (with TERMISU-021 downgraded to LOW; don't bother splitting ffi/core.cr).
+
+**Sprint 3 — dropped.** The backpressure/Source-invariant refactor (TERMISU-009 + -023 + -027) is now all LOW or "partial/refined" — not worth a dedicated sprint. Land the TERMISU-009 diagnostic improvement (drop-counter logging + cap bump to 256) as a single-commit fix.
+
+**Opportunistic:** Remaining MEDIUMs and LOWs when touched by other work.
+
+---
+
+End of review. 6 tickets dropped, 7 downgraded, 4 refined, 20 validated, 1 pending — net cleanup of ~30% of the original report's claims. The remaining tickets are high-confidence and ready to act on.

--- a/PROJECT_INDEX.json
+++ b/PROJECT_INDEX.json
@@ -1,0 +1,258 @@
+{
+  "name": "termisu",
+  "version": "0.3.0",
+  "language": "Crystal",
+  "language_version": ">= 1.18.2",
+  "description": "Terminal UI library with cell-based rendering and double buffering",
+  "created": "2025-01-25",
+  "structure": {
+    "src": {
+      "path": "src/termisu",
+      "files": 45,
+      "main": "src/termisu.cr",
+      "modules": {
+        "core": [
+          "termisu.cr",
+          "buffer.cr",
+          "terminal.cr",
+          "cell.cr",
+          "color.cr",
+          "attribute.cr",
+          "cursor.cr",
+          "render_state.cr"
+        ],
+        "event": [
+          "event.cr",
+          "event/loop.cr",
+          "event/key.cr",
+          "event/mouse.cr",
+          "event/resize.cr",
+          "event/tick.cr",
+          "event/mode_change.cr",
+          "event/source.cr",
+          "event/source/input.cr",
+          "event/source/resize.cr",
+          "event/source/timer.cr",
+          "event/source/system_timer.cr",
+          "event/poller.cr",
+          "event/poller/linux.cr",
+          "event/poller/kqueue.cr",
+          "event/poller/poll.cr"
+        ],
+        "input": [
+          "input.cr",
+          "input/key.cr",
+          "input/modifier.cr",
+          "input/parser.cr"
+        ],
+        "terminal": [
+          "terminal/backend.cr",
+          "terminal/mode.cr"
+        ],
+        "terminfo": [
+          "terminfo.cr",
+          "terminfo/database.cr",
+          "terminfo/parser.cr",
+          "terminfo/capabilities.cr",
+          "terminfo/builtin.cr",
+          "terminfo/tparm.cr"
+        ],
+        "other": [
+          "reader.cr",
+          "tty.cr",
+          "termios.cr",
+          "error.cr",
+          "log.cr",
+          "version.cr",
+          "renderer.cr"
+        ]
+      }
+    },
+    "spec": {
+      "path": "spec/termisu",
+      "files": 50,
+      "support": [
+        "spec_helper.cr",
+        "support/mock_renderers.cr",
+        "support/pipe_helpers.cr",
+        "support/mock_sources.cr",
+        "support/capture_terminal.cr",
+        "support/capture_renderer.cr"
+      ]
+    },
+    "examples": {
+      "path": "examples",
+      "files": 7,
+      "list": [
+        "simple.cr",
+        "demo.cr",
+        "showcase.cr",
+        "colors.cr",
+        "keyboard_and_mouse.cr",
+        "animation.cr",
+        "modes.cr"
+      ]
+    },
+    "bench": {
+      "path": "bench",
+      "files": 5
+    },
+    "docs": {
+      "path": "docs",
+      "key_files": [
+        "ARCHITECTURE.md",
+        "API.md",
+        "DEVELOPMENT.md",
+        "E2E_TESTING_PLAN.md"
+      ]
+    },
+    "e2e": {
+      "path": "e2e",
+      "language": "TypeScript",
+      "framework": "Jest"
+    }
+  },
+  "entry_points": {
+    "main": "src/termisu.cr",
+    "cli": "bin/hace",
+    "tests": "spec/spec_helper.cr"
+  },
+  "core_types": {
+    "Termisu": "Main facade class",
+    "Terminal": "High-level terminal interface",
+    "Buffer": "Double-buffered cell grid",
+    "Cell": "Single terminal cell (char + fg + bg + attr)",
+    "Color": "Color types (ANSI-8, 256, RGB)",
+    "Attribute": "Text attributes (bold, underline, etc.)",
+    "Cursor": "Cursor state management",
+    "RenderState": "Batched rendering optimization",
+    "Reader": "Buffered non-blocking input",
+    "Event::Loop": "Async event multiplexer",
+    "Event::Any": "Union type (Key | Mouse | Resize | Tick | ModeChange)",
+    "Event::Source": "Abstract event source class",
+    "Input::Parser": "Escape sequence parser",
+    "Input::Key": "Key enum (170+ keys)",
+    "Input::Modifier": "Modifier flags (Ctrl/Alt/Shift/Meta)",
+    "Terminal::Mode": "Terminal mode flags",
+    "Terminfo": "Terminfo capability access",
+    "Termios": "Raw mode configuration"
+  },
+  "build_system": {
+    "tool": "hace",
+    "config": "Hacefile.yml",
+    "commands": {
+      "spec": "Run tests with unbuffer",
+      "format": "Format code with crystal tool format",
+      "ameba": "Run Ameba linter",
+      "all": "Format, lint, and test in parallel",
+      "demo": "Run main demo example",
+      "showcase": "Run showcase example",
+      "animation": "Run animation example",
+      "kmd": "Run keyboard and mouse demo",
+      "colors": "Run colors example",
+      "bench": "Run benchmarks in release mode",
+      "bench-quick": "Run benchmarks in dev mode",
+      "perf": "Profile with Linux perf",
+      "callgrind": "Profile with Valgrind Callgrind",
+      "memcheck": "Check for memory leaks",
+      "e2e:test": "Run end-to-end tests",
+      "e2e:build": "Build E2E test binaries"
+    }
+  },
+  "dependencies": {
+    "runtime": [],
+    "development": [
+      {
+        "name": "ameba",
+        "purpose": "Linting"
+      },
+      {
+        "name": "hace",
+        "purpose": "Task runner"
+      }
+    ]
+  },
+  "configuration": {
+    "shard.yml": "Crystal package configuration",
+    "Hacefile.yml": "Development tasks",
+    ".ameba.yml": "Linting rules",
+    "lefthook.yml": "Git hooks"
+  },
+  "features": {
+    "complete": [
+      "Terminal I/O",
+      "Terminfo",
+      "Double Buffering",
+      "Colors (ANSI-8, 256, RGB)",
+      "Attributes",
+      "Keyboard Input (170+ keys)",
+      "Mouse Input (SGR protocol)",
+      "Event System",
+      "Async Event Loop",
+      "Resize Events",
+      "Timer/Tick Events",
+      "Terminal Modes",
+      "Synchronized Updates"
+    ],
+    "planned": [
+      "Unicode/Wide Characters",
+      "Image Protocols (Sixel, Kitty)"
+    ]
+  },
+  "logging": {
+    "env_vars": {
+      "TERMISU_LOG_LEVEL": "trace/debug/info/warn/error/fatal/none (default: debug)",
+      "TERMISU_LOG_FILE": "Path to log file (default: /tmp/termisu.log)",
+      "TERMISU_LOG_SYNC": "Dispatch mode - true for sync, false for async (default: false)"
+    },
+    "log_sources": [
+      "Log",
+      "Logs::Terminal",
+      "Logs::Buffer",
+      "Logs::Reader",
+      "Logs::Render",
+      "Logs::Input",
+      "Logs::Color",
+      "Logs::Terminfo"
+    ]
+  },
+  "api_categories": {
+    "rendering": ["set_cell", "clear", "render", "sync", "set_cursor", "hide_cursor", "show_cursor"],
+    "events": ["poll_event", "try_poll_event", "wait_event", "each_event"],
+    "timer": ["enable_timer", "enable_system_timer", "disable_timer", "timer_enabled?", "timer_interval"],
+    "modes": ["suspend", "with_cooked_mode", "with_cbreak_mode", "with_password_mode", "with_mode"],
+    "mouse": ["enable_mouse", "disable_mouse", "mouse_enabled?"],
+    "keyboard": ["enable_enhanced_keyboard", "disable_enhanced_keyboard", "enhanced_keyboard?"],
+    "terminal": ["size", "alternate_screen?", "raw_mode?", "current_mode", "sync_updates?"]
+  },
+  "testing": {
+    "framework": "crystal spec",
+    "structure": "mirrors src/",
+    "support_mocks": [
+      "mock_renderers.cr",
+      "pipe_helpers.cr",
+      "mock_sources.cr",
+      "capture_terminal.cr",
+      "capture_renderer.cr"
+    ]
+  },
+  "documentation": {
+    "api": "docs/API.md",
+    "architecture": "docs/ARCHITECTURE.md",
+    "development": "docs/DEVELOPMENT.md",
+    "e2e_plan": "docs/E2E_TESTING_PLAN.md",
+    "design_docs": [
+      "docs/design/async-event-system.md",
+      "docs/design/cooked-mode-plan.md",
+      "docs/design/dec-plan.md",
+      "docs/plans/system-timer-refactor.md"
+    ],
+    "articles": [
+      "docs/articles/kernel-timers-for-smooth-animations.md"
+    ]
+  },
+  "inspiration": [
+    "nsf/termbox (C)",
+    "nsf/termbox-go (Go)"
+  ]
+}

--- a/PROJECT_INDEX.md
+++ b/PROJECT_INDEX.md
@@ -1,0 +1,289 @@
+# Project Index: Termisu
+
+**Generated:** 2026-04-22
+**Version:** 0.4.5
+**Language:** Crystal (>= 1.17.0)
+
+## Overview
+
+Termisu is a terminal UI library providing cell-based rendering with double buffering and zero runtime dependencies. Inspired by termbox, it offers a minimal API for writing TUI applications in pure Crystal, plus a C ABI layer for embedding Termisu in non-Crystal hosts.
+
+## Project Structure
+
+```
+src/                              # Core library (71 Crystal files)
+├── termisu.cr                    # Top-level require graph
+└── termisu/
+    ├── termisu.cr                # Main facade & public API
+    ├── version.cr                # VERSION parsed from shard.yml at compile time
+    ├── terminal.cr               # High-level terminal interface
+    ├── buffer.cr                 # Double-buffered cell grid
+    ├── cell.cr                   # Cell (char + fg + bg + attr)
+    ├── color.cr                  # Color types and modes
+    ├── color/
+    │   ├── conversions.cr        # Color space conversion (RGB/HSL/ANSI)
+    │   ├── palette.cr            # ANSI palette definitions
+    │   ├── validator.cr          # Color value validation
+    │   └── formatters.cr         # Color-to-string formatting
+    ├── attribute.cr              # Text attributes (bold, underline, etc.)
+    ├── render_state.cr           # Batched rendering optimization
+    ├── renderer.cr               # Abstract renderer interface
+    ├── reader.cr                 # Buffered non-blocking input
+    ├── unicode_width.cr          # East Asian wide / grapheme width
+    ├── time_compat.cr            # Time API compat shim
+    ├── error.cr                  # Error types
+    ├── log.cr                    # Structured logging
+    ├── event.cr                  # Event module & Event::Any union
+    ├── event/
+    │   ├── loop.cr               # Event multiplexer
+    │   ├── key.cr                # Keyboard events
+    │   ├── mouse.cr              # Mouse events
+    │   ├── resize.cr             # Terminal resize events
+    │   ├── tick.cr               # Timer tick events
+    │   ├── mode_change.cr        # Mode change events
+    │   ├── source.cr             # Abstract event source
+    │   ├── source/
+    │   │   ├── input.cr          # Keyboard/mouse source
+    │   │   ├── resize.cr         # SIGWINCH source
+    │   │   ├── timer.cr          # Sleep-based timer
+    │   │   └── system_timer.cr   # Kernel timerfd/kqueue timer
+    │   ├── poller.cr             # Poller interface
+    │   └── poller/
+    │       ├── linux.cr          # epoll
+    │       ├── kqueue.cr         # kqueue (macOS/BSD)
+    │       └── poll.cr           # poll(2) fallback
+    ├── input.cr                  # Input module entry
+    ├── input/
+    │   ├── key.cr                # Key enum (170+ keys)
+    │   ├── modifier.cr           # Ctrl/Alt/Shift/Meta flags
+    │   └── parser.cr             # Escape sequence parser
+    ├── terminal/
+    │   ├── backend.cr            # Low-level I/O (TTY + Termios)
+    │   ├── cursor.cr             # Cursor state management
+    │   └── mode.cr               # Terminal mode flags
+    ├── terminfo.cr               # Terminfo module entry
+    ├── terminfo/
+    │   ├── database.cr           # Terminfo file locator
+    │   ├── parser.cr             # Binary format parser (16/32-bit magic)
+    │   ├── capabilities.cr       # Capability name mappings (414 caps)
+    │   ├── builtin.cr            # Fallback sequences (xterm/linux)
+    │   ├── tparm.cr              # Tparm entry
+    │   └── tparm/                # Parametrized string processor
+    ├── tty.cr                    # /dev/tty file descriptor management
+    ├── termios.cr                # Raw mode terminal configuration
+    ├── system/
+    │   └── poll.cr               # poll(2) syscall wrapper
+    ├── lib_c/
+    │   └── kqueue.cr             # kqueue LibC bindings
+    ├── ffi.cr                    # C ABI module entry
+    └── ffi/                      # Embeddable C FFI layer
+        ├── abi.cr                # ABI version & type aliases
+        ├── core.cr               # Core FFI surface
+        ├── runtime.cr            # Runtime lifecycle
+        ├── context.cr            # Opaque context handles
+        ├── registry.cr           # Handle registry
+        ├── exports.cr            # @[Extern] function exports
+        ├── layout.cr             # Layout/geometry types
+        ├── event_type.cr         # Event type codes
+        ├── color_mode.cr         # Color mode codes
+        ├── conversions.cr        # Crystal <-> C conversions
+        ├── error_state.cr        # Thread-local error state
+        ├── guards.cr             # Safety guards
+        ├── status.cr             # Status/result codes
+        └── version.cr            # FFI ABI version
+
+spec/termisu/                     # Test suite (54 Crystal spec files)
+├── input/ event/ terminal/ terminfo/ ffi/  # Mirrors src/ structure
+spec/support/                     # Mock renderers, pipe helpers, mock sources
+spec/shared/                      # Shared spec examples
+
+examples/                         # Demo programs
+├── demo.cr                       # Main demo
+├── showcase.cr                   # Feature showcase
+├── animation.cr                  # Timer-driven animation
+├── colors.cr                     # Color palette
+├── keyboard_and_mouse.cr         # Input demo
+├── simple.cr                     # Minimal example
+└── c/basic.c                     # C FFI consumer example
+
+bench/                            # Performance benchmarks
+├── bench_runner.cr
+├── run.cr
+└── suites/                       # buffer / parser / color suites
+
+docs/                             # Architecture & API docs
+docs-web/                         # Web documentation site
+e2e/                              # End-to-end tests (TypeScript)
+javascript/                       # JS bindings / platform glue
+```
+
+## Entry Points
+
+| Entry Point | Path | Purpose |
+|-------------|------|---------|
+| Crystal API | `src/termisu.cr` | Public `Termisu` class facade |
+| C ABI | `src/termisu/ffi/exports.cr` | Embeddable C function exports |
+| CLI | `bin/hace` | Development task runner |
+| Specs | `spec/spec_helper.cr` | Test configuration |
+| Examples | `examples/*.cr`, `examples/c/basic.c` | Demo programs |
+
+## Core Modules
+
+### Termisu (Facade)
+- **Path:** `src/termisu/termisu.cr`
+- **Exports:** `Termisu` class
+- **Purpose:** Main public API coordinating all components
+
+### Terminal
+- **Path:** `src/termisu/terminal.cr`
+- **Exports:** `Terminal` class
+- **Purpose:** High-level terminal interface with I/O, rendering, and mode management
+
+### Buffer
+- **Path:** `src/termisu/buffer.cr`
+- **Exports:** `Buffer` class
+- **Purpose:** Double-buffered cell grid with diff-based rendering
+
+### Event Loop
+- **Path:** `src/termisu/event/loop.cr`
+- **Exports:** `Event::Loop` class
+- **Purpose:** Async multiplexer for input/resize/timer events. Pollers under `event/poller/` select `epoll`, `kqueue`, or `poll(2)` per platform.
+
+### Terminfo
+- **Path:** `src/termisu/terminfo/`
+- **Exports:** `Terminfo` module, `Database`, `Parser`, `Tparm`
+- **Purpose:** Terminal capability database (414 capabilities) with full parametrized string processor
+
+### FFI / C ABI
+- **Path:** `src/termisu/ffi/`
+- **Exports:** C-callable functions via `exports.cr`
+- **Purpose:** Embed Termisu in C/other languages with opaque context handles, versioned ABI, and thread-local error state
+
+### Unicode Width
+- **Path:** `src/termisu/unicode_width.cr`
+- **Purpose:** East Asian Wide, ambiguous, and zero-width character handling for correct grid layout
+
+## Key APIs
+
+### Rendering
+```crystal
+termisu.set_cell(x, y, 'A', fg: Color.red, bg: Color.black, attr: Attribute::Bold)
+termisu.clear
+termisu.render  # Diff-based
+termisu.sync    # Full redraw
+```
+
+### Events
+```crystal
+event = termisu.poll_event(100.milliseconds)
+case event
+when Termisu::Event::Key        # Keyboard
+when Termisu::Event::Mouse      # Mouse click/move/wheel
+when Termisu::Event::Resize     # Terminal resize (SIGWINCH)
+when Termisu::Event::Tick       # Timer tick
+when Termisu::Event::ModeChange # Terminal mode switched
+end
+```
+
+### Timer
+```crystal
+termisu.enable_timer(16.milliseconds)        # Sleep-based (portable)
+termisu.enable_system_timer(16.milliseconds) # Kernel timerfd / kqueue EVFILT_TIMER
+```
+
+### Terminal Modes
+```crystal
+termisu.suspend { system("vim file.txt") }   # Shell-out (cooked mode)
+termisu.with_password_mode { gets }          # No-echo line input
+termisu.with_cbreak_mode { STDIN.read_char } # Char-by-char with echo
+```
+
+### C ABI (example)
+```c
+// See examples/c/basic.c
+termisu_context_t ctx = termisu_new();
+termisu_set_cell(ctx, 0, 0, 'H', TERMISU_COLOR_GREEN, TERMISU_COLOR_DEFAULT, 0);
+termisu_render(ctx);
+termisu_close(ctx);
+```
+
+## Build Commands (via `bin/hace`)
+
+| Command | Purpose |
+|---------|---------|
+| `bin/hace spec` | Run tests |
+| `bin/hace format` | Format code |
+| `bin/hace ameba` | Run linter |
+| `bin/hace all` | Format + lint + test (parallel) |
+| `bin/hace demo` | Run main demo |
+| `bin/hace showcase` | Feature showcase |
+| `bin/hace animation` | Timer/animation demo |
+| `bin/hace bench` | Release-mode benchmarks |
+| `bin/hace bench-quick` | Dev-mode benchmarks |
+| `bin/hace perf` | CPU profiling with perf (Linux) |
+| `bin/hace callgrind` | Call graph profiling |
+| `bin/hace memcheck` | Memory leak detection |
+
+## Configuration
+
+| File | Purpose |
+|------|---------|
+| `shard.yml` | Crystal dependencies and version |
+| `Hacefile.yml` | Development task definitions |
+| `.ameba.yml` | Linting rules |
+| `lefthook.yml` | Git hooks (format, lint, test) |
+| `mise.toml` | Toolchain pins |
+| `biome.json`, `package.json` | JS / e2e tooling |
+
+## Key Dependencies
+
+- **Crystal:** >= 1.17.0 (language)
+- **ameba:** Development linter (dev-only)
+- **hace:** Task runner (dev-only)
+- Runtime: **none** (zero runtime dependencies)
+
+## Development Status
+
+| Component | Status |
+|-----------|--------|
+| Terminal I/O | Complete |
+| Terminfo | Complete |
+| Double Buffering | Complete |
+| Colors (16 / 256 / truecolor) | Complete |
+| Attributes | Complete |
+| Keyboard Input | Complete |
+| Mouse Input | Complete |
+| Event System | Complete |
+| Async Event Loop | Complete |
+| Platform Pollers (epoll/kqueue/poll) | Complete |
+| Resize Events | Complete |
+| Timer / System Timer | Complete |
+| Terminal Modes | Complete |
+| Synchronized Updates | Complete |
+| Unicode / Wide Chars | In progress (see `WIDECHAR_PLAN.md`) |
+| C FFI / ABI | In progress |
+
+## Documentation
+
+- **API Reference:** `docs/API.md`
+- **Architecture:** `docs/ARCHITECTURE.md`
+- **Development:** `docs/DEVELOPMENT.md`
+- **E2E Testing:** `docs/E2E_TESTING_PLAN.md`
+- **Wide-char plan:** `WIDECHAR_PLAN.md`
+- **LLM context:** `llms.txt`
+- **Meta-framework:** `.claude/INDEX.md`
+
+## Quick Start
+
+```bash
+# Setup
+shards install
+shards build ameba
+shards build hace
+
+# Run tests
+bin/hace spec
+
+# Run demo
+bin/hace demo
+```

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,806 @@
+# Termisu Development TODO
+
+## Project Status
+
+**Version:** 0.0.2 (Alpha)
+**Source Lines:** ~6,200 (47 files)
+**Test Lines:** ~7,800 (38 spec files)
+**Test-to-Code Ratio:** 1.26x
+**Test Coverage:** 979 tests, 0 failures
+**Linting:** 111 files, 0 issues (ameba clean)
+**Priority 1:** ✅ All critical fixes complete
+**Priority 2:** ✅ All performance optimizations complete
+**Priority 3:** ✅ Input handling system complete (P3.1, P3.2, P3.3, P3.4)
+**Priority 8:** ✅ Async event system complete (P8.1-P8.6)
+**Task Runner:** hace (migrated from task-go)
+
+---
+
+## Current Architecture
+
+```
+Termisu (facade)
+├── Terminal (I/O control, state caching, mouse/keyboard protocols)
+│   ├── Termios (raw mode, ISIG disabled)
+│   └── Renderer interface (abstract)
+├── Terminfo (capabilities)
+│   ├── Database (standard path search)
+│   ├── Parser (binary format, 16/32-bit magic)
+│   ├── Builtin (xterm/linux fallbacks)
+│   ├── Capabilities (414 STRING_CAPS, O(1) lookup)
+│   └── Tparm (full processor with conditionals, stack, variables)
+├── Buffer (double-buffered cell grid)
+│   ├── Cell (char, fg, bg, attr)
+│   ├── Cursor (position, visibility, clamping)
+│   ├── RenderState (escape sequence optimization)
+│   └── IO::Memory batch buffer
+├── Reader (buffered input, EINTR/EAGAIN handling, select timeouts)
+├── Input (complete input system)
+│   ├── Key (170+ keys: A-Z, a-z, 0-9, symbols, F1-F24, nav)
+│   ├── Modifier (Shift, Alt, Ctrl, Meta flags)
+│   ├── Parser (CSI, SS3, Kitty protocol, modifyOtherKeys)
+│   └── Mouse (SGR mode 1006, normal mode 1000)
+├── Event (async event system)
+│   ├── Any (Key | Mouse | Resize | Tick | ModeChange union)
+│   ├── Key (key + char + modifiers struct)
+│   ├── Mouse (x, y, button, modifiers, motion)
+│   ├── Resize (width, height, old dimensions)
+│   ├── Tick (frame, elapsed, delta, missed_ticks)
+│   ├── ModeChange (mode, previous_mode)
+│   ├── Source (abstract class for event producers)
+│   │   ├── Input (keyboard/mouse from TTY)
+│   │   ├── Resize (SIGWINCH + polling)
+│   │   ├── Timer (sleep-based interval ticks)
+│   │   └── SystemTimer (kernel timerfd/kqueue ticks)
+│   ├── Poller (kernel event polling abstraction)
+│   │   ├── Epoll (Linux epoll + timerfd)
+│   │   ├── Kqueue (macOS/BSD kqueue + EVFILT_TIMER)
+│   │   └── Poll (POSIX poll fallback)
+│   └── Loop (multiplexer coordinating all sources)
+├── Color (multi-mode)
+│   ├── Default, ANSI-8, ANSI-256, RGB/TrueColor
+│   ├── Conversions (RGB ↔ ANSI-256 ↔ ANSI-8)
+│   └── Palette (standard 256-color)
+├── Attribute (Bold, Underline, Reverse, Blink, Dim, Cursive, Hidden, Strikethrough)
+└── Logging (structured async/sync dispatch)
+    ├── SafeFileIO (graceful shutdown)
+    └── Component logs (Terminal, Buffer, Reader, Terminfo, Input, Event)
+```
+
+---
+
+## Priority 1: Critical Fixes ✅ COMPLETE
+
+### P1.1 - Fix Parser Error Handling ✅ COMPLETED
+- ParseError class with typed errors (InvalidMagic, TruncatedData, InvalidHeader, InvalidOffset)
+- Comprehensive validation for header, magic number, and offsets
+- 15+ tests covering error handling edge cases
+
+### P1.2 - Fix Cursor Bounds After Resize ✅ COMPLETED
+- Cursor#clamp method called in Buffer#resize
+- Bounds check in Buffer#set_cursor with clamping
+- 13+ tests for cursor bounds scenarios
+
+### P1.3 - Handle EINTR in Reader ✅ COMPLETED
+- EINTR retry loops in check_fd_readable and fill_buffer
+- MAX_EINTR_RETRIES limit, IOError class for context
+- Handles EAGAIN, EBADF, EIO errors
+- 32+ tests including pipe-based I/O tests
+
+---
+
+## Priority 2: Performance Optimizations ✅ COMPLETE
+
+### P2.1 - Optimize Attribute Rendering ✅ COMPLETED
+- RenderState struct tracks terminal state (fg, bg, attr, cursor position)
+- render_row_diff and render_row_full with cell batching
+- Only emits escape sequences when state changes
+- 25+ tests for rendering optimization
+
+### P2.2 - Add State Caching in Terminal ✅ COMPLETED
+- Cached state: @cached_fg, @cached_bg, @cached_attr, @cached_cursor_visible
+- Skip redundant escape sequences
+- Reset integrated with screen operations
+- 27 tests covering caching scenarios
+
+---
+
+## Priority 3: Feature Completion ✅ MOSTLY COMPLETE
+
+### P3.1 - Mouse Input Support ✅ COMPLETED
+- SGR extended mouse protocol (mode 1006) with full parsing
+- Normal mouse protocol (mode 1000) support
+- Mouse::Button enum with from_cb decoding (Left, Middle, Right, WheelUp, WheelDown, Release)
+- Motion events with MOUSE_MOTION_BIT detection
+- Modifier extraction from mouse events
+- Terminal#enable_mouse / #disable_mouse sequences
+
+### P3.2 - Event System & Key Sequence Parsing ✅ COMPLETED
+- Complete Key enum with 170+ keys (A-Z, a-z, 0-9, all symbols, F1-F24, nav keys)
+- Modifier flags (Shift, Alt, Ctrl, Meta) with from_xterm_code
+- Input::Parser with timeout-based ESC detection (50ms)
+- CSI sequence parsing (arrows, nav, function keys, tilde codes)
+- SS3 sequence parsing (F1-F4, alternate arrows)
+- Kitty keyboard protocol support (codepoint + modifiers)
+- modifyOtherKeys support (CSI 27;modifier;keycode~)
+- Linux console function keys (\e[[A through \e[[E)
+- Alt+key and Ctrl+key detection
+- Hash-based O(1) key lookups (CSI_KEYS, TILDE_KEYS, SS3_KEYS, KITTY_CODEPOINTS)
+- Events::Key and Events::Mouse structs with convenience methods
+- Termisu#poll_event, #wait_event integration
+
+### P3.3 - Use Terminfo for Cursor Movement ✅ COMPLETED
+- Full tparm processor (Processor, Conditional, Operations, Variables, Output)
+- Terminfo `cup` capability for cursor positioning
+- 12 cached parametrized capabilities (cup, setaf, setab, cuf, cub, cuu, cud, hpa, vpa, ech, il, dl)
+- Comprehensive tparm tests
+
+### P3.4 - Extended Attribute Support ✅ COMPLETED
+- dim (SGR 2), sitm (SGR 3), invis (SGR 8) in REQUIRED_FUNCS
+- Builtin fallbacks for xterm/linux
+- Terminfo methods: dim_seq, italic_seq, hidden_seq
+- Renderer interface: enable_dim, enable_cursive, enable_hidden
+- Terminal implementation with caching
+- RenderState applies new attributes during rendering
+- 19 tests for extended attributes
+
+---
+
+## Priority 4: Missing Terminal Features
+
+### P4.1 - SIGWINCH Resize Event Handling ✅ COMPLETED
+**Status:** IMPLEMENTED via P8.1 (Async Architecture)
+**Implementation:** Event::Source::Resize with SIGWINCH + polling hybrid
+**API:** `Event::Resize` with `width`, `height`, `old_width`, `old_height`, `changed?`
+
+### P4.2 - Unicode / Wide Character Support 🟡 MEDIUM PRIORITY
+**Status:** NOT IMPLEMENTED
+**Issue:** No handling for double-width characters (CJK, emoji)
+**Impact:** CJK text and emoji display incorrectly (overlap or misalign)
+**Action:**
+- [ ] Add wcwidth/wcswidth bindings or implementation
+- [ ] Track cell width in Buffer (1 or 2 columns)
+- [ ] Handle wide character cursor movement
+- [ ] Test with CJK characters and emoji
+
+### P4.3 - Synchronized Updates (DEC mode 2026) ✅ COMPLETED
+**Status:** IMPLEMENTED
+**Implementation:**
+- [x] Added BSU/ESU constants (`\e[?2026h` / `\e[?2026l`) to Terminal
+- [x] Added `@sync_updates` flag (enabled by default)
+- [x] Wrapped `render()` and `sync()` methods with BSU/ESU sequences
+- [x] Added `sync_updates?` getter and `sync_updates=` setter
+- [x] Added `sync_updates` constructor parameter to Terminal and Termisu
+- [x] Unsupported terminals gracefully ignore the sequences (self-degrading)
+- [x] 7 tests covering constants, flag defaults, and runtime toggling
+**Design:** See `dec-plan.md` for design document
+
+### P4.4 - Strikethrough Attribute (SGR 9) ✅ COMPLETED
+**Status:** IMPLEMENTED
+**Implementation:**
+- [x] Added `Strikethrough = 128` to Attribute flags enum
+- [x] Added `smxx` capability to REQUIRED_FUNCS (index 27)
+- [x] Added `"\e[9m"` to Builtin fallbacks (xterm/linux)
+- [x] Added `strikethrough_seq` method to Terminfo
+- [x] Added `enable_strikethrough` to Renderer interface
+- [x] Implemented in Terminal with caching
+- [x] Updated RenderState to apply strikethrough
+- [x] Added tests for attribute, render_state, and builtin specs
+- [x] Updated examples (showcase.cr, simple.cr)
+- [x] Updated README documentation
+
+### P4.5 - Bracket Paste Mode 🟢 LOW PRIORITY
+**Status:** NOT IMPLEMENTED
+**Issue:** No bracketed paste support (mode 2004)
+**Impact:** Paste operations may trigger unintended commands
+**Action:**
+- [ ] Add enable_bracketed_paste / disable_bracketed_paste
+- [ ] Detect paste start (\e[200~) and end (\e[201~) sequences
+- [ ] Create Events::Paste with pasted content
+- [ ] Buffer paste content between brackets
+
+### P4.6 - Focus Tracking (mode 1004) 🟢 LOW PRIORITY
+**Status:** NOT IMPLEMENTED
+**Issue:** Cannot detect terminal focus/blur events
+**Impact:** Applications cannot optimize for background state
+**Action:**
+- [ ] Add enable_focus_tracking / disable_focus_tracking
+- [ ] Parse focus events (\e[I for focus, \e[O for blur)
+- [ ] Create Events::Focus(gained: Bool) struct
+
+### P4.7 - Extended Color Detection 🟢 LOW PRIORITY
+**Status:** NOT IMPLEMENTED
+**Issue:** No automatic detection of TrueColor support
+**Impact:** May send RGB sequences to terminals that don't support them
+**Action:**
+- [ ] Check COLORTERM environment variable
+- [ ] Query terminal capabilities (DA1/DA2)
+- [ ] Provide Color.supports_truecolor? method
+- [ ] Auto-downgrade RGB to ANSI-256 when needed
+
+---
+
+## Priority 5: Advanced Features (Backlog)
+
+### P5.1 - Scroll Regions
+- [ ] Set scrolling region (CSR capability)
+- [ ] Scroll up/down within region
+- [ ] Preserve content outside region
+
+### P5.2 - ACS Box Drawing Characters
+- [ ] Use terminfo `acsc` capability
+- [ ] Map line-drawing characters to ACS
+- [ ] Provide box-drawing helper methods
+
+### P5.3 - OSC 8 Hyperlinks
+- [ ] Add hyperlink support with OSC 8 sequences
+- [ ] Hyperlink IDs for proper tracking
+- [ ] Methods: start_hyperlink(url), end_hyperlink
+
+### P5.4 - Extended Underline Styles (SGR 4:x)
+- [ ] Single, double, curly, dotted, dashed underlines
+- [ ] Underline color (SGR 58)
+- [ ] Requires modern terminal support detection
+
+### P5.5 - Image Protocol Support (Kitty/Sixel)
+- [ ] Kitty graphics protocol
+- [ ] Sixel support for legacy terminals
+- [ ] Image placement and scaling
+
+---
+
+## Priority 6: Performance & Optimization
+
+### P6.1 - Cell Structure Optimization 🟡 INVESTIGATE
+**Status:** Needs profiling
+**Issue:** Cell struct uses separate fields (char, fg, bg, attr)
+**Potential:** Packed representation could improve cache locality
+**Action:**
+- [ ] Profile current Cell memory layout
+- [ ] Benchmark packed vs unpacked representation
+- [ ] Consider union for color (24-bit RGB in Int32)
+- [ ] Measure cache miss rates for large buffers
+
+### P6.2 - String Pooling for Escape Sequences
+**Status:** Needs investigation
+**Issue:** Escape sequences regenerated on each call
+**Potential:** Intern common sequences for reduced allocation
+**Action:**
+- [ ] Profile escape sequence allocation rates
+- [ ] Implement string interning for common sequences
+- [ ] Benchmark memory vs performance tradeoff
+
+### P6.3 - SIMD Color Conversion
+**Status:** Future consideration
+**Issue:** RGB to ANSI-256 conversion involves many comparisons
+**Action:**
+- [ ] Profile color conversion hot paths
+- [ ] Investigate Crystal SIMD support
+- [ ] Consider lookup table optimization
+
+---
+
+## Priority 8: Concurrency & Async Architecture ✅ COMPLETE
+
+> **📄 Design Document:** See [`docs/design/async-event-system.md`](docs/design/async-event-system.md) for complete specification.
+> **📄 Implementation Tracker:** See [`events-epic.md`](events-epic.md) for detailed task breakdown.
+
+Crystal provides lightweight fibers (cooperative coroutines) and channels for safe inter-fiber communication. The async event system is now fully implemented.
+
+### Current Async Usage
+
+| Component | Status | Implementation |
+|-----------|--------|----------------|
+| Logging | ✅ Async dispatch | SafeFileIO with graceful shutdown |
+| Input Reader | ✅ Async fiber | Event::Source::Input with named fiber |
+| SIGWINCH | ✅ Implemented | Event::Source::Resize with signal + polling |
+| Event Loop | ✅ Channel-based | Event::Loop multiplexer with select |
+| Timer/Tick | ✅ Implemented | Event::Source::Timer (sleep-based) |
+| SystemTimer | ✅ Implemented | Event::Source::SystemTimer (kernel timerfd/kqueue) |
+| Custom Sources | ✅ Supported | `add_event_source` / `remove_event_source` API |
+
+### P8.1 - SIGWINCH Resize Events with Channel ✅ COMPLETED
+**Implementation:** `Event::Source::Resize` in `src/termisu/event/source/resize.cr`
+- Hybrid SIGWINCH signal + polling (100ms fallback)
+- Tracks old dimensions for `Event::Resize.changed?`
+- Thread-safe with `Atomic(Bool)` and `compare_and_set`
+
+### P8.2 - Unified Event Channel Architecture ✅ COMPLETED
+**Implementation:** `Event::Loop` in `src/termisu/event/loop.cr`
+- `Event::Any` union type: `Key | Mouse | Resize | Tick`
+- `poll_event`, `poll_event(timeout)`, `wait_event` APIs
+- `try_poll_event` for non-blocking (select/else pattern)
+- `each_event(&)` iterator for event loops
+
+### P8.3 - Async Input Reader Fiber ✅ COMPLETED
+**Implementation:** `Event::Source::Input` in `src/termisu/event/source/input.cr`
+- Named fiber "termisu-input" for debugging
+- Thread-safe lifecycle with `Atomic(Bool)`
+- Handles `Channel::ClosedError` gracefully
+
+### P8.4 - Timer/Tick Channel for Animations ✅ COMPLETED
+**Implementation:** `Event::Source::Timer` in `src/termisu/event/source/timer.cr`
+- Sleep-based timer with configurable interval (default 16ms for ~60 FPS)
+- `Event::Tick` with `frame`, `elapsed`, `delta`, `missed_ticks`
+- Runtime interval changes via `timer_interval=`
+- API: `enable_timer`, `disable_timer`, `timer_enabled?`
+
+### P8.5 - Fan-In Event Multiplexer ✅ COMPLETED
+**Implementation:** `Event::Loop` + custom source API
+- `add_event_source(source)` - add custom Event::Source
+- `remove_event_source(source)` - remove source
+- Sources auto-start when loop is running
+- Example in README shows custom source pattern
+
+### P8.6 - Kernel-Level SystemTimer ✅ COMPLETED
+**Implementation:** `Event::Source::SystemTimer` in `src/termisu/event/source/system_timer.cr`
+- Kernel-level timing via timerfd/epoll (Linux) or kqueue (macOS/BSD)
+- Sub-millisecond precision, reliable up to ~90 FPS
+- `missed_ticks` field for detecting slow frame processing
+- Poll fallback for unsupported platforms
+- API: `enable_system_timer`, shared `disable_timer`, `timer_interval=`
+- Poller abstraction: `Event::Poller::Epoll`, `Event::Poller::Kqueue`, `Event::Poller::Poll`
+
+### P8.7 - Async Logging Batching 🟢 LOW PRIORITY (Deferred)
+**Status:** Partial (async dispatch exists)
+**Rationale:** Current SafeFileIO is sufficient for most use cases
+
+---
+
+## Async Architecture Summary
+
+### Current Event Loop Pattern (v0.1.0+)
+
+```crystal
+termisu = Termisu.new
+termisu.enable_timer(16.milliseconds)  # Optional: ~60 FPS for animations
+
+termisu.each_event do |event|
+  case event
+  when Termisu::Event::Key
+    break if event.key.escape?
+    handle_key(event)
+  when Termisu::Event::Mouse
+    handle_mouse(event)
+  when Termisu::Event::Resize
+    termisu.resize(event.width, event.height)
+    termisu.sync
+  when Termisu::Event::Tick
+    animate(event.delta)
+    termisu.render
+  end
+end
+
+termisu.close
+```
+
+### Non-Blocking Pattern (Game Loops)
+
+```crystal
+# Process all pending events without blocking
+while event = termisu.try_poll_event
+  handle_event(event)
+end
+
+# Then do frame update
+update_game_state
+render_frame
+```
+
+### Event API Summary
+
+| Method | Behavior |
+|--------|----------|
+| `poll_event` | Blocking, returns `Event::Any` |
+| `poll_event(timeout)` | With timeout, returns `Event::Any?` |
+| `try_poll_event` | Non-blocking (select/else), returns `Event::Any?` |
+| `wait_event` | Alias for blocking `poll_event` |
+| `each_event(&)` | Iterator yielding events |
+
+---
+
+## Priority 7: Infrastructure & Quality
+
+### P7.1 - Fix Benchmark Suite ✅ COMPLETED
+**File:** `bench/suites/buffer_suite.cr`
+**Issue:** NullRenderer was missing abstract methods added in P3.4
+**Solution:** Added `enable_dim`, `enable_cursive`, `enable_hidden` to NullRenderer
+**Benchmark Results (2024-12, after hot path log removal):**
+- Cell operations: ~28M ops/sec (35ns per cell)
+- Buffer clear: 280K/s (small) to 44K/s (large)
+- Render diff: 80K/s (no changes) to 72K/s (10% changed)
+- Resize: 12-16K ops/sec
+- Cursor ops: 28-32M ops/sec
+
+### P7.2 - Add Integration Tests
+**Status:** Partial
+**Action:**
+- [ ] End-to-end rendering tests with PTY
+- [ ] Color conversion round-trip tests
+- [ ] Full event parsing integration tests
+- [ ] Resize handling tests
+
+### P7.3 - Improve Error Types
+**Status:** Partial (ParseError, IOError done)
+**Action:**
+- [ ] Create ValidationError for input validation
+- [ ] Create CapabilityError for missing terminfo capabilities
+- [ ] Standardize error hierarchy
+
+### P7.4 - CI/CD Improvements
+**Status:** Partial
+**Action:**
+- [ ] Add release automation
+- [ ] Add changelog generation
+- [ ] Add benchmark CI job
+
+### P7.5 - Documentation
+**Status:** Partial progress
+**Completed:**
+- [x] `CLAUDE.md` - AI agent guidance with architecture overview
+- [x] `AGENTS.md` - AI coding agent instructions
+- [x] `CONTRIBUTING.md` - Updated with hace commands
+- [x] `docs/ARCHITECTURE.md` - Architecture documentation
+- [x] `docs/API.md` - API reference
+- [x] `docs/DEVELOPMENT.md` - Development guide
+- [x] `docs/design/async-event-system.md` - Async system design spec
+**Remaining:**
+- [ ] Add getting started guide (quick tutorial)
+- [ ] Add more usage examples to README
+- [ ] Add docstrings to all public methods
+
+---
+
+## Recently Completed
+
+### 2025-12 Session 4 (Kernel-Level SystemTimer)
+- [x] **P8.6** SystemTimer implementation with kernel-level timing
+  - Added `Event::Source::SystemTimer` using timerfd/epoll (Linux) and kqueue (macOS/BSD)
+  - Added `Event::Poller` abstraction with Epoll, Kqueue, and Poll backends
+  - Added `missed_ticks` field to `Event::Tick` for frame drop detection
+  - Sub-millisecond precision, reliable up to ~90 FPS (limited by terminal I/O)
+  - API: `enable_system_timer`, unified `disable_timer`, `timer_interval=`
+  - Comprehensive specs (25 tests for SystemTimer)
+  - Updated animation.cr example with runtime timer switching
+  - Benchmarking shows ~91 FPS ceiling due to terminal I/O overhead
+
+### 2025-12 Session 3 (Synchronized Updates - DEC Mode 2026)
+- [x] **P4.3** Synchronized Updates implementation
+  - Added BSU/ESU constants (`\e[?2026h` / `\e[?2026l`) to Terminal
+  - Added `@sync_updates` flag (enabled by default)
+  - Wrapped `render()` and `sync()` methods with BSU/ESU sequences
+  - Added `sync_updates?` getter and `sync_updates=` setter
+  - Added `sync_updates` constructor parameter to Terminal and Termisu
+  - Created `dec-plan.md` design document
+  - Added 7 new tests (904 total, +51 from 853)
+
+### 2025-12 Session 2 (Strikethrough Attribute)
+- [x] **P4.4** Strikethrough attribute implementation
+  - Added `Strikethrough = 128` to Attribute flags
+  - Added `smxx` to REQUIRED_FUNCS and builtin fallbacks
+  - Added `strikethrough_seq` to Terminfo
+  - Added `enable_strikethrough` to Renderer/Terminal
+  - Updated RenderState for attribute application
+  - Added 9 new tests (853 total, +9 from 844)
+  - Updated examples: showcase.cr, simple.cr
+  - Updated README.md documentation
+
+### 2025-12 Session (hace Migration & Documentation)
+- [x] Migrated from task-go (Taskfile.yml) to hace (Hacefile.yml)
+- [x] Created `CLAUDE.md` for AI agent guidance
+- [x] Created `AGENTS.md` for AI coding agents
+- [x] Updated `CONTRIBUTING.md` with hace commands
+- [x] Fixed binary content in `docs/DEVELOPMENT.md` project structure
+- [x] Added profiling tasks to Hacefile (perf, callgrind, memcheck)
+- [x] Added parallel task execution support
+
+**Current Stats (2025-12):**
+- **Test Coverage:** 979 tests passing, 0 failures
+- **Code Quality:** ameba clean (111 files, 0 issues)
+- **Source Lines:** ~6,200 (47 files)
+- **Test Lines:** ~7,800 (38 spec files)
+- **Test-to-Code Ratio:** 1.26x
+
+### 2024-12 Session 2 (Async Event System)
+- [x] **P8.1-P8.5** Complete async event system implementation
+  - Event::Source abstract class with Input, Resize, Timer implementations
+  - Event::Loop multiplexer with channel-based event routing
+  - Event::Any union type (Key | Mouse | Resize | Tick)
+  - SIGWINCH resize handling with hybrid signal + polling
+  - Timer source for animations (~60 FPS default)
+  - Custom event source API
+- [x] `try_poll_event` non-blocking method (select/else pattern)
+- [x] Case-insensitive letter matching (`key.q?` matches 'q' or 'Q')
+- [x] Comprehensive README API documentation
+- [x] `examples/animation.cr` bouncing ball demo
+- [x] `AGENTS.md` for AI agent instructions
+- [x] Ameba lint cleanup (26 violations fixed)
+  - Whitespace around macro expressions
+  - Redundant nil in control expressions
+  - Redundant self references
+  - Short block notation
+
+### 2024-12 Session 1 (Analysis & Cleanup)
+- [x] P7.1 Benchmark suite fixed (NullRenderer missing enable_dim, enable_cursive, enable_hidden)
+- [x] Hot path logging removed - 17 trace/debug logs removed
+- [x] Code quality audit completed
+
+---
+
+## Previously Completed
+
+- [x] Structured logging system (async/sync dispatch, SafeFileIO)
+- [x] P3.3 Terminfo cursor movement with full tparm processor
+- [x] P3.4 Extended attribute support (dim, italic, hidden)
+- [x] P3.2 Complete input parsing (CSI, SS3, Kitty, modifyOtherKeys)
+- [x] P3.1 Mouse input (SGR, normal mode)
+- [x] P2.2 Terminal state caching
+- [x] P2.1 Attribute rendering optimization with RenderState
+- [x] P1.3 EINTR handling in Reader
+- [x] P1.2 Cursor bounds clamping
+- [x] P1.1 Parser error handling with ParseError
+- [x] Concurrent benchmark suite (needs NullRenderer fix)
+- [x] Full color support (ANSI-8, ANSI-256, RGB)
+- [x] Color modular architecture
+- [x] GitHub Pages documentation workflow
+- [x] Lefthook pre-commit hooks
+
+---
+
+## Version Roadmap
+
+### v0.0.2 (Current - Alpha) ✅ COMPLETE
+- ✅ Core terminal control
+- ✅ Double-buffered rendering
+- ✅ Full terminfo support
+- ✅ Complete input handling (keyboard, mouse)
+- ✅ Color support (8, 256, RGB)
+- ✅ Text attributes (8 attributes including strikethrough)
+- ✅ **Async event system** (P8.1-P8.5)
+  - ✅ Event::Loop multiplexer
+  - ✅ Event::Source abstraction (Input, Resize, Timer)
+  - ✅ SIGWINCH resize handling
+  - ✅ Timer/tick for animations
+  - ✅ Custom event source API
+- ✅ hace task runner with parallel execution
+- ✅ AI agent documentation (CLAUDE.md, AGENTS.md)
+
+### v0.1.0 (Next - Beta) - Polish & Features
+- [ ] P4.2 Unicode/wide character support
+- [x] P4.3 Synchronized updates (DEC 2026) ✅
+- [x] P4.4 Strikethrough attribute ✅
+- [ ] P7.5 Documentation improvements (getting started guide)
+
+### v0.2.0 (Future) - Extended Input
+- [ ] P4.5 Bracket paste mode
+- [ ] P4.6 Focus tracking
+- [ ] P4.7 Extended color detection
+
+### v0.3.0 (Future) - Advanced Features
+- [ ] P5.1 Scroll regions
+- [ ] P5.2 ACS box drawing
+- [ ] P5.3 OSC 8 hyperlinks
+- [ ] P5.4 Extended underline styles
+- [ ] P5.5 Image protocol support (Kitty/Sixel)
+
+### v1.0.0 (Stable)
+- [ ] All P4 + P5 features complete
+- [ ] Comprehensive documentation
+- [ ] Widget system (optional)
+- [ ] Platform compatibility (Windows ConPTY)
+
+---
+
+## Priority 9: Code Quality & Technical Debt
+
+### Code Quality Analysis (2024-12 Audit)
+
+**Overall Assessment: GOOD** - Codebase is well-structured with excellent patterns. Minor improvements identified.
+
+#### 9.1 Minor Code Smells
+
+##### 9.1.1 - Cursor `show` Method Conditional Check 🟢 ACCEPTABLE
+**File:** `src/termisu/cursor.cr:55-63`
+**Pattern:** `.as(Int32)` after nil check
+```crystal
+if @last_x && @last_y
+  @x = @last_x.as(Int32)
+  @y = @last_y.as(Int32)
+```
+**Analysis:** This is correct - the `.as(Int32)` is explicit and readable. Crystal's flow analysis doesn't narrow instance variables in conditionals, so the cast is required.
+**Status:** Acceptable as-is
+
+##### 9.1.2 - Parser `parse_sgr_mouse` Complexity ✅ FIXED
+**File:** `src/termisu/input/parser.cr:364-417`
+**Issue:** Method flagged by ameba `Metrics/CyclomaticComplexity`
+**Solution:** Refactored using SRP into three focused methods:
+```crystal
+# Main entry point - now ~2 lines, minimal complexity
+private def parse_sgr_mouse : Event
+  result = read_sgr_sequence
+  return Events::Key.new(Key::Unknown) unless result
+  raw_params, is_release = result
+  parse_sgr_params_to_event(raw_params, is_release) || Events::Key.new(Key::Unknown)
+end
+
+# Single responsibility: read bytes until terminator
+private def read_sgr_sequence : {String, Bool}?
+
+# Single responsibility: parse params and create event
+private def parse_sgr_params_to_event(raw_params : String, is_release : Bool) : Events::Mouse?
+```
+**Benefits:**
+- Removed `ameba:disable` comment - passes lint naturally
+- Each method has single responsibility (SOLID: SRP)
+- Testable units: reading vs parsing are now separate
+- Also fixed: wheel check now includes WheelLeft/WheelRight (was missing)
+
+##### 9.1.3 - Termios Pointer Pattern 🟢 TRIVIAL
+**File:** `src/termisu/termios.cr:89-95`
+```crystal
+private def set_attrs(tios : LibC::Termios)
+  tios_copy = tios  # Creates copy just to get a pointer
+  if LibC.tcsetattr(@fd, LibC::TCSAFLUSH, pointerof(tios_copy)) != 0
+```
+**Analysis:** This is actually correct Crystal pattern for FFI, not a smell
+
+##### 9.1.4 - Terminfo Parser String Allocation ✅ FIXED
+**File:** `src/termisu/terminfo/parser.cr:266-271`
+**Issue:** Dynamic array growth during parsing
+**Solution:** Used `String.build` with variable binding pattern:
+```crystal
+String.build do |builder|
+  while (byte = io.read_byte) && byte != 0
+    builder.write_byte(byte)
+  end
+end
+```
+**Status:** Fixed - cleaner, better memory allocation, idiomatic Crystal
+
+##### 9.1.5 - Color Conversion Threshold Magic Numbers ✅ FIXED
+**File:** `src/termisu/color/conversions.cr:12-14`
+**Issue:** Magic number without named constant
+**Solution:** Added documented constant:
+```crystal
+# Threshold for RGB to ANSI-8 color mapping.
+# Values >= 128 are considered "on" for that color channel.
+ANSI8_THRESHOLD = 128_u8
+```
+**Status:** Fixed - self-documenting constant with clear explanation
+
+#### 9.2 Performance Opportunities (All Low Priority)
+
+##### 9.2.1 - Buffer Clear Loop 🟢 LOW PRIORITY
+**File:** `src/termisu/buffer.cr:85-89`
+```crystal
+def clear
+  @back.size.times do |index|
+    @back[index] = Cell.default
+  end
+end
+```
+**Potential:** Could use `Array#fill` but Crystal optimizes the loop well
+**Benchmark:** 280K ops/sec (small) - already performant
+**Action:** Keep as-is; readability > micro-optimization
+
+##### 9.2.2 - Color Struct Allocation 🟢 LOW PRIORITY
+**File:** `src/termisu/color.cr`
+**Analysis:** Color is a struct (value type), not heap allocated
+**No Issue:** Already optimal - uses value semantics throughout
+
+##### 9.2.3 - String::Builder in Parser 🟢 ACCEPTABLE
+**File:** `src/termisu/input/parser.cr:187, 376`
+```crystal
+def parse_csi_sequence : Event
+  buffer = String::Builder.new  # Allocates new builder each call
+```
+**Analysis:** Investigated optimization - not worth implementing because:
+1. **No clear() method** - String::Builder lacks reset capability (verified in Crystal 1.14 API)
+2. **Tiny allocations** - MAX_SEQUENCE_LENGTH is 32 bytes, typical sequences are 3-10 bytes
+3. **Short-lived objects** - GC generation 0 handles these efficiently
+4. **Alternatives add complexity**:
+   - IO::Memory has `clear` but isn't optimized for string building
+   - Manual Bytes buffer with position tracking adds bug surface
+   - Buffer pooling overkill for 32-byte objects
+5. **Current pattern is idiomatic** - matches `String.build` usage elsewhere in Crystal
+**Status:** Acceptable - premature optimization would violate KISS/YAGNI
+
+##### 9.2.4 - Tparm Static Variable Storage 🟢 LOW PRIORITY
+**File:** `src/termisu/terminfo/tparm/processor.cr:45`
+```crystal
+@@static_storage : Hash(Char, Int64) = {} of Char => Int64
+```
+**Issue:** Class variable for static vars shared across all calls
+**Impact:** Minimal - rarely used feature (static vars in terminfo are uncommon)
+**Note:** Proper design for terminfo spec compliance
+
+#### 9.3 Missing Defensive Patterns 🟡 MINOR
+
+##### 9.3.1 - Reader Buffer Size Validation
+**File:** `src/termisu/reader.cr:37`
+```crystal
+def initialize(@fd : Int32, buffer_size : Int32 = 128)
+  @buffer = Bytes.new(buffer_size)
+```
+**Issue:** No validation that `buffer_size > 0`
+**Impact:** Very low (internal constructor)
+**Action:** Consider adding `raise ArgumentError.new("buffer_size must be positive")` for robustness
+
+##### 9.3.2 - Terminal Cleanup Guarantee
+**File:** `src/termisu/terminal.cr`
+**Issue:** No finalize/at_exit to guarantee raw mode restoration
+**Impact:** If user forgets to call `close`, terminal may be left in raw mode
+**Action:** Consider adding `at_exit { disable_raw_mode }` pattern or document requirement
+
+##### 9.3.3 - Buffer Dimension Validation
+**File:** `src/termisu/buffer.cr:38-46`
+```crystal
+def initialize(@width : Int32, @height : Int32)
+  size = @width * @height
+  @front = Array(Cell).new(size) { Cell.default }
+```
+**Issue:** No validation that width/height > 0
+**Impact:** Minimal - terminal always provides valid dimensions
+**Action:** Consider adding defensive check for robustness
+
+##### 9.3.4 - Terminfo TERM Environment Validation
+**File:** `src/termisu/terminfo.cr:43`
+```crystal
+term_name = ENV["TERM"]? || raise Termisu::Error.new("TERM environment variable not set")
+```
+**Issue:** Good error message but could validate TERM content
+**Impact:** Minimal - Database.new handles invalid TERM gracefully
+**Status:** ✅ Already acceptable
+
+#### 9.4 Good Patterns Already Present ✅
+
+| Pattern | Location | Implementation |
+|---------|----------|----------------|
+| **Idempotent operations** | Backend#enable_raw_mode | Guards against double-enable |
+| **Defensive EINTR handling** | Reader#fill_buffer | Retry loop with max limit |
+| **Clear error types** | error.cr | ParseError, IOError with context |
+| **State caching** | Terminal, RenderState | Prevents redundant escape sequences |
+| **Bounds clamping** | Buffer#set_cursor, Cursor#clamp | Safe coordinate handling |
+| **Platform abstraction** | TTY#USE_RDWR | BSD vs Linux handling |
+| **Async logging** | log.cr | SafeFileIO wrapper prevents crashes |
+| **Hash-based dispatch** | Input::Parser | O(1) key lookups |
+| **Double buffering** | Buffer | Front/back with diff rendering |
+| **Capability caching** | Terminfo | 12 cached parametrized caps |
+| **Value types** | Color, Cell, RenderState | Struct for stack allocation |
+| **Macro-based constants** | TTY, LibC | Compile-time platform detection |
+| **@[AlwaysInline]** | Tparm::Processor | Hot path optimization |
+| **Event union type** | events.cr | Type-safe event handling |
+| **Modifier flags enum** | Modifier | Bitwise operations with type safety |
+
+### Summary
+
+**No Critical Issues Found.** The codebase demonstrates solid engineering:
+- Well-structured modules with clear responsibilities
+- Good error handling patterns
+- Performance optimizations where they matter
+- Clean abstractions (Renderer interface, Event union type)
+- Proper platform handling
+- Value types used appropriately for stack allocation
+
+**Code Smells Fixed (2024-12):**
+- ✅ 9.1.2 - Parser complexity (refactored into 3 SRP methods, removed ameba:disable)
+- ✅ 9.1.4 - Terminfo parser string (String.build)
+- ✅ 9.1.5 - Color conversion constant (ANSI8_THRESHOLD)
+
+**Acceptable Patterns (no change needed):**
+- 🟢 9.1.1 - Cursor `.as(Int32)` cast (explicit, required by Crystal)
+- 🟢 9.1.3 - Termios pointer (correct FFI pattern)
+
+**Remaining Minor Technical Debt:** ~2-3 hours for 9.3 defensive patterns
+
+---
+
+## Contributing
+
+Pick any item marked with `[ ]`. Priority order for contributions:
+1. **P4.2** - Unicode/wide character support (high impact)
+2. **P5.5** - Image protocols (Kitty/Sixel) (high impact for rich UIs)
+3. **P7.5** - Documentation improvements
+4. **P4.5** - Bracket paste mode
+
+Create a PR with tests for any changes.

--- a/WIDECHAR_PLAN.md
+++ b/WIDECHAR_PLAN.md
@@ -1,0 +1,147 @@
+# Wide Character Support Plan for Termisu
+
+**Status:** Research Complete | Implementation Pending
+
+**Date:** 2025-02-24
+
+## Quick Summary
+
+Termisu currently has basic wide character support in `buffer.cr#char_display_width`, but it's incomplete. This plan documents the research on how major TUI libraries handle CJK characters, emoji, combining characters, and complex Unicode sequences.
+
+## Current State
+
+**What Termisu Does Now:**
+- ✅ Has `char_display_width(ch : Char)` function in buffer.cr
+- ✅ Covers ~60% of common CJK and emoji ranges
+- ✅ Handles cursor advancement for wide chars in RenderState
+
+**What's Missing:**
+- ❌ Grapheme cluster support (combining characters like é = e + ´)
+- ❌ ZWJ sequence handling (family emoji 👨‍👩‍👧‍👦)
+- ❌ Skin tone modifier support
+- ❌ Variation selector handling (VS15/VS16)
+- ❌ Cell stores `Char` instead of full grapheme `String`
+- ❌ No "continuation cell" marking for wide characters
+
+## Key Findings
+
+### 1. The Standard: wcwidth() and Unicode Annex #11
+
+- **wcwidth()** returns: 0 (combining/control), 1 (narrow), 2 (wide), -1 (non-printable)
+- **East Asian Width** categories: A (Ambiguous), F (Fullwidth), H (Halfwidth), N (Neutral), W (Wide)
+- **Reference implementations:**
+  - [Markus Kuhn's wcwidth.c](https://www.cl.cam.ac.uk/~mgk25/ucs/wcwidth.c)
+  - [jquast/wcwidth](https://github.com/jquast/wcwidth) (Python, Unicode 15.1.0)
+  - [termux/wcwidth](https://github.com/termux/wcwidth) (C, Unicode 15)
+
+### 2. How Other Libraries Do It
+
+| Library | Cell Storage | Width Calc | Combining | ZWJ |
+|---------|--------------|------------|-----------|-----|
+| **ratatui** | `String` (grapheme) + `skip: bool` | `unicode-width` crate | ✅ via `unicode-segmentation` | ⚠️ partial (width 2) |
+| **tcell** | `main: rune` + `comb: []rune` | `golang.org/x/text/width` | ✅ explicit array | ⚠️ partial |
+| **notcurses** | `gcluster: u32` or egcpool index | Custom wcwidth | ✅ full EGC | ✅ full support |
+| **ncursesw** | `cchar_t` struct | libc wcwidth | ✅ wchar array | ⚠️ partial |
+
+### 3. Crystal Has Built-in Grapheme Support
+
+```crystal
+# Crystal 1.19+ has String::Grapheme
+string.each_grapheme do |grapheme|
+  # grapheme is a String representing 1 user-perceived character
+  # "e\u0301" => "é" (single grapheme, 2 codepoints)
+end
+```
+
+## Recommended Implementation
+
+### Design: "String-per-Cell with Skip Marker"
+
+```crystal
+struct Termisu::Cell
+  property grapheme : String    # Full grapheme cluster (not just Char)
+  property fg : Color
+  property bg : Color
+  property attr : Attribute
+  property width : Int32         # Cached display width (0, 1, or 2)
+  property skip : Bool = false  # Continuation cell marker
+  
+  def initialize(@grapheme = " ", @fg = Color.white, @bg = Color.default, @attr = Attribute::None)
+    @width = UnicodeWidth.width(@grapheme)
+  end
+  
+  # Backward compatibility
+  def self.new(ch : Char, fg, bg, attr)
+    new(ch.to_s, fg, bg, attr)
+  end
+end
+```
+
+### Why This Approach?
+
+1. **Leverages Crystal's built-in grapheme support** - no external dependencies
+2. **Simple API** - users work with strings naturally
+3. **Future-proof** - handles new Unicode features automatically
+4. **Backward compatible** - can keep `set_cell(x, y, ch, ...)` API
+
+## Implementation Phases
+
+### Phase 1: Core Infrastructure
+- Create `UnicodeWidth` module with wcwidth algorithm
+- Update `Cell` struct to store `grapheme: String`
+- Add `width` and `skip` fields
+- Implement backward-compatible `initialize(Char)` overload
+
+### Phase 2: Buffer & Rendering
+- Update `set_cell` to handle graphemes
+- Add `set_grapheme` method for explicit grapheme setting
+- Mark continuation cells when width > 1
+- Update rendering to skip cells marked as continuation
+
+### Phase 3: Advanced Features
+- Proper combining character rendering
+- ZWJ sequence width calculation
+- Skin tone modifier support
+- Variation selector (VS15/VS16) handling
+
+### Phase 4: Testing
+- Unit tests for width calculation
+- Visual test suite for CJK, emoji, combining chars
+- Terminal compatibility matrix
+
+## Edge Cases to Handle
+
+| Case | Example | Width | Notes |
+|------|---------|-------|-------|
+| CJK | '中', '日' | 2 | Most common case |
+| Emoji | '😀', '👍' | 2 | Standard emoji |
+| ZWJ | '👨‍👩‍👧‍👦' | 2 | 7 codepoints, 1 grapheme |
+| Combining | "e\u0301" (é) | 1 | 2 codepoints, 1 grapheme |
+| VS15 | "\u26A0\uFE0E" (⚠︎) | 1 | Text presentation |
+| VS16 | "\u26A0\uFE0F" (⚠️) | 2 | Emoji presentation |
+| Skin tone | "\u{1F44D}\u{1F3FB}" (👍🏻) | 2 | Base + modifier |
+
+## Performance Considerations
+
+- **Width caching:** Memoize codepoint widths to avoid repeated lookups
+- **Table size:** Full Unicode 15 tables ~100KB; can use subset for common ranges
+- **Grapheme iteration:** Slightly slower than char iteration, but acceptable for TUI
+
+## References
+
+Full research report: `.claude/cache/agents/oracle/output-widechar-*.md`
+
+**Key Sources:**
+- [UAX #11 - East Asian Width](https://www.unicode.org/reports/tr11/)
+- [UAX #29 - Text Segmentation](https://www.unicode.org/reports/tr29/)
+- [ratatui Issue #1438](https://github.com/ratatui/ratatui/discussions/1438)
+- [tcell source](https://github.com/gdamore/tcell)
+- [notcurses documentation](https://notcurses.com/notcurses_cell.3.html)
+
+## Next Steps
+
+1. Review and approve this plan
+2. Create UnicodeWidth module
+3. Update Cell struct
+4. Implement grapheme-aware rendering
+5. Add comprehensive tests

--- a/bench/BENCHMARK_IMPROVEMENT_PLAN.md
+++ b/bench/BENCHMARK_IMPROVEMENT_PLAN.md
@@ -1,0 +1,231 @@
+# Benchmark Suite Improvement Plan
+
+## Summary
+
+Analysis of [Crystal Forum Post](https://forum.crystal-lang.org/t/how-to-use-benchmark-correctly/6008) reveals critical issues with current benchmark implementation.
+
+## Current Issues
+
+### 1. Compiler Optimization Vulnerability (CRITICAL)
+
+**Problem**: Crystal compiler eliminates operations with no side effects.
+
+```crystal
+# CURRENT (INVALID) - compiler optimizes away
+capture.report("Color.default") { Color.default }
+capture.report("color ==") { color1 == color2 }
+```
+
+**Affected Files**:
+| File | Affected Benchmarks |
+|------|---------------------|
+| `color_suite.cr` | `Color.default`, `Color.black`, `Color.ansi256`, `Color.rgb`, all conversions, equality checks |
+| `buffer_suite.cr` | `hide_cursor`, `show_cursor` (void returns okay) |
+| `parser_suite.cr` | `Parser.new`, `parse`, `parse?` |
+
+### 2. Hardcoded Constants (HIGH)
+
+**Problem**: Compile-time constant evaluation bypasses runtime measurement.
+
+```crystal
+# CURRENT - may be evaluated at compile time
+Color.ansi256(42)
+Color.rgb(128, 64, 255)
+```
+
+### 3. Insufficient Warmup & Measurement (HIGH)
+
+| Metric | Current | Best Practice |
+|--------|---------|---------------|
+| Warmup | 100 iterations | 2s (time-based) |
+| Measurement | 100ms | 2-5s |
+| Samples | 1 | 3-5 |
+| Std Dev | Always 0.0 | Calculated |
+
+### 4. No Memory Tracking (MEDIUM)
+
+`bytes_per_op` always `0_i64` - no allocation tracking.
+
+---
+
+## Implementation Plan
+
+### Phase 1: Fix Compiler Optimization Issues
+
+**Objective**: Ensure all benchmarks produce valid measurements.
+
+**Pattern**:
+```crystal
+# Before
+capture.report("Color.default") { Color.default }
+
+# After - capture return value
+y = Color.default
+capture.report("Color.default") { y = Color.default }
+```
+
+**Changes Required**:
+
+#### `color_suite.cr`
+```crystal
+# Creation benchmarks
+y = Color.default
+capture.report("Color.default") { y = Color.default }
+capture.report("Color.black") { y = Color.black }
+
+# Use runtime values
+idx = rand(256).to_u8
+capture.report("Color.ansi256(index)") { y = Color.ansi256(idx) }
+
+r, g, b = rand(256).to_u8, rand(256).to_u8, rand(256).to_u8
+capture.report("Color.rgb(r,g,b)") { y = Color.rgb(r, g, b) }
+
+# Conversion benchmarks
+result = 0_u8
+capture.report("rgb_to_ansi256") { result = Color::Conversions.rgb_to_ansi256(r, g, b) }
+
+tuple = {0_u8, 0_u8, 0_u8}
+capture.report("ansi256_to_rgb") { tuple = Color::Conversions.ansi256_to_rgb(idx) }
+
+# Equality benchmarks
+eq_result = false
+capture.report("color == (equal)") { eq_result = color1 == color2 }
+```
+
+#### `parser_suite.cr`
+```crystal
+parser = Terminfo::Parser.new(mock_data)
+capture.report("Parser.new") { parser = Terminfo::Parser.new(mock_data) }
+
+caps = {} of String => String?
+capture.report("parse 1 cap") { caps = parser.parse(["clear"]) }
+```
+
+### Phase 2: Upgrade Measurement Engine
+
+**Objective**: Match `Benchmark.ips` statistical rigor.
+
+**Replace `BenchCapture.report`**:
+
+```crystal
+class BenchCapture
+  WARMUP_DURATION = 500.milliseconds
+  SAMPLE_DURATION = 500.milliseconds
+  SAMPLE_COUNT = 5
+
+  def report(name : String, &block)
+    # Time-based warmup
+    warmup_start = Time.instant
+    while (Time.instant - warmup_start) < WARMUP_DURATION
+      block.call
+    end
+
+    # Multi-sample measurement
+    samples = [] of Float64
+    SAMPLE_COUNT.times do
+      iterations = 0
+      gc_before = GC.stats.total_bytes
+
+      start = Time.instant
+      while (Time.instant - start) < SAMPLE_DURATION
+        block.call
+        iterations += 1
+      end
+      elapsed = Time.instant - start
+
+      gc_after = GC.stats.total_bytes
+      samples << iterations / elapsed.total_seconds
+      @last_bytes_delta = (gc_after - gc_before) / iterations
+    end
+
+    # Statistical analysis
+    mean_ips = samples.sum / samples.size
+    variance = samples.map { |s| (s - mean_ips) ** 2 }.sum / samples.size
+    std_dev = Math.sqrt(variance)
+    std_dev_percent = (std_dev / mean_ips) * 100.0
+    mean_time = Time::Instant.new(nanoseconds: (1_000_000_000 / mean_ips).to_i64)
+
+    @results << BenchResult.new(
+      name: name,
+      iterations_per_second: mean_ips,
+      mean_time: mean_time,
+      std_dev_percent: std_dev_percent,
+      bytes_per_op: @last_bytes_delta
+    )
+  end
+end
+```
+
+### Phase 3: Add Memory Tracking
+
+**Objective**: Track allocation overhead per operation.
+
+```crystal
+# Track GC allocation delta
+gc_before = GC.stats.total_bytes
+# ... run benchmark ...
+gc_after = GC.stats.total_bytes
+bytes_per_op = (gc_after - gc_before) / iterations
+```
+
+**Renderer Update**:
+```crystal
+def render_result(result : BenchResult, fastest_ips : Float64)
+  # ... existing code ...
+
+  # Add allocation info if significant
+  if result.bytes_per_op > 0
+    line += " #{YELLOW}#{result.bytes_per_op}B/op#{RESET}"
+  end
+end
+```
+
+### Phase 4: Statistical Improvements
+
+**Add to output**:
+- Standard deviation percentage (already in struct)
+- Confidence indicator: `(+/- X%)`
+
+```crystal
+def render_result(result : BenchResult, fastest_ips : Float64)
+  # ... existing code ...
+
+  # Add variance indicator
+  variance_color = result.std_dev_percent < 5.0 ? GREEN : YELLOW
+  line += " #{variance_color}(+/-#{result.std_dev_percent.round(1)}%)#{RESET}"
+end
+```
+
+---
+
+## Timeline
+
+| Phase | Priority | Effort | Impact |
+|-------|----------|--------|--------|
+| 1. Fix optimization | CRITICAL | 2h | Measurements valid |
+| 2. Upgrade engine | HIGH | 3h | Statistical rigor |
+| 3. Memory tracking | MEDIUM | 1h | Allocation insights |
+| 4. Stats display | LOW | 1h | Better reporting |
+
+**Total**: ~7 hours
+
+## Validation
+
+After implementation, verify with:
+
+```bash
+# Compare before/after
+bin/hace bench > before.txt
+# ... apply changes ...
+bin/hace bench > after.txt
+
+# Look for:
+# 1. Reasonable IPS values (not billions for simple ops)
+# 2. Non-zero std_dev values
+# 3. Memory tracking showing allocations
+```
+
+## References
+
+- [Crystal Forum: How to use Benchmark correctly](https://forum.crystal-lang.org/t/how-to-use-benchmark-correctly/6008)
+- Crystal stdlib `Benchmark.ips` implementation

--- a/docs-web/content/guide/mouse-keyboard.md
+++ b/docs-web/content/guide/mouse-keyboard.md
@@ -23,3 +23,37 @@ termisu.enhanced_keyboard?
 ```
 
 Enhanced keyboard mode helps disambiguate key combos (for example `Tab` vs `Ctrl+I`).
+
+## Bracketed Paste
+
+```crystal
+termisu.enable_bracketed_paste
+termisu.disable_bracketed_paste
+termisu.bracketed_paste?
+```
+
+With DEC private mode 2004 on, the terminal wraps pasted text in boundary markers that
+arrive as `Key::PasteStart` and `Key::PasteEnd`, and stops translating line endings
+inside the paste. Without it a paste is indistinguishable from typing: a pasted CRLF
+arrives as the same bytes `Enter` produces, and some terminals map the LF to a second
+CR, so one pasted line break looks exactly like two deliberate `Enter` presses.
+
+The bytes between the markers are reported as they arrive — bracketing says *where* the
+paste is, it does not normalize what is inside it.
+
+```crystal
+pasting = false
+termisu.each_event do |event|
+  case event
+  when Termisu::Event::Key
+    case event.key
+    when .paste_start? then pasting = true
+    when .paste_end?   then pasting = false
+    else                    handle(event, pasted: pasting)
+    end
+  end
+end
+```
+
+All three modes are also exposed over the C ABI and the JavaScript binding
+(`enableBracketedPaste`, `disableBracketedPaste`, `bracketedPaste`).

--- a/include/termisu/ffi.h
+++ b/include/termisu/ffi.h
@@ -228,6 +228,15 @@ int32_t termisu_enable_mouse(termisu_handle_t handle);
 int32_t termisu_disable_mouse(termisu_handle_t handle);
 int32_t termisu_enable_enhanced_keyboard(termisu_handle_t handle);
 int32_t termisu_disable_enhanced_keyboard(termisu_handle_t handle);
+int32_t termisu_enable_bracketed_paste(termisu_handle_t handle);
+int32_t termisu_disable_bracketed_paste(termisu_handle_t handle);
+
+/* Input mode queries. Non-zero when the mode is on. `with_mode` suspends and
+   restores these, so a caller that shadows the state itself will drift. */
+uint8_t termisu_mouse_enabled(termisu_handle_t handle);
+uint8_t termisu_enhanced_keyboard(termisu_handle_t handle);
+uint8_t termisu_bracketed_paste(termisu_handle_t handle);
+
 int32_t termisu_poll_event(termisu_handle_t handle, int32_t timeout_ms, termisu_event_t *out_event);
 
 /* Error handling */

--- a/javascript/core/src/native.ts
+++ b/javascript/core/src/native.ts
@@ -32,6 +32,11 @@ const SYMBOLS = {
   termisu_disable_mouse: { args: ["u64"], returns: "i32" },
   termisu_enable_enhanced_keyboard: { args: ["u64"], returns: "i32" },
   termisu_disable_enhanced_keyboard: { args: ["u64"], returns: "i32" },
+  termisu_enable_bracketed_paste: { args: ["u64"], returns: "i32" },
+  termisu_disable_bracketed_paste: { args: ["u64"], returns: "i32" },
+  termisu_mouse_enabled: { args: ["u64"], returns: "u8" },
+  termisu_enhanced_keyboard: { args: ["u64"], returns: "u8" },
+  termisu_bracketed_paste: { args: ["u64"], returns: "u8" },
   termisu_poll_event: { args: ["u64", "i32", "ptr"], returns: "i32" },
 
   termisu_last_error_length: { args: [], returns: "u64" },

--- a/javascript/core/src/termisu.ts
+++ b/javascript/core/src/termisu.ts
@@ -103,11 +103,7 @@ export class Termisu {
   }
 
   syncUpdates(): boolean {
-    this.assertAlive();
-    const value = asNumber(
-      this.native.symbols.termisu_sync_updates(this.handle) as number | bigint
-    );
-    return value !== 0;
+    return this.queryFlag("termisu_sync_updates");
   }
 
   clear(): void {
@@ -211,6 +207,26 @@ export class Termisu {
     this.callVoidStatus("termisu_disable_enhanced_keyboard");
   }
 
+  enableBracketedPaste(): void {
+    this.callVoidStatus("termisu_enable_bracketed_paste");
+  }
+
+  disableBracketedPaste(): void {
+    this.callVoidStatus("termisu_disable_bracketed_paste");
+  }
+
+  mouseEnabled(): boolean {
+    return this.queryFlag("termisu_mouse_enabled");
+  }
+
+  enhancedKeyboard(): boolean {
+    return this.queryFlag("termisu_enhanced_keyboard");
+  }
+
+  bracketedPaste(): boolean {
+    return this.queryFlag("termisu_bracketed_paste");
+  }
+
   pollEvent(timeoutMs: number = -1): AnyEvent | null {
     this.assertAlive();
 
@@ -259,10 +275,26 @@ export class Termisu {
       | "termisu_disable_mouse"
       | "termisu_enable_enhanced_keyboard"
       | "termisu_disable_enhanced_keyboard"
+      | "termisu_enable_bracketed_paste"
+      | "termisu_disable_bracketed_paste"
   ): void {
     this.assertAlive();
     const status = asNumber(this.native.symbols[symbolName](this.handle) as number | bigint);
     this.assertStatus(status, symbolName);
+  }
+
+  // Reads a u8 mode flag. These modes are suspended and restored by with_mode on
+  // the Crystal side, so asking is the only reliable way to know the current state.
+  private queryFlag(
+    symbolName:
+      | "termisu_sync_updates"
+      | "termisu_mouse_enabled"
+      | "termisu_enhanced_keyboard"
+      | "termisu_bracketed_paste"
+  ): boolean {
+    this.assertAlive();
+    const value = asNumber(this.native.symbols[symbolName](this.handle) as number | bigint);
+    return value !== 0;
   }
 
   private ensureStyleScratch(): Scratch {

--- a/javascript/core/tests/termisu.test.ts
+++ b/javascript/core/tests/termisu.test.ts
@@ -29,6 +29,11 @@ type TestTermisu = {
   disableMouse(): void;
   enableEnhancedKeyboard(): void;
   disableEnhancedKeyboard(): void;
+  enableBracketedPaste(): void;
+  disableBracketedPaste(): void;
+  mouseEnabled(): boolean;
+  enhancedKeyboard(): boolean;
+  bracketedPaste(): boolean;
   pollEvent(timeoutMs?: number): unknown;
   close(): void;
   destroy(): void;
@@ -73,6 +78,11 @@ function buildMockTermisu(
     termisu_disable_mouse: () => Status.Ok,
     termisu_enable_enhanced_keyboard: () => Status.Ok,
     termisu_disable_enhanced_keyboard: () => Status.Ok,
+    termisu_enable_bracketed_paste: () => Status.Ok,
+    termisu_disable_bracketed_paste: () => Status.Ok,
+    termisu_mouse_enabled: () => 1,
+    termisu_enhanced_keyboard: () => 0,
+    termisu_bracketed_paste: () => 1,
     termisu_poll_event: () => Status.Ok,
     termisu_last_error_length: () => 0n,
     termisu_last_error_copy: () => 0n,
@@ -109,6 +119,8 @@ describe("Termisu wrapper behavior", () => {
     termisu.disableMouse();
     termisu.enableEnhancedKeyboard();
     termisu.disableEnhancedKeyboard();
+    termisu.enableBracketedPaste();
+    termisu.disableBracketedPaste();
     termisu.close();
 
     const names = calls.map((entry) => entry.name);
@@ -121,7 +133,24 @@ describe("Termisu wrapper behavior", () => {
     expect(names).toContain("termisu_disable_mouse");
     expect(names).toContain("termisu_enable_enhanced_keyboard");
     expect(names).toContain("termisu_disable_enhanced_keyboard");
+    expect(names).toContain("termisu_enable_bracketed_paste");
+    expect(names).toContain("termisu_disable_bracketed_paste");
     expect(names).toContain("termisu_close");
+  });
+
+  it("decodes the u8 input-mode queries as booleans", () => {
+    // with_mode suspends and restores these on the Crystal side, so a caller that
+    // shadows the state locally drifts; asking is the only reliable read.
+    const { termisu, calls } = buildMockTermisu();
+
+    expect(termisu.mouseEnabled()).toBe(true);
+    expect(termisu.enhancedKeyboard()).toBe(false);
+    expect(termisu.bracketedPaste()).toBe(true);
+
+    const names = calls.map((entry) => entry.name);
+    expect(names).toContain("termisu_mouse_enabled");
+    expect(names).toContain("termisu_enhanced_keyboard");
+    expect(names).toContain("termisu_bracketed_paste");
   });
 
   it("converts boolean sync update values and reads back bool state", () => {

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,925 @@
+# Termisu — LLM Reference
+
+**Project:** Pure-Crystal terminal UI library, termbox-style, cell-based double buffering, async event multiplexing, zero runtime dependencies, plus a C ABI for embedding.
+
+**Version:** 0.4.5  •  **Crystal:** >= 1.17.0  •  **License:** MIT  •  **Generated:** 2026-04-22
+
+This file is the canonical context for LLMs working on Termisu. It is dense and file-anchored — every claim cites `file:line`. Read it top-to-bottom once to understand the wiring; jump in by section when working on a specific subsystem.
+
+---
+
+## 0. Orientation map
+
+Four user-facing concerns, one embedding concern:
+
+| Concern | Key files | Role |
+|---|---|---|
+| Rendering | `buffer.cr`, `cell.cr`, `render_state.cr`, `renderer.cr`, `terminal.cr` | Cells → diff → batched SGR/CUP → bytes |
+| Terminal I/O | `tty.cr`, `termios.cr`, `terminal/backend.cr`, `terminal/mode.cr`, `reader.cr` | `/dev/tty`, termios modes, alternate screen, mouse, buffered input |
+| Events | `event/*.cr`, `event/source/*.cr`, `event/poller*.cr`, `input/parser.cr` | One channel, many sources, platform pollers |
+| Capabilities | `terminfo/*.cr`, `terminfo/tparm/*.cr` | `$TERM` lookup + parametrized-string interpreter |
+| Embedding | `ffi.cr`, `ffi/*.cr` | C-callable `termisu_*` functions with opaque handles |
+
+Facade `Termisu::Termisu` (in `src/termisu/termisu.cr`) instantiates every subsystem. User code interacts almost exclusively with the facade.
+
+---
+
+## 1. Top-level ownership graph
+
+```
+Termisu::Termisu              (facade, src/termisu/termisu.cr)
+├── Terminal                  src/termisu/terminal.cr        (implements Renderer)
+│   ├── Terminal::Backend     src/termisu/terminal/backend.cr
+│   │   ├── TTY               src/termisu/tty.cr               (/dev/tty fd)
+│   │   └── Termios           src/termisu/termios.cr           (tcgetattr/tcsetattr)
+│   ├── Terminfo              src/termisu/terminfo.cr
+│   │   ├── Database          src/termisu/terminfo/database.cr (file lookup)
+│   │   ├── Parser            src/termisu/terminfo/parser.cr   (binary format)
+│   │   ├── Capabilities      src/termisu/terminfo/capabilities.cr
+│   │   ├── Builtin           src/termisu/terminfo/builtin.cr  (xterm/linux fallback)
+│   │   └── Tparm             src/termisu/terminfo/tparm*.cr   (stack VM)
+│   ├── Buffer                src/termisu/buffer.cr
+│   │   ├── Cell[]            src/termisu/cell.cr + unicode_width.cr
+│   │   └── RenderState       src/termisu/render_state.cr      (SGR cache)
+│   └── Cursor                src/termisu/terminal/cursor.cr
+├── Reader                    src/termisu/reader.cr            (4 KB poll+read buffer)
+├── Input::Parser             src/termisu/input/parser.cr      (ESC state machine)
+└── Event::Loop               src/termisu/event/loop.cr        (one shared channel)
+    ├── Source::Input         event/source/input.cr            (fiber "termisu-input")
+    ├── Source::Resize        event/source/resize.cr           (SIGWINCH + 100ms poll hybrid)
+    ├── Source::Timer         event/source/timer.cr            (sleep-based)
+    └── Source::SystemTimer   event/source/system_timer.cr
+        └── Poller            event/poller/{linux,kqueue,poll}.cr  (compile-time dispatched)
+
+Termisu::FFI (parallel embedding surface, src/termisu/ffi/*)
+├── Registry                  ffi/registry.cr   (Hash UInt64 → Context, Mutex-guarded)
+├── Context                   ffi/context.cr    (wraps a ::Termisu + Atomic(Bool) closed flag)
+├── Guards                    ffi/guards.cr     (exception → status code translation)
+├── ErrorState                ffi/error_state.cr (thread-local last-error string)
+├── Exports                   ffi/exports.cr    (21 `fun termisu_*` symbols)
+└── Runtime                   ffi/runtime.cr    (ensure_initialized for .so mode)
+```
+
+---
+
+## 2. Complete file index (what's where, why)
+
+### 2.1 Core rendering
+
+| File | Role | Key types/methods |
+|---|---|---|
+| `src/termisu.cr` | Loader (`require "./termisu/*"`) | — |
+| `src/termisu/termisu.cr` | Facade class `Termisu::Termisu` | `set_cell`, `render`, `poll_event`, `suspend`, mode switchers. Instantiates Terminal, Reader, Parser, Event::Loop at `termisu.cr:38-72` |
+| `src/termisu/terminal.cr` | `class Terminal` implementing abstract `Renderer` | Owns Backend, Terminfo, Buffer, Cursor, cached SGR state `@cached_fg/@cached_bg/@cached_attr` (l.36-38). `foreground=`/`background=` emit SGR per color mode (l.129-167). Attribute setters (l.182-249). `render` → `Buffer.render_to` (l.481). `suspend`, `with_mode`, `with_password_mode`, `with_cbreak_mode` implement block-scoped mode switches |
+| `src/termisu/buffer.cr` | Double-buffered cell grid | `@front`/`@back : Array(Cell)`, `@render_state`, `@batch_buffer : IO::Memory`, `@row_non_default_counts`, `@dirty_rows`, `@dirty_row_list`, `@any_dirty` (l.25-32). `set_cell` (l.66) → `set_cell_internal` (l.106-158) handles wide-char leading+continuation pair + overlap clearing. `render_to` (l.212-238) walks dirty rows. `render_row_diff` (l.394-475) skips unchanged cells and batches same-styled runs. `invalidate` (l.200) fills front with NUL sentinels to force full redraw. `resize` (l.265-316) copies min dims, fixes orphan continuations, rebuilds dirty tracking |
+| `src/termisu/cell.cr` | `struct Cell` | Fields: `grapheme : String`, `width : UInt8 (0/1/2)`, `continuation : Bool`, `fg : Color`, `bg : Color`, `attr : Attribute` (l.43-48). Initializer extracts first grapheme cluster, computes width via `UnicodeWidth.grapheme_width` (l.92-108). Default equality drives diff |
+| `src/termisu/renderer.cr` | Abstract `Renderer` interface | `write`, `flush`, `size`, `close`, `move_cursor`, `show_cursor`, `hide_cursor`, `foreground=`, `background=`, `reset_attributes`, `enable_bold`, `enable_underline`, etc. Implemented by Terminal; mock renderers live in `spec/support/mock_renderers.cr` |
+| `src/termisu/render_state.cr` | SGR escape-sequence optimizer | Tracks current `@fg/@bg/@attr` (l.22-28). `apply_style` (l.42-101) compares desired to current, emits only deltas. If any attribute removed, emits `SGR 0` then re-applies active ones. State resets on buffer invalidate (l.208) and on mode switches that clear screen |
+| `src/termisu/unicode_width.cr` | East Asian Wide / grapheme width | `UnicodeWidth.grapheme_width(cluster : String) : UInt8` returns 0/1/2. Handles combining marks (binary search over ranges, l.478-499), CJK wide ranges (block checks, l.668-706), ZWJ sequences, VS15/VS16, regional indicator flags, keycaps (l.71-80, 521-532) |
+| `src/termisu/terminal/cursor.cr` | `struct Cursor` + movement/visibility | `x`, `y`, `visible`, `blink`, `shape` (Block=1/Underline=3/Bar=5). Owned by Terminal as `@cursor`. `move_cursor` uses terminfo `cup`, falls back to `\e[y;xH` (l.79-99). `show_cursor`/`hide_cursor` emit terminfo `civis`/`cnorm` (l.33-44). Ephemeral cursor pattern: hide during render, restore after (l.101-111) |
+| `src/termisu/color.cr` | `struct Color` | Mode discriminator enum (l.40-44): Default/ANSI8/ANSI256/RGB, carrying either index (UInt8) or r/g/b. Named factories: `Color.red`, `Color.bright_red`, `Color.ansi256(N)`, `Color.rgb(r,g,b)`, `Color.from_hex(hex)` |
+| `src/termisu/color/conversions.cr` | Color-space conversions | RGB↔ANSI256 via 6×6×6 cube + grayscale ramp (l.42-54, 114-131). RGB↔ANSI8 via threshold mapping (l.56-63). ANSI→RGB uses lookup tables (l.17-29, 108-111) |
+| `src/termisu/color/palette.cr` | Named-color factory methods | basic (l.9-24) + bright (l.27-48) ANSI colors |
+| `src/termisu/color/validator.cr` | Range checks | Raises `ArgumentError` for invalid index/rgb values (l.9-33) |
+| `src/termisu/color/formatters.cr` | `Color#to_s` debug format | (l.8-17) |
+| `src/termisu/attribute.cr` | `@[Flags] enum Attribute : UInt16` | None=0, Bold=1, Underline=2, Reverse=4, Blink=8, Dim=16, Italic/Cursive=32, Hidden=64, Strikethrough=128. Bitwise OR to combine. Individual SGR codes emitted per bit |
+
+### 2.2 Terminal I/O
+
+| File | Role | Key types/methods |
+|---|---|---|
+| `src/termisu/tty.cr` | `class TTY` wrapping `/dev/tty` fd | `TTY.open` calls `LibC.open("/dev/tty", O_RDWR)` (l.16) + `LibC.isatty` (l.23). Raises `Termisu::Error` if no tty — **no fallback to stdin/stdout**. `fd : Int32` accessor, `close` is idempotent (checks `@fd >= 0`) |
+| `src/termisu/termios.cr` | `class Termios` raw-mode save/restore | Ctor calls `tcgetattr` saving `@original`; `apply!` calls `tcsetattr(TCSANOW)` with `@current` (l.12, 44). `raw!` clears input flags `IGNBRK|BRKINT|PARMRK|ISTRIP|INLCR|IGNCR|ICRNL|IXON` and local flags `ECHO|ECHONL|ICANON|ISIG|IEXTEN`, sets `VMIN=1`/`VTIME=0` (l.56-68). `cooked!` re-enables them (l.74-81). Compile-time struct-size check guards Linux/BSD NCCS difference (l.8-11) |
+| `src/termisu/terminal/mode.cr` | `@[Flags] enum Mode` | Primitives: `None=0`, `Echo=1<<0`, `Canonical=1<<1`, `Signals=1<<2`, `ProcessOutput=1<<3`, `Extended=1<<4` (l.7-13). Named combos (l.16-36): **Raw**=None, **SemiRaw**=Signals, **Cbreak**=Echo|Signals, **Password**=Canonical|Signals|ProcessOutput|Extended, **Cooked**/**FullCooked**=all five |
+| `src/termisu/terminal/backend.cr` | `class Backend` low-level I/O | State: `@tty`, `@termios`, `@mode`, `@alternate_screen`, `@mouse_enabled` (l.14-19). `apply_mode(mode)` translates bitflag → termios c_iflag/c_oflag/c_lflag, calls `@termios.apply!`, returns previous mode (l.142-160). `alternate_screen=` writes `\e[?1049h/l` (l.119-132). `mouse_enabled=` writes all three protocols `\e[?1000h`, `\e[?1002h`, `\e[?1006h` (l.137). `write(data : Bytes)` calls `LibC.write(tty_fd, data, data.size)` — no buffering, partial writes raise (l.95). `close` restores original termios and closes TTY |
+| `src/termisu/reader.cr` | `class Reader` buffered non-blocking input | `@fd`, `@buffer : Bytes (4096)`, `@buffer_pos`, `@buffer_len` (l.13-17). `read_char` blocks via `LibC.poll` no-timeout, refills buffer via `LibC.read` (l.52-74). `read_char_available` uses poll timeout 0. EINTR retried in tight loop (l.63-70). Not thread-safe, but fiber-safe (blocking poll yields) |
+
+### 2.3 Event system
+
+| File | Role | Key types/methods |
+|---|---|---|
+| `src/termisu/event.cr` | `alias Event::Any = Key \| Mouse \| Resize \| Tick \| ModeChange` (l.41) | Module body empty; file requires `./event/*` and `./event/source/*` |
+| `src/termisu/event/key.cr` | `struct Event::Key` | `key : Input::Key`, `modifiers : Input::Modifier`. Predicates: `ctrl?`/`alt?`/`shift?`/`meta?` delegate to modifiers; shorthand `ctrl_c?`/`ctrl_d?`/`ctrl_z?`/`ctrl_q?` (l.71-73); `char : Char?` → `key.to_char` (l.68) |
+| `src/termisu/event/mouse.cr` | `struct Event::Mouse` | Fields: `x`, `y`, `button : Button`, `modifiers`, `motion : Bool`. Nested enum `Button`: None/Left/Middle/Right/WheelUp/WheelDown/WheelLeft/WheelRight/Release/Button4/Button5. `Button.from_cb(cb)` (l.78-100): `WHEEL_BIT=64` bit-6 selects wheel, `BUTTON_MASK=3` low-2 selects button. Predicates `press?`, `wheel?` (l.133, 137) |
+| `src/termisu/event/resize.cr` | `struct Event::Resize` | `width`, `height`, `old_width : Int32?`, `old_height : Int32?`. `changed?` returns true if prev nil or differ (l.43-49) |
+| `src/termisu/event/tick.cr` | `struct Event::Tick` | `elapsed : Time::Span`, `delta : Time::Span`, `frame : UInt64`, `missed_ticks : UInt64 = 0`. Docstring at l.44-46 specifies: SystemTimer reports kernel-level drops + channel backpressure; sleep-based Timer reports only channel backpressure |
+| `src/termisu/event/mode_change.cr` | `struct Event::ModeChange` | `mode : Terminal::Mode`, `previous_mode : Terminal::Mode?`. Predicates: `to_raw?` (l.35), `from_raw?` (l.38-42), `changed?` (l.52-56), `to_user_interactive?` (l.62), `from_user_interactive?` (l.66-70) |
+| `src/termisu/event/source.cr` | Abstract `class Event::Source` | Abstract: `start(Channel(Event::Any))`, `stop`, `running?`, `name`. Protected helpers: `send_nonblocking(output, event) : Bool` using `select/else` (l.82-89), `next_pending_missed(delivered, missed)` for backpressure accounting (l.91-93). Invariant: all impls use `Atomic(Bool)` + `compare_and_set` for idempotent lifecycle |
+| `src/termisu/event/loop.cr` | `class Event::Loop` multiplexer | One shared `Channel(Event::Any)` cap `DEFAULT_BUFFER_SIZE=32` (l.53). `@running : Atomic(Bool)`, `@sources : Array(Source)` (l.58-60). `add_source`: append, if running call `source.start(@output)` — hot-add. `start` CAS-flips then `source.start(@output)` on each (l.116). `stop` CAS-flips, `source.stop` on each, `sleep SHUTDOWN_TIMEOUT_MS/10` + `Fiber.yield`, closes channel. Exposes `getter output : Channel(Any)` (l.177). **Note:** `poll_event` and `each_event` live on the facade, not here — they read from `loop.output` |
+| `src/termisu/event/source/input.cr` | `class Source::Input` | `@running : Atomic(Bool)`, `@reader`, `@parser : Input::Parser`. `start` spawns named fiber `"termisu-input"` running `run_loop`. Loop drains up to `MAX_DRAIN_PER_CYCLE=64` events per cycle via `@parser.poll_event(0)`, each `output.send(event)` is **blocking** — backpressure blocks this fiber. After drain: `Fiber.yield` if emitted, else `sleep IDLE_SLEEP=1ms` (l.99-127). Graceful close on `Channel::ClosedError` |
+| `src/termisu/event/source/resize.cr` | `class Source::Resize` hybrid detector | `Signal::WINCH.trap` handler (l.174-178) flips `@signal_received : Atomic(Bool)` (signal-safe, non-blocking). Poll loop at `DEFAULT_POLL_INTERVAL=100ms` (l.186): `@signal_received.swap(false)`; if signaled skip sleep else `sleep @poll_interval`. Generation counter `@generation : Atomic(Int32)` stales in-flight fibers on stop+restart. `check_and_emit_resize` calls `@size_provider.call` (proc wrapping `backend.size` which `ioctl TIOCGWINSZ`) and compares against `@last_width`/`@last_height`. Stop resets `Signal::WINCH` |
+| `src/termisu/event/source/timer.cr` | `class Source::Timer` sleep-based | `run_loop` (l.118) calls `sleep @interval`; computes `elapsed`, `delta` from monotonic clock; uses `send_nonblocking` (inherited). Channel-full ⇒ `pending_missed += 1` via `next_pending_missed`. `interval=` setter (l.67) takes effect on next sleep. No kernel drop detection |
+| `src/termisu/event/source/system_timer.cr` | `class Source::SystemTimer` kernel-based | Uses `Event::Poller.create` (l.91); `@timer_handle = poller.add_timer(@interval, repeating: true)` (l.93). `run_loop` (l.129) blocks on `poller.wait` (epoll_wait/kevent). Reads `result.timer_expirations` — kernel's count of firings since last read. `missed_ticks = (expirations - 1) + pending_missed` (l.219). `interval=` calls `poller.modify_timer` (live kernel update, l.68-72). Stop-race safety: poller.close makes `poller.wait` raise `IO::Error`; re-raise only if `@running` still true and `wait_token == @run_token` (l.159-166) |
+
+### 2.4 Platform pollers
+
+| File | Role | Key types/methods |
+|---|---|---|
+| `src/termisu/event/poller.cr` | Abstract `class Event::Poller` | Contract: `register_fd(fd, FDEvents) : Nil`, `unregister_fd(fd) : Nil`, `add_timer(Time::Span, repeating : Bool) : TimerHandle`, `modify_timer(TimerHandle, Time::Span) : Nil`, `remove_timer(TimerHandle) : Nil`, `wait : PollResult?`, `wait(Time::Span) : PollResult?`, `close`. Inner types: `FDEvents` (@[Flags] Read\|Write\|Error), `TimerHandle` (opaque UInt64), `PollResult` struct. `Poller.create` (l.189-197) compile-time picks Linux/Kqueue/Poll by OS flag |
+| `src/termisu/event/poller/linux.cr` | `Poller::Linux` (epoll + timerfd) | `{% if flag?(:linux) %}` guard (l.22). `epoll_create1(EPOLL_CLOEXEC)` (l.49). Level-triggered `EPOLLIN` (no ET). `MAX_EVENTS=16` (l.30) but only `events[0]` consumed per wait. Timer: one `timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK\|TFD_CLOEXEC)` per timer, `arm_timerfd` sets it_value + it_interval (kernel auto-rearms for repeating), added to same epoll fd with `EPOLLIN`. `@fd_to_timer : Hash(Int32, UInt64)` maps fd→id. `read_timerfd` reads 8-byte expiration count (l.244) with EINTR/EAGAIN handling. Timeout: `-1` for infinite, else `total_milliseconds.to_i` |
+| `src/termisu/event/poller/kqueue.cr` | `Poller::Kqueue` | `{% if flag?(:darwin) \|\| flag?(:freebsd) \|\| flag?(:openbsd) %}` guard (l.22). `LibC.kqueue` single syscall. `apply_changes` calls `LibC.kevent(@kq, changes, changes.size, nil, 0, nil)` changelist-only (l.274-283), EINTR retried. `EVFILT_READ`/`EVFILT_WRITE` for fds. **Timers use `EVFILT_TIMER` directly — no extra fd**. `EV_ONESHOT` added for non-repeating. Interval passed as ms in `change.data`. Expiration count from `event.data`, clamped to min 1. FreeBSD/OpenBSD require custom bindings from `lib_c/kqueue.cr`; macOS uses stdlib `c/sys/event` |
+| `src/termisu/event/poller/poll.cr` | `Poller::Poll` (fallback) | Always compiled (no guard) — it's the `else` branch. `@fds : Array(System::Poll::Pollfd)`. Flags: `POLLIN`/`POLLOUT` registration; `POLLERR\|POLLNVAL\|POLLHUP` all map to `FDError` (l.309-323). **Software timers**: `TimerState` records `next_deadline : MonotonicTime`. `calculate_timeout` (l.202) = min(user deadline, earliest timer deadline). `check_expired_timers` computes missed expirations via `calculate_expirations` (l.273-278). Repeating: `state.reset` (new deadline = now + interval). EINTR retry subtracts elapsed time from remaining (l.283-298) |
+| `src/termisu/system/poll.cr` | `lib Termisu::System::Poll` | Thin LibC-style bindings: struct `Pollfd {fd, events, revents}`, `alias NfdsT = LibC::ULong`, `fun poll(fds*, nfds, timeout : Int32) : Int32`. Constants POLLIN=0x0001, POLLOUT=0x0004, POLLERR=0x0008, POLLHUP=0x0010, POLLNVAL=0x0020. Scoped to avoid collision with stdlib |
+| `src/termisu/lib_c/kqueue.cr` | `lib LibC` supplement | `{% if flag?(:freebsd) \|\| flag?(:openbsd) %}` only. Adds `fun kqueue : Int32` and `fun kevent(...)` — stdlib omits these on *BSD. macOS uses stdlib `c/sys/event` (kqueue.cr:24) |
+| `src/termisu/time_compat.cr` | Crystal 1.19 polyfill | `compare_versions` macro (l.10): ≥1.19 → `alias MonotonicTime = Time::Instant`, `monotonic_now = Time.instant`; <1.19 → `alias MonotonicTime = Time::Span`, `monotonic_now = Time.monotonic`. Unified callers: `poller/poll.cr`, `event/source/*` |
+
+### 2.5 Input parsing
+
+| File | Role | Key types/methods |
+|---|---|---|
+| `src/termisu/input.cr` | Module loader | `require "./input/*"` |
+| `src/termisu/input/key.cr` | `enum Input::Key` 177 values | All letters as `UpperA..UpperZ` + `LowerA..LowerZ`, `Num0..Num9`, 21 symbol keys (`Backtick` to `Question`), control keys (Space/Tab/Enter/Backspace/Escape), arrows, navigation (Home/End/PageUp/PageDown/Insert/Delete), F1..F24, enhanced-only (CapsLock/ScrollLock/NumLock/PrintScreen/Pause/BackTab/Unknown). Predicates: `letter?` (l.208), `digit?` (l.214), `function_key?` (l.219), `navigation?` (l.224), `printable?` (l.229). Macro-generated `a?..z?` predicates match both cases (l.244-248). `Key.from_char(c)` / `Key#to_char` (l.183, 195). `KeySymbolMaps` (l.254) holds lazy class-var hashes for symbol↔key mapping |
+| `src/termisu/input/modifier.cr` | `@[Flags] enum Modifier : UInt8` | `None=0`, `Shift=1`, `Alt=2`, `Ctrl=4`, `Meta=8` (l.16-31). **No Super/Hyper**. `from_xterm_code(code)` XTerm encoding (l.36): `code = 1 + shift + alt*2 + ctrl*4 + meta*8`. `from_mouse_cb(cb)` mouse Cb encoding with different bit positions (l.52): MOUSE_SHIFT=4, MOUSE_ALT=8, MOUSE_CTRL=16 |
+| `src/termisu/input/parser.cr` | `class Input::Parser` ESC state machine | Entry: `poll_event(timeout_ms = -1) : Event::Any?` (l.118) — `@reader.wait_for_data`, `@reader.read_byte`, dispatch to `parse_byte`. Method-dispatch, not state-enum. See §5 below |
+
+### 2.6 Terminfo
+
+| File | Role | Key types/methods |
+|---|---|---|
+| `src/termisu/terminfo.cr` | `class Terminfo` | Ctor chain (l.42-66): `load_from_database` → `fill_missing_with_builtins` → `cache_frequent_capabilities`. Caches 12 hot caps as instance vars (`@cached_cup`, `@cached_setaf`, l.29-41). `get_cap(name)` = `@caps.fetch(name, "")` (l.97). `process_param_cap(cap, name, *params)` calls `Tparm.process` (l.238, 245). `cursor_position_seq(row, col)` → `process_param_cap(@cached_cup, "cup", row, col)` (l.158) |
+| `src/termisu/terminfo/database.cr` | `class Database` | Search order (l.56-73): `$TERMINFO`, `~/.terminfo`, `$TERMINFO_DIRS` (`:` sep, empty = `/usr/share/terminfo`), `/lib/terminfo`, `/usr/local/share/terminfo`, `/usr/share/terminfo`. `try_path` (l.76) tries two schemes: Unix `<base>/<first-char>/<term>` and Darwin hex `<base>/<hex>/<term>` |
+| `src/termisu/terminfo/parser.cr` | `class Parser` (binary format) | `MAGIC=0o432` (16-bit numbers), `EXTENDED_MAGIC=542` (32-bit numbers) (l.40-41). Header: 12 bytes, 6 × Int16 LE `[magic, names_len, bools_count, nums_count, strings_count, table_size]` (l.210). Booleans section word-aligned (1 pad if `names_len+bools_len` odd). `str_offset = 12 + names_len + bools_len_aligned + number_size * nums_count`; `table_offset = str_offset + 2 * strings_count` (l.221). Strings: offset table of Int16 LE, −1 = absent, else absolute = `table_offset + offset`. Sanity limits: names ≤ 4096, sections ≤ 512 each, table ≤ 65536. Errors: `ParseError` with type enum (InvalidMagic/TruncatedData/InvalidHeader/InvalidOffset/CorruptedString) |
+| `src/termisu/terminfo/capabilities.cr` | 414-entry string-cap order | `STRING_CAPS : Array(String)` in ncurses `term.h` order (l.25-68) — index == binary strings-section index. `@@string_cap_indices : Hash(String, Int32)?` lazy-built (l.134). `REQUIRED_FUNCS` (28 caps) and `REQUIRED_KEYS` (22 caps) narrow extraction to 50 actually-used caps (l.73-120) |
+| `src/termisu/terminfo/builtin.cr` | Hardcoded xterm/linux fallback | Two families: `name.includes?("linux")` picks Linux (l.126), else xterm. Each has `FUNCS[28]` + `KEYS[22]`. `fill_missing_with_builtins` uses `@caps[name] \|\|= builtin` — DB wins (l.91). Linux lacks alternate-screen/keypad; Linux F1-F5 = `\e[[A..\e[[E` (matched by parser's `LINUX_CONSOLE_KEYS`) |
+| `src/termisu/terminfo/tparm.cr` | Entry | `Tparm.process(format, *params)` → `Processor.new(format, [params...]).run` (l.58-67) |
+| `src/termisu/terminfo/tparm/processor.cr` | Stack VM | State: `@format`, `@params : Array(Int64)`, `@stack : Array(Int64)` (cap 8), `@output : IO::Memory` (cap 32), `@pos`. `@@static_storage : Hash(Char, Int64)` shared across calls. Byte scan; `%` → `process_escape` which dispatches via `Operations::BINARY` hash then `dispatch_*` methods (l.57-143) |
+| `src/termisu/terminfo/tparm/operations.cr` | Binary ops | `BINARY : Hash(Char, Proc(Int64, Int64, Int64))` for `+-*/m&\|^=<>AO` (logical AND/OR). Division/mod guard zero. Also: `OUTPUT_OPS`, `VARIABLE_OPS`, `CONSTANT_OPS`, `SPECIAL_OPS` sets (l.24-55) |
+| `src/termisu/terminfo/tparm/conditional.cr` | `%? cond %t then %e else %;` | `process_conditional` (l.9): `skip_to_then` scans evaluating until `%t`, pops result, either `process_branch`+`skip_branch` or inverse. Nesting counter increments on `%?`, decrements on `%;` — `%e` only effective at depth 1 (l.94-113) |
+| `src/termisu/terminfo/tparm/variables.cr` | Parameter + variable ops | `%p1..%p9` (1-indexed, l.7), `%Pa..%Pz` dynamic / `%PA..%PZ` static, `%'c'` (char const → ASCII, l.41), `%{nn}` (scan to `}`, l.49), `%i` (increment params[0]+[1] in place, l.61) |
+| `src/termisu/terminfo/tparm/output.cr` | Output verbs | `%d` (l.14), `%c` (l.7), `%s` (l.19), `%l` (push length, l.24), `%!` (logical not, l.29), `%~` (bitwise not, l.35). All `@[AlwaysInline]` |
+
+### 2.7 FFI / C ABI
+
+| File | Role | Key types/methods |
+|---|---|---|
+| `src/termisu/ffi.cr` | Loader | Loads 15 submodules in order (l.5-22). **Always compiled — no opt-out** |
+| `src/termisu/ffi/version.cr` | `ABI_VERSION = 1_u32` | Exposed via `termisu_abi_version()` |
+| `src/termisu/ffi/status.cr` | `enum Status : Int32` | Ok=0, Timeout=1, InvalidArgument=2, InvalidHandle=3, Rejected=4, Error=5 |
+| `src/termisu/ffi/event_type.cr` | `enum EventType : UInt8` | None=0, Key=1, Mouse=2, Resize=3, Tick=4, ModeChange=5 |
+| `src/termisu/ffi/color_mode.cr` | `enum ColorMode : UInt8` | Default=0, Ansi8=1, Ansi256=2, Rgb=3 |
+| `src/termisu/ffi/abi.cr` | C struct definitions | `Color`, `Event` tagged union, `Size`, `Style`. Relied upon by conversions/exports |
+| `src/termisu/ffi/layout.cr` | Layout signature | FNV-1a hash over `sizeof` + `offsetof` of every ABI field (l.2-51). `signature() : UInt64` (l.45-50) — C caller compares against compile-time constant to detect ABI mismatch |
+| `src/termisu/ffi/context.cr` | `class Context` | Wraps a `::Termisu` plus `@closed : Atomic(Bool)` (l.1-22). `close` uses CAS for idempotency (l.11-20) |
+| `src/termisu/ffi/registry.cr` | Handle table | `@@contexts : Hash(UInt64, Context)`, `@@lock : Mutex`, `@@next_handle : UInt64` (l.2-5). `insert` returns monotonic handle under mutex (l.6-13). `fetch(handle)` mutex-guarded lookup (l.15-17). `delete(handle)` (l.19-21) |
+| `src/termisu/ffi/runtime.cr` | Bootstrap for .so mode | `ensure_initialized` (l.9-36) double-checked with `Atomic(Bool)`. First call: `GC.init`, `Crystal.init_runtime`, `Crystal.main_user_code` (l.22-26). Executable mode marks bootstrapped at startup; shared-library mode must call at every entry point |
+| `src/termisu/ffi/error_state.cr` | Thread-local last error | Uses `Crystal::ThreadLocalValue(String)` (l.4). `current`/`set`/`clear`/`format(ex)` (l.6-22) |
+| `src/termisu/ffi/guards.cr` | Exception shield | `with_error_fallback(fallback) { ... }` catches all, stores `ErrorState.set(format(ex))`, returns fallback (l.14-21). Convenience wrappers: `safe_handle` (fallback 0), `safe_status` (fallback Status::Error), `safe_u8`. **Crystal exceptions never cross FFI boundary** |
+| `src/termisu/ffi/conversions.cr` | Crystal ↔ C | `codepoint_to_char(UInt32) : Char` (l.12-16) raises on invalid Unicode. `color_from_abi(struct) : Color` unpacks ColorMode byte (l.28-41). `attr_from_bits(UInt16) : Attribute` unpacks bitmask (l.43-57). `to_abi_event(Event::Any) : ABI::Event` dispatches per variant (l.59-74); helpers `to_abi_event_key` (76), `_mouse` (85), `_resize` (96), `_tick` (111), `_mode_change` (121). `blank_event` (132-139) zero-inits |
+| `src/termisu/ffi/core.cr` | Crystal-side implementations | `create(sync_updates) : UInt64` (l.2-5), `destroy(handle)` (l.7-14), `close(handle)` (l.16-21), `render` (l.56-61), `set_cell` (l.91-103), plus all other ops. Each uses `with_context(handle) { |ctx| ... }` (l.204-208) to safely look up registered context |
+| `src/termisu/ffi/exports.cr` | 21 `fun termisu_*` symbols | See §9 below for the full surface |
+
+### 2.8 Support modules
+
+| File | Role | Key types/methods |
+|---|---|---|
+| `src/termisu/error.cr` | Exception hierarchy | `Termisu::Error < Exception` (l.2-3). `Termisu::IOError < Error` with `getter errno : Errno` + factory `select_failed`, `read_failed` (l.9-26). `Termisu::ParseError < Error` with `enum Type` (InvalidMagic/TruncatedData/InvalidHeader/InvalidOffset/CorruptedString), `getter type, details` + factories (l.35-80) |
+| `src/termisu/log.cr` | Structured logging | 8 levels: trace/debug/info/notice/warn/error/fatal/none (l.97-106). Env: `TERMISU_LOG_LEVEL` (default debug, l.144), `TERMISU_LOG_FILE` (default `/tmp/termisu.log`, l.154), `TERMISU_LOG_SYNC` (default false, l.162). Async path uses `SafeFileIO` wrapper to swallow post-close writes (l.54-80). `close` yields 3× to drain async queue (l.189-194). 8 component sources: Terminal, Buffer, Reader, Render, Input, Color, Terminfo, Event (l.215-223) |
+| `src/termisu/version.cr` | Compile-time shard.yml parse | Macro reads `shard.yml`, splits on `-` for state, splits numbers on `.`. Exposes `VERSION`, `VERSION_MAJOR`, `VERSION_MINOR`, `VERSION_PATCH`, `VERSION_STATE` (l.8-33) |
+
+---
+
+## 3. Public Crystal API (what user code calls)
+
+### 3.1 Lifecycle
+
+```crystal
+termisu = Termisu.new                        # Raw + alt screen; hides cursor
+# ... do stuff
+termisu.close                                # ALWAYS in ensure; restores termios + screen
+```
+
+Implicit side effects of `Termisu.new` (`termisu.cr:38-72`):
+1. `Terminal.new` — opens /dev/tty, saves termios, loads terminfo for `$TERM`, builds Buffer sized to `ioctl TIOCGWINSZ`
+2. `Reader.new(@terminal.infd)` — 4 KB input buffer
+3. `Input::Parser.new(@reader)` — ESC state machine
+4. `Event::Loop.new` with Source::Input + Source::Resize (Timer opt-in)
+5. `@terminal.enable_raw_mode` — termios clobber
+6. `@event_loop.start` — spawns fibers
+7. `@terminal.enter_alternate_screen` — `\e[?1049h`
+
+### 3.2 Rendering
+
+```crystal
+termisu.set_cell(x, y, 'A', fg: Color.red, bg: Color.black, attr: Attribute::Bold)
+termisu.set_cell(x, y, "東", fg: Color.green)     # wide char (width 2), creates continuation cell
+termisu.clear                                    # fills back buffer with space cells
+termisu.render                                   # diff render (default)
+termisu.sync                                     # force full redraw (use after resize/mode switch)
+```
+
+Performance note: `render` is O(dirty rows × width) in the worst case, but each unchanged cell is skipped and consecutive same-style cells share one SGR emission. `sync` invalidates the front buffer, triggering full re-emit on next `render`.
+
+### 3.3 Cursor
+
+```crystal
+termisu.set_cursor(x, y)           # move
+termisu.hide_cursor                # \e[?25l
+termisu.show_cursor                # \e[?25h
+```
+
+### 3.4 Events
+
+```crystal
+# Blocking
+event = termisu.poll_event
+
+# With timeout (Int ms or Time::Span)
+event = termisu.poll_event(100)
+event = termisu.poll_event(100.milliseconds)
+
+# Non-blocking
+event = termisu.try_poll_event
+
+# Iterator (preferred for animation-free apps)
+termisu.each_event do |event|
+  case event
+  when Termisu::Event::Key
+    break if event.key.escape?
+  when Termisu::Event::Mouse
+    termisu.set_cell(event.x, event.y, '*')
+  when Termisu::Event::Resize
+    termisu.sync
+  when Termisu::Event::Tick
+    update_animation(event.delta)
+  when Termisu::Event::ModeChange
+    # Terminal mode changed (e.g., from suspend)
+  end
+  termisu.render
+end
+```
+
+### 3.5 Timers
+
+```crystal
+termisu.enable_timer(16.milliseconds)        # Sleep-based, portable, jittery
+termisu.enable_system_timer(16.milliseconds) # Kernel: timerfd on Linux, EVFILT_TIMER on BSD, poll deadline elsewhere
+termisu.timer_interval = 8.milliseconds      # Live change
+termisu.disable_timer
+termisu.timer_enabled?
+```
+
+`missed_ticks` meaning on each backend:
+- **Sleep timer:** channel-full drops only (since fiber actually slept the interval)
+- **SystemTimer:** `(kernel_expirations - 1) + channel_drops` — detects when process was too busy to drain the timer fd
+
+### 3.6 Terminal modes
+
+```crystal
+termisu.suspend { system("vim", "file.txt") }   # Cooked + exit alt screen; full restore on block exit
+
+password = termisu.with_password_mode do        # Canonical + no echo
+  print "Password: "
+  gets.try(&.chomp)
+end
+
+char = termisu.with_cbreak_mode do              # Char-by-char + echo + signals
+  STDIN.read_char
+end
+
+custom = Terminal::Mode::Echo | Terminal::Mode::Signals
+termisu.with_mode(custom) { ... }               # Arbitrary bitmask
+
+termisu.raw_mode?                               # => true/false
+termisu.current_mode                            # => Terminal::Mode?
+termisu.alternate_screen?                       # => true/false
+```
+
+Mode switches emit `Event::ModeChange` so you can react in the event loop.
+
+### 3.7 Mouse / keyboard enhancements
+
+```crystal
+termisu.enable_mouse                  # Emits \e[?1000h \e[?1002h \e[?1006h (X10 + button-event + SGR)
+termisu.disable_mouse
+termisu.enable_enhanced_keyboard      # Kitty protocol: distinguishes Tab from Ctrl+I, reports all modifiers
+termisu.disable_enhanced_keyboard
+```
+
+### 3.8 Colors
+
+```crystal
+Color.red                  # ANSI8 index 1
+Color.bright_red           # ANSI8 bright
+Color.ansi256(208)         # ANSI256 index
+Color.rgb(255, 128, 64)    # TrueColor
+Color.from_hex("#FF8040")
+Color.default              # "reset foreground" (SGR 39/49)
+
+color.to_rgb               # downcast/upcast conversions
+color.to_ansi256
+color.to_ansi8
+```
+
+### 3.9 Attributes
+
+```crystal
+Attribute::Bold
+Attribute::Dim
+Attribute::Italic          # aka Cursive
+Attribute::Underline
+Attribute::Blink
+Attribute::Reverse
+Attribute::Hidden
+Attribute::Strikethrough
+combined = Attribute::Bold | Attribute::Underline
+```
+
+### 3.10 Key matching
+
+```crystal
+# Special keys
+event.key.escape?
+event.key.enter?
+event.key.tab?
+event.key.backspace?
+event.key.up?  event.key.down?  event.key.left?  event.key.right?
+event.key.home?  event.key.end?  event.key.page_up?  event.key.page_down?
+event.key.f1?  # ...  event.key.f24?
+
+# Case-insensitive letter matching (macro-generated, matches both UpperX and LowerX)
+event.key.q?
+
+# Case-specific
+event.key.lower_q?
+event.key.upper_q?
+
+# Chars & predicates
+event.key.char           # Char? for printable
+event.key.printable?
+event.key.letter?
+event.key.digit?
+event.key.function_key?
+event.key.navigation?
+
+# Modifiers
+event.ctrl?  event.alt?  event.shift?  event.meta?
+event.ctrl_c?  event.ctrl_d?  event.ctrl_z?  event.ctrl_q?
+```
+
+### 3.11 Custom event sources
+
+Extend `Termisu::Event::Source`:
+
+```crystal
+class MySource < Termisu::Event::Source
+  @running = Atomic(Bool).new(false)
+  @fiber : Fiber?
+  @output : Channel(Termisu::Event::Any)?
+
+  def start(output : Channel(Termisu::Event::Any)) : Nil
+    return unless @running.compare_and_set(false, true)
+    @output = output
+    @fiber = spawn(name: "my-source") do
+      while @running.get
+        # Produce events
+        send_nonblocking(output, some_event)  # inherited helper
+        Fiber.yield
+      end
+    end
+  end
+
+  def stop : Nil
+    return unless @running.compare_and_set(true, false)
+  end
+
+  def running? : Bool
+    @running.get
+  end
+
+  def name : String
+    "MySource"
+  end
+end
+
+termisu.add_event_source(MySource.new)
+```
+
+---
+
+## 4. End-to-end traces
+
+### 4.1 Keypress `A` → user code receives `Event::Key`
+
+1. **Kernel TTY** places byte `0x61` into the tty input queue.
+2. **Source::Input fiber** (`"termisu-input"`) is idle at `sleep 1ms` or just returned from `Fiber.yield`; next iteration calls `@parser.poll_event(0)`.
+3. **Input::Parser#poll_event(0)** calls `@reader.wait_for_data(0)` then `@reader.read_byte` — `Reader` polls and reads `0x61` (with EINTR retry).
+4. **Parser#parse_byte(0x61)** sees printable ASCII, calls `Key.from_char('a')` → `Key::LowerA`, returns `Event::Key.new(LowerA, Modifier::None)`.
+5. **Source::Input** `output.send(event)` — blocking send on `@output : Channel(Event::Any)` (cap 32). Returns immediately since channel has capacity.
+6. **Source::Input** calls `Fiber.yield` (emitted > 0).
+7. **Facade fiber** was blocked on `loop.output.receive` (inside `termisu.poll_event`). Crystal's channel scheduler wakes it.
+8. **`termisu.poll_event`** returns `Event::Key`.
+9. User code pattern-matches `when Termisu::Event::Key`, reads `event.char`, `event.ctrl?`, etc.
+
+### 4.2 Escape `\e[A` → `Event::Key::Up`
+
+1. **Parser** receives `0x1B`, enters `parse_escape_sequence`.
+2. Calls `@reader.wait_for_data(ESCAPE_TIMEOUT_MS=50)`. Byte `[` arrives → peek returns `'['.ord`.
+3. `@reader.read_byte` consumes `[`. Enters `parse_csi_sequence`.
+4. Loop reads `A` (0x41, in 0x40–0x7E final-char range). `buffer=""`, `params=""`, `final='A'`.
+5. `decode_csi_key("", 'A')`: not `'u'`, not `'~'`. Checks `LINUX_CONSOLE_KEYS["[A"]?` — absent. `CSI_KEYS['A']?` → `Key::Up`.
+6. `parse_modifiers("")` → `Modifier::None`.
+7. Returns `Event::Key.new(Up, None)`.
+
+### 4.3 `set_cell(10, 5, 'A', fg: red)` → bytes on TTY
+
+1. **Termisu** facade delegates to `Terminal#set_cell` (l.458).
+2. **Terminal** forwards to `Buffer#set_cell(10, 5, 'A', fg: red, ...)` (`buffer.cr:66`).
+3. `Buffer#set_cell_internal` extracts grapheme `"A"`, width=1, creates `Cell.new(...)`, assigns to `@back[5 * width + 10]` (`buffer.cr:334`), marks row 5 dirty (`buffer.cr:345`), increments `@row_non_default_counts[5]`.
+4. Later, **`termisu.render`** → `Terminal#render` (`terminal.cr:481`) → `Buffer#render_to` (`buffer.cr:227`).
+5. Walks `@dirty_row_list`. For row 5, calls `render_row_diff` (l.394).
+6. Column 10: `@back[5,10] != @front[5,10]`. Finds a batch of consecutive cells with same style. Batch of 1.
+7. `render_batch` → `RenderState#apply_style(fg=red, bg=default, attr=none)` (`render_state.cr:42`). Current state changed. Emits `\e[31m` via `Terminal#foreground=` (`terminal.cr:129-167`).
+8. `renderer.move_cursor(10, 5)` → `Terminal#move_cursor` → `Cursor#move_cursor` (`cursor.cr:79-99`) → `Tparm.process("\e[%i%p1%d;%p2%dH", 5, 10)` → bytes `"\e[6;11H"`.
+9. `renderer.write("A".bytes)` → `Terminal#write` → `Backend#write` → `LibC.write(tty_fd, ...)`.
+10. Front buffer updated: `@front[5,10] = @back[5,10]`. Dirty row flag cleared.
+
+### 4.4 `termisu.suspend { system("vim") }`
+
+1. Facade `suspend` captures current Terminal state.
+2. **Buffer invalidates** (`@front` filled with NUL) — ensures full redraw on resume.
+3. `Backend#apply_mode(Mode::Cooked)` (`backend.cr:142-160`) translates flags: enable `ECHO|ICANON|ISIG|IEXTEN` on c_lflag, `OPOST` on c_oflag; call `@termios.apply!` → `LibC.tcsetattr(fd, TCSANOW, ...)`.
+4. `Backend#alternate_screen=false` writes `\e[?1049l` — user back on main screen.
+5. `Cursor.show_cursor` — otherwise vim's cursor is hidden.
+6. `system("vim")` runs in cooked terminal.
+7. **`ensure` block** executes regardless of outcome:
+   - `Backend#apply_mode(previous_mode)` — back to Raw (usually).
+   - `Backend#alternate_screen=true` writes `\e[?1049h`.
+   - `Buffer.sync` — full re-emit on next render so screen state matches.
+8. Facade emits `Event::ModeChange` so any watcher fiber is notified.
+
+### 4.5 C embedding: `termisu_create → set_cell → render → close`
+
+1. C: `handle_t h = termisu_create(1);`
+2. Exports (`exports.cr:12`) → `Guards.safe_handle` (fallback 0) wraps `Core.create(sync_updates: 1)`.
+3. `Guards.safe_handle` calls `Runtime.ensure_initialized` — first call bootstraps Crystal GC + runtime under `Atomic(Bool)` double-check (`runtime.cr:9-36`).
+4. `Core.create` → `Context.new(::Termisu.new(sync_updates: true))` → `Registry.insert(ctx)` returns monotonic handle under `Mutex`.
+5. Return `UInt64` handle to C.
+6. C: `termisu_set_cell(h, 10, 5, 0x41, &style);`
+7. `Guards.safe_status` (fallback Status::Error) → `Core.set_cell(handle, x, y, codepoint, style_ptr)`.
+8. `with_context(handle) { |ctx| ... }` → `Registry.fetch(h)` mutex-guarded.
+9. `Conversions.codepoint_to_char(0x41)` → `'A'`. `Conversions.style_from_ptr(ptr)` unpacks Color + Attribute.
+10. `ctx.termisu.set_cell(10, 5, 'A', fg: red)`.
+11. Return `Status::Ok`. Any Crystal exception → caught, `ErrorState.set(format(ex))`, return `Status::Error`/`Rejected`.
+12. C: `termisu_render(h);` — same flow, ends in `ctx.termisu.render`.
+13. C: `termisu_close(h);` — `Core.close` → `ctx.close` (CAS-idempotent) → `ctx.termisu.close`. `termisu_destroy(h)` additionally `Registry.delete(h)`.
+14. C on any failure: `termisu_last_error_length()` + `termisu_last_error_copy(buf, len)` retrieves the thread-local message.
+
+---
+
+## 5. Input parser details
+
+`Input::Parser#poll_event(timeout_ms = -1)` (`parser.cr:118`). Not a state enum — method dispatch:
+
+```
+parse_byte(byte):
+  0x1B     → parse_escape_sequence
+  0x00     → Key(Space, Ctrl)
+  0x08/7F  → Backspace
+  0x09     → Tab
+  0x0A/0D  → Enter
+  0x01-1A  → Ctrl+<letter> via Key.from_char
+  printable → Key.from_char
+
+parse_escape_sequence:
+  wait 50 ms:
+    nothing  → Key::Escape
+    '['      → parse_csi_sequence
+    'O'      → parse_ss3_sequence
+    else     → Alt+<key>
+
+parse_csi_sequence:
+  read until final byte 0x40-0x7E
+  prefix '<' → parse_sgr_mouse        (mode 1006)
+  prefix 'M' → parse_normal_mouse     (mode 1000, X10)
+  else       → decode_csi_key(params, final):
+    final 'u'                   → parse_kitty_key  (codepoint;mod[:event_type]u)
+    final '~' with params 27;m;k → parse_modify_other_keys
+    final '~' else              → TILDE_KEYS[code]  (codes 1-34)
+    final A/B/C/D/H/F/Z/P/Q/R/S → CSI_KEYS
+    Linux [[A..[[E              → LINUX_CONSOLE_KEYS
+
+parse_ss3_sequence:
+  read one byte → SS3_KEYS (F1-F4 = PQRS, arrows = ABCD, Home/End = HF)
+
+parse_sgr_mouse:
+  read Cb;Cx;Cy followed by 'M' (press) or 'm' (release)
+  button = Event::Mouse::Button.from_cb(cb)
+  motion = cb & 32
+  modifiers = Modifier.from_mouse_cb(cb)
+
+parse_normal_mouse:
+  read 3 raw bytes, each -= 32
+  Cx/Cy clamped to 1-223
+```
+
+Important non-obvious details:
+- **Alt vs. bare ESC** is disambiguated by a 50 ms timeout (`ESCAPE_TIMEOUT_MS`). This means bare-Escape keypresses have a 50 ms delay.
+- Parser does **not** reassemble UTF-8 multi-byte sequences. Bytes >0x7F hit `Key.from_char` as a single-byte char. Kitty protocol is the Unicode path (numeric codepoint).
+- **modifyOtherKeys** is the `\e[27;m;k~` form; Kitty is the `\e[c;m[:et]u` form. Both use `Modifier.from_xterm_code` for the modifier field.
+- Mouse Cb decoding: `from_cb` checks `cb & 64` for wheel, `cb & 3` for which regular button, press/release determined by the terminating char in SGR mode.
+
+---
+
+## 6. Platform matrix
+
+| Concern | Linux | macOS | FreeBSD/OpenBSD | Other |
+|---|---|---|---|---|
+| Poller | epoll + timerfd | kqueue + EVFILT_TIMER | kqueue + EVFILT_TIMER | poll(2) + software timers |
+| Kqueue bindings | n/a | stdlib `c/sys/event` | `lib_c/kqueue.cr` supplements stdlib | n/a |
+| Max events per wait | 16 | unlimited (changelist) | unlimited | 1 at a time (array scan) |
+| Timer fd per timer | yes (timerfd_create) | no (in-kernel) | no (in-kernel) | no (monotonic deadline in array) |
+| Termios NCCS | 32 | 20 | 20 | runtime check |
+| Time API (< Crystal 1.19) | Time::Span | Time::Span | Time::Span | Time::Span |
+| Time API (≥ Crystal 1.19) | Time::Instant | Time::Instant | Time::Instant | Time::Instant |
+
+Compile-time dispatch (`event/poller.cr:189-197`):
+```crystal
+def self.create : Poller
+  {% if flag?(:linux) %}
+    Poller::Linux.new
+  {% elsif flag?(:darwin) || flag?(:freebsd) || flag?(:openbsd) %}
+    Poller::Kqueue.new
+  {% else %}
+    Poller::Poll.new
+  {% end %}
+end
+```
+
+Each impl file guards its own body, so unused impls are **elided from the binary** — no runtime platform check.
+
+---
+
+## 7. Concurrency model
+
+Termisu uses **Crystal fibers only** (no OS threads for its own work). Coordination is via `Channel(Event::Any)`, `Atomic(Bool)`, `Atomic(Int32)`, and one `Mutex` (FFI registry).
+
+### 7.1 Fiber roster
+
+| Fiber | Spawned by | Blocks on | Lifetime |
+|---|---|---|---|
+| Main | Caller | `channel.receive` inside `termisu.poll_event` | App lifetime |
+| `termisu-input` | `Source::Input#start` | `Input::Parser#poll_event(0)` or `sleep 1ms` | Until `Source::Input#stop` |
+| Resize poll | `Source::Resize#start` | `sleep 100ms` or immediate continue when signal received | Until `stop` (generation increment stales it) |
+| Timer | `Source::Timer#start` | `sleep @interval` | Until `stop` |
+| SystemTimer | `Source::SystemTimer#start` | `poller.wait` (epoll_wait/kevent) | Until `stop` (poller.close unblocks it) |
+
+### 7.2 Atomics in use
+
+- `Atomic(Bool) @running` on every source — CAS for idempotent start/stop
+- `Atomic(Bool) @signal_received` in Resize — set from signal handler (must be non-blocking)
+- `Atomic(Int32) @generation` in Resize — stales in-flight fibers after stop+restart
+- `Atomic(UInt64) @run_token` in SystemTimer — disambiguates shutdown races where `poller.close` raises `IO::Error` in the blocked `wait`
+- `Atomic(Bool) @closed` in FFI Context — CAS for idempotent close
+- `Atomic(Bool)` + double-check in `Runtime.ensure_initialized`
+
+### 7.3 Channel semantics
+
+- **Single shared channel**, cap `DEFAULT_BUFFER_SIZE = 32` (`event/loop.cr:53`).
+- **Input source** uses blocking `send` — if backpressured, the input fiber blocks (events will be accurately queued but delivered late).
+- **Timer sources** use `send_nonblocking` (`event/source.cr:82-89`, implemented via `select/else`). Failed sends increment `pending_missed`, which is surfaced in the next successfully delivered Tick's `missed_ticks`.
+- **Channel close** is the shutdown signal. `loop.stop` closes `@output`; sources exit on `Channel::ClosedError`.
+
+### 7.4 Signal handling
+
+`Signal::WINCH.trap` in `Source::Resize` is the **only** signal handler Termisu installs. Handler does one thing: flip `@signal_received : Atomic(Bool)`. Actual work (ioctl, diff, send) happens in the resize poll fiber which is safe to block.
+
+---
+
+## 8. Rendering pipeline (detail)
+
+### 8.1 Cell layout
+
+```crystal
+struct Cell
+  getter grapheme : String       # single grapheme cluster, or "" for continuation
+  getter width : UInt8           # 0 (combining), 1 (narrow), 2 (wide)
+  getter continuation : Bool     # true for the second slot of a wide-char cell
+  getter fg : Color
+  getter bg : Color
+  getter attr : Attribute
+end
+```
+
+Wide chars occupy two adjacent cells: the leading cell has `width=2, grapheme="東"`, the trailing has `continuation=true, grapheme=""`. Writing a narrow char into either half clears both (overlap handling at `buffer.cr:118-142`).
+
+### 8.2 Diff algorithm
+
+```
+render_to(renderer):
+  for each row_y in @dirty_row_list:
+    render_row_diff(renderer, row_y):
+      x = 0
+      while x < width:
+        if @back[y,x] == @front[y,x]:      # unchanged
+          x += 1; continue
+        if @back[y,x].continuation:        # never render continuations directly
+          x += 1; continue
+        # Start of a change batch
+        batch_start_x = x
+        style = @back[y,x].{fg,bg,attr}
+        while x < width && @back[y,x] != @front[y,x] && @back[y,x].{fg,bg,attr} == style:
+          x += 1
+        render_batch(renderer, y, batch_start_x, x - batch_start_x, style)
+        # Update front buffer for this range
+```
+
+Per batch, `render_batch` does:
+1. `RenderState.apply_style(style)` — emit only SGR deltas.
+2. `renderer.move_cursor(batch_start_x, y)` — terminfo `cup` or `\e[y;xH`.
+3. `renderer.write(grapheme_bytes_of_batch)` — single write call.
+
+### 8.3 RenderState optimization
+
+`RenderState` remembers the last emitted `(fg, bg, attr)`. On `apply_style(new_style)`:
+- If `new_style == current`: emit nothing.
+- Else compute `diff`: if any attribute bit was *removed*, emit `\e[0m` (full reset) then re-enable all active bits and colors. Otherwise emit only the changed components.
+- Updates `current` to `new_style`.
+
+This keeps a full-screen redraw of same-styled content near-optimal: one `\e[0m\e[31m`, then just positioning + text for every cell.
+
+---
+
+## 9. C ABI complete reference
+
+Declared in `src/termisu/ffi/exports.cr` (lines shown). All functions are C calling convention.
+
+### 9.1 ABI metadata
+
+```c
+uint32_t termisu_abi_version(void);              // exports.cr:3-5 — always == 1 in this release
+uint64_t termisu_layout_signature(void);         // exports.cr:7-10 — FNV-1a of struct layouts; compare to header-generated constant
+```
+
+### 9.2 Lifecycle
+
+```c
+uint64_t termisu_create(uint8_t sync_updates);   // exports.cr:12-14 — returns handle or 0 on failure (check last_error)
+int32_t  termisu_destroy(uint64_t handle);       // exports.cr:16-18 — close + remove from registry
+int32_t  termisu_close(uint64_t handle);         // exports.cr:20-22 — close only, handle still valid for last_error_*
+```
+
+### 9.3 Rendering
+
+```c
+int32_t  termisu_clear(uint64_t h);              // exports.cr — status code
+int32_t  termisu_render(uint64_t h);             // diff render
+int32_t  termisu_sync(uint64_t h);               // full redraw
+int32_t  termisu_set_cell(uint64_t h,
+                          int32_t x, int32_t y,
+                          uint32_t codepoint,
+                          termisu_style_t *style); // style is {color fg; color bg; uint16_t attr_bits}
+int32_t  termisu_set_cursor(uint64_t h, int32_t x, int32_t y);
+int32_t  termisu_hide_cursor(uint64_t h);
+int32_t  termisu_show_cursor(uint64_t h);
+int32_t  termisu_size(uint64_t h, termisu_size_t *out);   // writes {int32 width; int32 height}
+```
+
+### 9.4 Events
+
+```c
+int32_t  termisu_poll_event(uint64_t h, int32_t timeout_ms, termisu_event_t *out);
+int32_t  termisu_enable_mouse(uint64_t h);
+int32_t  termisu_disable_mouse(uint64_t h);
+int32_t  termisu_enable_enhanced_keyboard(uint64_t h);
+int32_t  termisu_disable_enhanced_keyboard(uint64_t h);
+int32_t  termisu_enable_timer_ms(uint64_t h, uint32_t interval_ms);
+int32_t  termisu_enable_system_timer_ms(uint64_t h, uint32_t interval_ms);
+int32_t  termisu_disable_timer(uint64_t h);
+```
+
+### 9.5 Error reporting (thread-local)
+
+```c
+uint64_t termisu_last_error_length(void);                             // exports.cr:107
+uint64_t termisu_last_error_copy(uint8_t *buffer, uint64_t buflen);   // exports.cr:112 — returns bytes copied
+void     termisu_clear_error(void);                                   // exports.cr:117
+```
+
+### 9.6 Status codes (`ffi/status.cr`)
+
+| Name | Value | Meaning |
+|---|---|---|
+| Ok | 0 | Success |
+| Timeout | 1 | `poll_event` timed out |
+| InvalidArgument | 2 | Bad coords, null pointer, etc. |
+| InvalidHandle | 3 | Unknown handle |
+| Rejected | 4 | Valid call but refused (e.g., write out of bounds) |
+| Error | 5 | Internal error; see `termisu_last_error_*` |
+
+### 9.7 Struct ABI
+
+C side declares structs matching `ffi/abi.cr`. Crystal verifies layout at FFI-boundary via `termisu_layout_signature()`. C header should include an `assert(termisu_layout_signature() == GENERATED_CONSTANT)` at startup.
+
+---
+
+## 10. Development workflow
+
+### 10.1 Setup
+
+```bash
+shards install
+shards build ameba
+shards build hace
+```
+
+### 10.2 `bin/hace` tasks (`Hacefile.yml`)
+
+| Command | What |
+|---|---|
+| `bin/hace spec` | Run all Crystal specs |
+| `bin/hace format` | Run `crystal tool format` |
+| `bin/hace format:check` | Check formatting without rewriting |
+| `bin/hace ameba` | Run linter |
+| `bin/hace ameba:fix` | Auto-fix lint where possible |
+| `bin/hace all` | format + ameba + spec in parallel |
+| `bin/hace demo` | Run `examples/demo.cr` |
+| `bin/hace showcase` | Run `examples/showcase.cr` |
+| `bin/hace animation` | Timer-driven animation demo |
+| `bin/hace colors` | Color palette showcase |
+| `bin/hace kmd` | Keyboard + mouse demo |
+| `bin/hace modes` | Terminal mode switch demo |
+| `bin/hace bench` | Release-mode benchmarks |
+| `bin/hace bench-quick` | Dev-mode benchmarks (faster compile) |
+| `bin/hace perf` | Linux `perf` CPU profiling |
+| `bin/hace callgrind` | Call-graph profiling |
+| `bin/hace memcheck` | Memory leak detection |
+
+### 10.3 Running a single spec
+
+```bash
+crystal spec spec/termisu/buffer_spec.cr
+crystal spec spec/termisu/buffer_spec.cr:42       # Specific line
+crystal spec --error-trace                         # Full backtrace on failure
+```
+
+### 10.4 Logging
+
+```bash
+TERMISU_LOG_LEVEL=debug      # trace|debug|info|notice|warn|error|fatal|none
+TERMISU_LOG_FILE=/tmp/termisu.log
+TERMISU_LOG_SYNC=true        # sync (real-time debug) vs async (perf)
+```
+
+Watch while running:
+```bash
+tail -f /tmp/termisu.log
+```
+
+Stdout is reserved for rendering — never write user output there.
+
+### 10.5 Commit workflow (`.claude/rules/commit-workflow.md`)
+
+Pre-commit (via `lefthook.yml`): `format:check` + `ameba`. Pre-push: `spec`. Commit subjects use conventional prefix (`feat(scope): subject`, imperative, lowercase after prefix, no trailing period, ≤ 50 chars).
+
+---
+
+## 11. Testing patterns
+
+```
+spec/
+├── spec_helper.cr
+├── support/
+│   ├── mock_renderers.cr   # Record writes for Buffer tests
+│   ├── pipe_helpers.cr     # OS-pipe helpers for Reader/parser tests
+│   └── mock_sources.cr     # Fake event sources
+├── shared/                  # Shared examples
+└── termisu/                 # Mirrors src/termisu structure
+    ├── buffer_spec.cr
+    ├── input/
+    ├── event/
+    ├── terminal/
+    ├── terminfo/
+    └── ffi/
+```
+
+Canonical patterns:
+- **Renderer tests**: inject a `CaptureRenderer` (writes to `IO::Memory`), inspect emitted bytes.
+- **Reader/parser tests**: write to a pipe, feed the read end into the parser, assert events.
+- **Source tests**: mock the shared channel, start source, assert sends/timings.
+- **Mode tests**: use `CaptureTerminal`, ensure `close` restores termios even on exception.
+
+---
+
+## 12. Common pitfalls & design notes
+
+1. **Always `ensure termisu.close`.** Without it, termios is left in raw mode and the terminal becomes unusable on crash.
+2. **Never mix `gets`/`STDIN.read_char` with raw mode.** In raw mode use `termisu.poll_event`; use normal IO only inside `termisu.suspend { }` or `with_cbreak_mode { }`.
+3. **Sync after every resize.** `Event::Resize` → call `termisu.sync` because the cell grid changed dimensions and the front buffer may be a lie.
+4. **Bare-Escape keypress has 50 ms latency.** This is fundamental to Alt/ESC disambiguation. No way around it without enhanced keyboard protocol.
+5. **Wide-char continuation cells are not writable directly.** The `set_cell_internal` path rejects or re-assigns them.
+6. **Sleep timer drift.** Fibers scheduled cooperatively; if another fiber runs long, the timer fires late. Use `enable_system_timer` for precise animation.
+7. **`missed_ticks` means different things** per timer backend — sleep only reports channel drops, system timer reports both channel + kernel drops.
+8. **Backpressure blocks input.** If you stop calling `poll_event`, the Source::Input fiber blocks on `send` and input accumulates in the 4 KB reader buffer; eventually the TTY backs up and types are lost.
+9. **SIGWINCH alone is unreliable** across modes/ttys. The hybrid 100 ms poll catches missed signals.
+10. **Crystal 1.19 Time::Instant renamed `Time::Span` usage.** `time_compat.cr` polyfills — don't hardcode either type; use `alias MonotonicTime`.
+11. **FFI registry is the only Mutex.** All other coordination is atomics + channels. Hot paths don't acquire it.
+12. **FFI layer is always compiled** — no way to opt out at compile time. If this ever becomes an issue, `ffi.cr` would need a `{% if flag?(:ffi) %}` guard.
+13. **Builtin terminfo has only xterm + linux.** If `$TERM` doesn't match and no terminfo file is found, you get xterm sequences by default.
+14. **Parser doesn't reassemble UTF-8.** Multi-byte characters come through as `Key.from_char(single_byte)`. Kitty protocol is the numeric-codepoint path.
+
+---
+
+## 13. Extension points
+
+1. **New event source** — Extend `Event::Source`, call `termisu.add_event_source(src)`. Contract: `start(Channel)`, `stop`, `running?`, `name`, idempotent via `Atomic(Bool)` CAS.
+2. **New color mode** — Unlikely; `Color` enum is fixed. Would need changes to `Color` struct, `Conversions`, `Terminal#foreground=`.
+3. **New attribute** — Add to `Attribute` enum (respect `@[Flags]`), add SGR emitter in `Terminal`.
+4. **New key** — Add to `Input::Key` enum, update `KeySymbolMaps` if it has a printable form, update parser tables (`CSI_KEYS`, `TILDE_KEYS`, etc.).
+5. **New terminfo capability** — Add to `STRING_CAPS` (must match ncurses order), add to `REQUIRED_FUNCS`/`REQUIRED_KEYS`, expose getter on `Terminfo`.
+6. **Custom renderer (for tests)** — Subclass abstract `Renderer` (`renderer.cr`), implement writes/moves/style setters; pass to `Buffer#render_to(my_renderer)`.
+7. **New FFI export** — Add `fun termisu_foo(...)` in `exports.cr`, wrap body with `Guards.safe_status`/`safe_handle`, implement in `core.cr`, add any needed conversions to `conversions.cr`. Update `layout.cr` if new struct fields introduced.
+
+---
+
+## 14. File structure overview
+
+```
+termisu/
+├── src/                               # 71 Crystal files
+│   ├── termisu.cr                     # Loader
+│   └── termisu/
+│       ├── termisu.cr                 # Facade
+│       ├── version.cr                 # VERSION from shard.yml
+│       ├── terminal.cr
+│       ├── buffer.cr
+│       ├── cell.cr
+│       ├── renderer.cr
+│       ├── render_state.cr
+│       ├── unicode_width.cr
+│       ├── color.cr + color/*.cr
+│       ├── attribute.cr
+│       ├── reader.cr
+│       ├── tty.cr
+│       ├── termios.cr
+│       ├── time_compat.cr
+│       ├── error.cr
+│       ├── log.cr
+│       ├── terminal/{backend,cursor,mode}.cr
+│       ├── input.cr + input/{key,modifier,parser}.cr
+│       ├── event.cr + event/*.cr + event/source/*.cr + event/poller*.cr
+│       ├── terminfo.cr + terminfo/*.cr + terminfo/tparm*.cr
+│       ├── system/poll.cr
+│       ├── lib_c/kqueue.cr
+│       └── ffi.cr + ffi/*.cr          # C ABI (15 files)
+│
+├── spec/termisu/                      # 54 spec files, mirrors src/
+├── spec/support/                      # Mock renderers, pipe helpers, mock sources
+├── examples/                          # demo, showcase, animation, colors, kmd, simple + c/basic.c
+├── bench/                             # bench_runner.cr + suites/ (buffer, parser, color)
+├── docs/ docs-web/                    # Architecture docs
+├── e2e/                               # TypeScript end-to-end harness
+├── javascript/                        # JS platform glue
+├── bin/hace                           # Task runner executable
+├── shard.yml                          # Dependencies + version
+├── Hacefile.yml                       # Dev task definitions
+├── .ameba.yml                         # Linter config
+├── lefthook.yml                       # Pre-commit/push hooks
+├── PROJECT_INDEX.md                   # Human-readable overview
+├── CLAUDE.md                          # This file's companion for Claude Code
+├── .claude/                           # Skills, rules, agents for Claude Code
+└── llms.txt                           # This file
+```
+
+---
+
+## 15. Quick checklists
+
+### Building a simple TUI
+1. `termisu = Termisu.new` (inside `begin`)
+2. Loop on `termisu.poll_event`, pattern-match event types
+3. Draw with `set_cell`, call `render` each iteration
+4. `break` on escape key
+5. `termisu.close` in `ensure`
+
+### Adding animation
+1. `termisu.enable_system_timer(16.milliseconds)` (prefer system over sleep for smooth 60 FPS)
+2. Handle `Event::Tick` in the event loop, use `event.delta` for physics
+3. Check `event.missed_ticks` and compensate if non-zero
+
+### Shell-out to external program
+1. `termisu.suspend { system("vim", file) }`
+2. Rely on the ensure block inside `suspend` for restore — don't manually change modes
+
+### C embedding
+1. `#include` the generated header
+2. Call `termisu_layout_signature()` once; `assert()` against build-time constant
+3. On every return that isn't `Status::Ok`, read `termisu_last_error_length` + `_copy`
+4. `termisu_destroy(h)` before process exit
+
+---
+
+## 16. Invariants to preserve when modifying
+
+- **`set_cell` is synchronous** (no fiber yield). Callers rely on this to batch updates before rendering.
+- **`render` emits nothing** if no cells changed since last render.
+- **`close` is idempotent.** Calling twice must not corrupt termios.
+- **Event sources use `compare_and_set`** for start/stop. Never set the running flag directly.
+- **Signal handlers never block.** Only flip atomics; do real work in a fiber.
+- **FFI guards must wrap every export.** A raw Crystal exception across the FFI boundary is undefined behavior.
+- **Wide chars always come in pairs** — leading + continuation. Buffer invariants enforce this.
+- **RenderState resets** when the buffer is invalidated or the terminal clears. Failing to reset causes wrong colors after the next draw.
+- **Compile-time platform dispatch** is elision; don't add runtime `if flag?(:linux)` checks.
+
+---
+
+End of llms.txt. If you're an LLM ingesting this file for code tasks on Termisu: the most common entry points you'll modify are `terminal.cr`, `buffer.cr`, `event/source/*.cr`, and `input/parser.cr`. Always cite `file:line` when referencing behavior. Before claiming "this doesn't exist" — verify by reading the file, not just grep.

--- a/spec/termisu/ffi_spec.cr
+++ b/spec/termisu/ffi_spec.cr
@@ -188,6 +188,26 @@ describe "Termisu C ABI" do
       termisu_enable_enhanced_keyboard(handle).should eq(Termisu::FFI::Status::Ok.value)
       termisu_disable_enhanced_keyboard(handle).should eq(Termisu::FFI::Status::Ok.value)
 
+      # The three input modes and their queries. Without the queries a C or JS
+      # caller can toggle a mode but never ask whether it is on, and shadowing the
+      # state locally drifts the moment with_mode suspends and restores it.
+      termisu_mouse_enabled(handle).should eq(0_u8)
+      termisu_enable_mouse(handle).should eq(Termisu::FFI::Status::Ok.value)
+      termisu_mouse_enabled(handle).should eq(1_u8)
+      termisu_disable_mouse(handle).should eq(Termisu::FFI::Status::Ok.value)
+      termisu_mouse_enabled(handle).should eq(0_u8)
+
+      termisu_enhanced_keyboard(handle).should eq(0_u8)
+      termisu_enable_enhanced_keyboard(handle).should eq(Termisu::FFI::Status::Ok.value)
+      termisu_enhanced_keyboard(handle).should eq(1_u8)
+      termisu_disable_enhanced_keyboard(handle).should eq(Termisu::FFI::Status::Ok.value)
+
+      termisu_bracketed_paste(handle).should eq(0_u8)
+      termisu_enable_bracketed_paste(handle).should eq(Termisu::FFI::Status::Ok.value)
+      termisu_bracketed_paste(handle).should eq(1_u8)
+      termisu_disable_bracketed_paste(handle).should eq(Termisu::FFI::Status::Ok.value)
+      termisu_bracketed_paste(handle).should eq(0_u8)
+
       event = uninitialized Termisu::FFI::ABI::Event
       poll_status = termisu_poll_event(handle, 0, pointerof(event))
       valid_poll = [Termisu::FFI::Status::Ok.value, Termisu::FFI::Status::Timeout.value]

--- a/src/termisu/ffi/core.cr
+++ b/src/termisu/ffi/core.cr
@@ -186,6 +186,41 @@ module Termisu::FFI
     end
   end
 
+  def self.enable_bracketed_paste(handle : UInt64) : Status
+    with_context(handle) do |context|
+      context.termisu.enable_bracketed_paste
+      Status::Ok
+    end
+  end
+
+  def self.disable_bracketed_paste(handle : UInt64) : Status
+    with_context(handle) do |context|
+      context.termisu.disable_bracketed_paste
+      Status::Ok
+    end
+  end
+
+  # Query counterparts for the three input modes. Without these a C or JS caller
+  # can toggle a mode but never ask whether it is on, and has to shadow the state
+  # itself — which desynchronizes the moment `with_mode` suspends and restores.
+  def self.mouse_enabled?(handle : UInt64) : UInt8
+    with_context_u8(handle) do |context|
+      context.termisu.mouse_enabled? ? 1_u8 : 0_u8
+    end
+  end
+
+  def self.enhanced_keyboard?(handle : UInt64) : UInt8
+    with_context_u8(handle) do |context|
+      context.termisu.enhanced_keyboard? ? 1_u8 : 0_u8
+    end
+  end
+
+  def self.bracketed_paste?(handle : UInt64) : UInt8
+    with_context_u8(handle) do |context|
+      context.termisu.bracketed_paste? ? 1_u8 : 0_u8
+    end
+  end
+
   def self.poll_event(handle : UInt64, timeout_ms : Int32, out_event : ABI::Event*) : Status
     return invalid_argument_status("out_event is null") if out_event.null?
 

--- a/src/termisu/ffi/exports.cr
+++ b/src/termisu/ffi/exports.cr
@@ -103,6 +103,26 @@ fun termisu_disable_enhanced_keyboard(handle : UInt64) : Int32
   Termisu::FFI::Guards.safe_status { Termisu::FFI.disable_enhanced_keyboard(handle) }
 end
 
+fun termisu_enable_bracketed_paste(handle : UInt64) : Int32
+  Termisu::FFI::Guards.safe_status { Termisu::FFI.enable_bracketed_paste(handle) }
+end
+
+fun termisu_disable_bracketed_paste(handle : UInt64) : Int32
+  Termisu::FFI::Guards.safe_status { Termisu::FFI.disable_bracketed_paste(handle) }
+end
+
+fun termisu_mouse_enabled(handle : UInt64) : UInt8
+  Termisu::FFI::Guards.safe_u8 { Termisu::FFI.mouse_enabled?(handle) }
+end
+
+fun termisu_enhanced_keyboard(handle : UInt64) : UInt8
+  Termisu::FFI::Guards.safe_u8 { Termisu::FFI.enhanced_keyboard?(handle) }
+end
+
+fun termisu_bracketed_paste(handle : UInt64) : UInt8
+  Termisu::FFI::Guards.safe_u8 { Termisu::FFI.bracketed_paste?(handle) }
+end
+
 fun termisu_poll_event(
   handle : UInt64,
   timeout_ms : Int32,

--- a/src/termisu/input/parser.cr
+++ b/src/termisu/input/parser.cr
@@ -365,7 +365,12 @@ class Termisu::Input::Parser
   private def ms_until(deadline : MonotonicTime?) : Int32
     return 0 unless deadline
     remaining = (deadline - monotonic_now).total_milliseconds
-    remaining <= 0 ? 0 : remaining.ceil.to_i
+    return 0 if remaining <= 0
+
+    # Truncate and add one rather than `ceil`: rounding a live deadline down to a
+    # 0ms wait would spin, and `Float#ceil` is the only thing in the library that
+    # pulls in libm — which the C ABI test links without `-lm`.
+    remaining.to_i + 1
   end
 
   private def parse_escape_sequence : Event::Any

--- a/thoughts/CODE_REVIEW_2026-05.md
+++ b/thoughts/CODE_REVIEW_2026-05.md
@@ -1,0 +1,224 @@
+# Termisu Crystal Codebase Review — 2026-05-30
+
+Full review of all 71 `src/**/*.cr` files (~10,628 lines) via 8 parallel subsystem
+reviewers, each reading every file in its area. Headline findings independently
+re-verified by direct read + `crystal eval`. Severities reflect verification, not
+the raw reviewer claim. Cross-referenced against `KNOWN_ISSUES.md`; **NEW** marks
+findings not in that backlog.
+
+Verification legend: ✅ verified by me · ☑ reviewer ran a repro · ◻ plausible, unverified.
+
+---
+
+## CRITICAL
+
+### C1 — No UTF-8 multibyte decode; all non-ASCII text input is mangled ✅ NEW
+`src/termisu/input/parser.cr:160,187,200` (also 154). The byte→char path is
+`Key.from_char(byte.chr)` on a single `UInt8`. Verified: `0xC3_u8.chr` → U+00C3
+(Latin-1), `0xE9_u8.chr` → 233 — `UInt8#chr` is a raw Latin-1 map, never a UTF-8
+decode. Typing `é` (UTF-8 `C3 A9`) emits two bogus `Key::Unknown` events; every
+BMP/emoji char is shredded into 2–4 garbage events. No lead-byte detection, no
+continuation-byte read loop. For a library that advertises Unicode/wide-char
+*rendering*, raw text *entry* of any non-ASCII char is broken. Fix: in the `else`
+branch detect a UTF-8 lead byte (0xC0/0xE0/0xF0 masks), read 1–3 continuation
+bytes through the reader (same split-read timeout strategy as C2), assemble +
+validate the codepoint, emit one key event. Interacts with C2 (continuation
+bytes can straddle `read()` boundaries) — solve both with one
+`next_byte_within(timeout)` primitive.
+
+---
+
+## HIGH
+
+### H1 — `Termisu#close` is not exception-safe: a raise skips terminal restoration ✅ (rel. TERMISU-001)
+`src/termisu.cr:84-96`. The four teardown steps (`@event_loop.stop`,
+`@reader.close`, `@terminal.close`, `Logging.*`) run as bare sequential
+statements with no `ensure`. If `@event_loop.stop` (joins fibers, sends on
+channels) or `@reader.close` raises, `@terminal.close` never runs — user is left
+in raw mode + alternate screen + mouse tracking on = unusable shell. Terminal
+restoration is the one hard guarantee a TUI library must keep. Same pattern in
+`terminal.cr` close (the cosmetic `disable_mouse`/`exit_alternate_screen` writes
+flush to the TTY first; if that write fails on SIGHUP/disconnect, `disable_raw_mode`
++ `@backend.close` never run → fd leak + raw termios). Fix: put termios restore +
+fd close in `ensure` so they always run.
+
+### H2 — Split escape/mouse sequences silently corrupt input ✅ NEW (broader than TERMISU-013)
+`src/termisu/input/parser.cr:199,363,388,433-435` + `reader.cr:284-288`.
+Only the top-level ESC disambiguation calls `wait_for_data` (parser.cr:168). Once
+inside a CSI/SS3/SGR-mouse/normal-mouse body, continuation bytes are fetched with
+bare `@reader.read_byte`, no wait. `fill_buffer` treats `EAGAIN` as "no data" →
+`read_byte` returns `nil`. If a sequence splits across two `read()`s (9600 baud,
+SSH, paste under load — the 128-byte buffer makes whole-sequence delivery *likely*
+but never *guaranteed*), `parse_csi_sequence` returns `Key::Unknown` and the tail
+(`2 0 0 ~`) is reparsed as 4 stray keystrokes; `parse_normal_mouse` loses sync.
+Timing-dependent, intermittent. Fix: route every mid-sequence fetch through a
+helper that, on `nil`, does `wait_for_data(ESCAPE_TIMEOUT_MS)` and retries once.
+
+### H3 — FFI use-after-free: handle lock released before the call runs ✅ NEW (supersedes TERMISU-001)
+`src/termisu/ffi/core.cr:203-208` + `registry.cr:7,16,20`. `with_context` does
+`context = Registry.fetch(handle)` (acquires lock, returns context, **releases
+lock**) then `yield context` lock-free. A concurrent `termisu_destroy(h)` on
+another thread `context.close`s (tears down reader/terminal/TTY fds) +
+`Registry.delete`s while the first thread is mid-`render`/`set_cell` → write to a
+closed TTY / freed state. `poll_event` is worst: it blocks in
+`@event_loop.output.receive` holding the context, and a `destroy` stops the loop
+underneath it. The thread-local error state implies multi-thread use is expected,
+but no "one thread per handle" contract is documented/enforced. Fix: hold a
+per-context lock (or refcount "in use" flag) for the call duration and make
+`destroy` no-op/fail while a call is in flight — or document+enforce
+single-thread-per-handle.
+
+### H4 — FFI `Context#close` rolls back `@closed` on exception → raw-fd double-close ✅ (TERMISU-001, deeper)
+`src/termisu/ffi/context.cr:11-20` → `tty.cr:62-65`. `close` does
+`compare_and_set(false,true)` then on exception rolls `@closed` back to `false`.
+`::Termisu#close` is not idempotent, so a retried `destroy` re-runs the whole
+teardown. On Linux `TTY#close_input_fd` does `LibC.close(@in.as(Int32))` with no
+guard; `@in` is a raw fd → second teardown re-issues `close(2)` on that integer =
+classic fd-reuse double-close (closes whatever fd got that number meanwhile). Fix:
+make close idempotent (set `@in = -1` after close, skip if `< 0`); treat close as
+terminal even if it raises.
+
+### H5 — Terminfo string-offset arithmetic overflows Int16 → unhandled crash on crafted file ☑ NEW
+`src/termisu/terminfo/parser.cr:254` (also 177, 221-234). `read_string_at` does
+`string_pos = (table_start + offset).to_i` — both operands are Int16, added *as
+Int16* before widening. Reviewer confirmed via `crystal eval` that Crystal raises
+`OverflowError` (does not wrap). Terminfo files are UNTRUSTED external input
+(`$TERMINFO`, `~/.terminfo`). A positive `offset` near Int16::MAX overflows before
+the `>= @data.size` bounds check can run; `OverflowError` escapes `parse?` (which
+rescues only `ParseError`). DoS on attacker-placed terminfo. Fix: widen first —
+`table_start.to_i32 + offset.to_i32` — then the existing bounds check catches it
+and raises proper `ParseError`. (Note: TERMISU-014's "OOB read past buffer" is
+actually *false* — `IO::Memory#read_byte` returns nil at EOF; the real
+memory-safety severity belongs here at :254, and TERMISU-014's NUL-scan is only a
+LOW "silent truncation".)
+
+### H6 — Pollers process only `events[0]`, dropping the rest of each ready batch ✅ NEW
+`src/termisu/event/poller/linux.cr:196` + `kqueue.cr:197`. Both declare a
+16-slot event array, request up to 16 from `epoll_wait`/`kevent`, then handle
+`events[0]` and `return`. When `n > 1` (e.g. input fd + resize self-pipe both
+ready in one wakeup), the others are dropped that cycle. Level-triggered epoll
+re-reports next `wait` (latency/fairness bug); kqueue edge cases can genuinely
+drop. Defeats the point of the batch and starves fds under load. Fix: iterate
+`events[0...n]`, buffer extras in a small queue served before the next syscall.
+
+### H7 — Event-loop shutdown closes the channel under possibly-blocked producers; no fiber joins ✅ NEW (broader than TERMISU-009)
+`src/termisu/event/loop.cr:143-162`. `stop` flips `@running=false`, sleeps 10ms,
+yields once, then `@output.close` — never joins any source fiber. `Source::Input`
+uses a **blocking** `output.send` (input.cr:111); a stalled consumer parks it
+inside `send`, which the flag-flip can't wake, so close races a blocked producer
+(rescued, so contained today, but structurally fragile). `Source::Resize`
+(resize.cr:236) also blocking-sends and **has no `rescue Channel::ClosedError`** —
+an unhandled fiber exception prints to STDERR (the render channel). Fix: make every
+source's blocking point interruptible (the `send_nonblocking`+drop-counter the two
+timers already use) and have `stop` join each source fiber before `@output.close`.
+
+### H8 — `Color.rgb(Int,…)` raises raw `OverflowError` instead of `ArgumentError`; no `validate_rgb` ✅ NEW
+`src/termisu/color.cr:84-86`. `r.to_u8`/`g.to_u8`/`b.to_u8` with no validation;
+`300.to_u8` and `(-1).to_u8` both raise `OverflowError`, not the library's
+`ArgumentError`. Every other public constructor (`ansi8`/`ansi256`/`grayscale`/
+`from_hex`) validates. `from_hex` is safe (hex bytes ≤255). Fix: add
+`Validator.validate_rgb` (0..255) called before `to_u8`. (FFI path is safe — ABI
+already passes UInt8.)
+
+---
+
+## MEDIUM (selected; full list in per-subsystem notes)
+
+- **M1 — `RenderState#reset` then `apply_style(attr: None)` emits no `\e[0m`** ✅ (TERMISU-004).
+  `render_state.cr:73-75,51-54`. `default_state` returns `Attribute::None` (not a
+  `nil` sentinel like fg/bg), so after `reset`/`sync`/`suspend{vim}` a terminal left
+  bold/italic bleeds into the first cell. Fix: `@attr : Attribute?`, nil post-reset.
+- **M2 — VTIME written to wrong `c_cc` index on Linux** ✅ NEW (reviewer said CRITICAL+both;
+  reality: only VTIME). `termios.cr:24-25,112`. Stdlib defines `LibC::VMIN`=6
+  (correct) but **not** `LibC::VTIME`, so the fallback `VTIME = 17` (a BSD value) is
+  used; line 112 writes to `c_cc[17]` (reserved slot) instead of `c_cc[5]`. Masked
+  because inherited VTIME is usually 0, so raw-mode VMIN=1/VTIME=0 happens to hold.
+  Fix: define per-platform (Linux VTIME=5, BSD/Darwin 17).
+- **M3 — `rgb_to_ansi256` maps pure black/white to near-black/near-white grays** ☑ NEW.
+  `color/conversions.cr:42-54,99-105`. All `r==g==b` route to the 24-step gray ramp
+  (never compares cube distance); `(0,0,0)`→232 (RGB 8) not cube 16; `(255,255,255)`→
+  255 (RGB ~238) not cube 231. Plus grayscale index truncates (floor), biasing dark.
+  Fix: compute cube + gray candidates, pick min Euclidean distance; `round` not floor.
+- **M4 — `with_mode` restoration emits an inverted `ModeChange` and can re-enter alt screen
+  after a partial failure** ✅ NEW. `terminal.cr:341-374` + `termisu.cr:598-604`. The
+  facade ensure reads `restored_mode` *after* the backend ensure already restored, so
+  the event reports `previous_mode: <block's mode>` (inverted). Fix: guard restoration
+  on a "did we switch" flag; fix event arg order.
+- **M5 — FFI bad codepoint/color routed to generic `Status::Error` via throw-and-catch** ✅
+  (TERMISU-010, refined). `ffi/core.cr:91-103`, `conversions.cr:39`. No UB (validated
+  + caught), but C callers can't distinguish "bad input" from "internal panic", and a
+  hot loop pays exception-unwind per cell. Fix: cheap pre-validation returning
+  `InvalidArgument`/`Rejected`.
+- **M6 — SystemTimer `stop` closes poller fds under a blocked `poller.wait`** ◻ NEW.
+  `event/source/system_timer.cr:103-114`. Use-after-close on raw fds guarded only by a
+  hand-rolled run-token race. Fix: self-pipe/eventfd wake instead of close-under.
+- **M7 — `kqueue.cr:201,240` `event.data.to_u64` raises on negative signed data**;
+  **`kqueue.cr:195` blocking wait returns nil on spurious `n==0`** (treated as shutdown);
+  **`linux.cr:82-91` `unregister_fd` tolerates ENOENT but not EBADF** → raises during
+  teardown if fd closed first. ✅ NEW (poller layer).
+- **M8 — Terminfo `%c` (`output.cr:7-8`) raises/ emits invalid UTF-8** on out-of-Int32 or
+  >0x10FFFF values from untrusted string caps. ☑ NEW. Fix: clamp to byte/codepoint.
+- **M9 — `$TERM` flows unsanitized into `File.join`** (`terminfo/database.cr:78,85`) — path
+  traversal, LOW real risk (user's own env, read-only, magic-checked). = TERMISU-035.
+
+---
+
+## Confirmed-from-KNOWN_ISSUES (still valid, re-verified)
+
+- **TERMISU-002 / 011 — per-cell + per-batch String allocation in the render hot path** ✅.
+  `buffer.cr:473` `@batch_buffer.to_s` (one String/style-run), `cell.cr:101`
+  `each_grapheme.first.to_s`, `buffer.cr:103` `ch.to_s`. A full-screen ASCII redraw
+  allocates ~2–3 Strings/changed cell/frame. The stated "zero-allocation steady state"
+  is not met. Fix: ASCII fast-path in `grapheme=`/`UnicodeWidth.grapheme_width`; a
+  renderer `write` that consumes the `IO::Memory` directly.
+- **TERMISU-008 / 017 — facade + terminal.cr god-objects** ✅ (facade also does mode
+  orchestration: `pause/resume_input_processing` reaches into source/reader/loop).
+- **TERMISU-003 / 007 / 020 — double SGR cache (RenderState + Terminal `@cached_*`),
+  18-method Renderer, 2×8 `includes?` per attr change** ✅. Best fixed as one bundle.
+- **TERMISU-015 / 022 — `Color.ansi8(-1)` accepted; `Color::Mode` lacks `Default` (FFI
+  ColorMode has it)** ✅. Root cause of 3 findings; promote `Default` to a real Mode.
+- **TERMISU-019 — `split(';')` per special key** ✅, and **mouse motion is the real hot
+  path** (per-event in `parse_sgr_params_to_event`), undersold by the ticket.
+- **TERMISU-024 / 025 — Cell fuses display + grid-occupancy; NUL-as-empty contract** ✅.
+
+---
+
+## New HIGH not in KNOWN_ISSUES — render-batch continuation edge ◻
+`buffer.cr:457-471`. If a wide leading cell is unchanged (`==`) but its continuation
+partner is inconsistent, the batch break-then-reenter can land `render_row_batch` on a
+continuation cell as `first_cell`, emitting a stray `move_cursor` with no write
+(`chars.empty?` guard). Invariants are assumed but never asserted on the render path.
+Reviewer flagged "verify with a test that flips a single continuation cell's `==`
+state" — not independently confirmed; treat as a robustness/assert-the-invariant item.
+
+---
+
+## Architectural themes (recurring across subsystems)
+
+1. **Shutdown is timing-based, not signal-based.** Loop stop, SystemTimer stop, and
+   close paths all flip a flag + sleep + hope, instead of *waking* blocked producers
+   and *joining* fibers. Root of H1, H4, H7, M6. One design move (interruptible blocking
+   points + bounded joins) closes the whole family.
+2. **Exception-as-validation at the FFI + Color boundary.** Bad input throws-and-catches
+   (H3-adjacent, H8, M5). A thin pre-validation layer returning typed statuses is faster
+   and more diagnosable; leave `Guards` to catch true bugs.
+3. **Int16-everywhere terminfo offset math** (H5) — the validator already widened to Int32
+   at parser.cr:162; the rest should follow rather than rely on `MAX_*` caps staying < 32767.
+4. **The `-1` default-color sentinel** spawns 3 findings (H8-adjacent, M9, FFI asymmetry).
+   First-class `Color::DEFAULT` / `Mode::Default` collapses them.
+5. **`Source` abstract class copy-pastes Atomic+CAS+spawn+rescue** 4× — and the one that
+   diverged (resize, no rescue) is exactly H7's bug. Template-method base would make the
+   rescue + future `join` structural.
+
+---
+
+## Suggested fix order (impact × effort)
+
+1. **C1** UTF-8 decode + **H2** split-sequence wait — one shared `next_byte_within` primitive. (correctness of all input)
+2. **H1/H4** idempotent + ensure-wrapped close (raw-fd guard) — the library's core guarantee.
+3. **H5** terminfo Int16→Int32 offsets — untrusted-input DoS, ~3 line fix.
+4. **H3** FFI handle lifetime (per-context lock / in-use flag) — C-ABI memory safety.
+5. **H7/M6** event-loop join + interruptible sends — shutdown race family.
+6. **H6** poller drain-all-events.
+7. **M1** RenderState attr sentinel, **H8/M3** color validation + nearest-neighbor.
+8. Perf bundle: TERMISU-002/011/003/007/020 (allocation + double SGR cache).

--- a/thoughts/plans/internal-poll-binding-compatibility.md
+++ b/thoughts/plans/internal-poll-binding-compatibility.md
@@ -1,0 +1,150 @@
+# Internal Poll Binding Compatibility Plan
+
+## Goal
+
+Stop patching global `LibC` for `poll(2)` support so Termisu can coexist with shards like `systemd.cr` that define the same missing bindings.
+
+## Context
+
+- Current collision points:
+  - `src/termisu/event/poller/poll.cr`
+  - `src/termisu/reader.cr`
+- Both files currently reopen `lib LibC` and define:
+  - `Pollfd`
+  - `NfdsT`
+  - `poll`
+  - `POLL*` constants
+- This creates shard-to-shard compile conflicts when another dependency patches `LibC` too.
+
+## Design Decision
+
+Use a **Termisu-private poll binding namespace** instead of global `LibC` patching.
+
+Preferred namespace:
+
+- `Termisu::System::Poll`
+
+Why:
+
+- avoids cross-shard symbol collisions
+- needs no consumer flags or compile-time coordination
+- keeps runtime behavior unchanged
+- centralizes poll fallback support in one place
+
+## Implementation Checklist
+
+### Phase 1: Add shared internal binding
+
+- [ ] Create shared binding file
+- [ ] Use a Termisu-private namespace
+- [ ] Define `Pollfd`
+- [ ] Define `NfdsT`
+- [ ] Define `poll`
+- [ ] Define `POLLIN`, `POLLOUT`, `POLLERR`, `POLLHUP`, `POLLNVAL`
+- [ ] Preserve platform-specific `NfdsT` sizing
+
+### Phase 2: Migrate fallback poller
+
+- [ ] Update `src/termisu/event/poller/poll.cr`
+- [ ] Require the new shared binding file
+- [ ] Replace `LibC::Pollfd`
+- [ ] Replace `LibC::NfdsT`
+- [ ] Replace `LibC.poll`
+- [ ] Replace `LibC::POLL*`
+- [ ] Remove inline `lib LibC` poll declarations
+
+### Phase 3: Migrate reader fallback
+
+- [ ] Update `src/termisu/reader.cr`
+- [ ] Require the new shared binding file
+- [ ] Replace `LibC::Pollfd`
+- [ ] Replace `LibC::NfdsT`
+- [ ] Replace `LibC.poll`
+- [ ] Replace `LibC::POLL*`
+- [ ] Remove inline `lib LibC` poll declarations
+
+### Phase 4: Cleanup verification
+
+- [ ] Search for remaining `fun poll`
+- [ ] Search for remaining `struct Pollfd`
+- [ ] Search for remaining `alias NfdsT`
+- [ ] Confirm only the internal binding owns poll support
+
+### Phase 5: Validation
+
+- [ ] Run focused checks for `Reader`
+- [ ] Run focused checks for fallback `Poller::Poll`
+- [ ] Run relevant specs
+- [ ] Run broader checks if focused validation passes
+
+## Patch Plan
+
+### New file
+
+Create:
+
+- `src/termisu/system/poll.cr`
+
+Add:
+
+- Termisu-private binding namespace
+- `Pollfd` struct
+- platform-correct `NfdsT`
+- `poll` function binding
+- `POLL*` constants used by reader and fallback poller
+
+### File: `src/termisu/event/poller/poll.cr`
+
+Planned edits:
+
+- add require for shared poll binding
+- remove local `lib LibC` poll patch block
+- replace all poll-specific `LibC` references with the internal namespace
+
+Watchpoints:
+
+- typed arrays of pollfds
+- `uninitialized` locals
+- event-mask translation helpers
+- preserving existing timeout and error behavior
+
+### File: `src/termisu/reader.cr`
+
+Planned edits:
+
+- add require for shared poll binding
+- remove local `lib LibC` poll patch block
+- replace poll-specific `LibC` references in `check_fd_readable_poll`
+
+Watchpoints:
+
+- keep select-based path unchanged
+- keep EINTR behavior unchanged
+- keep current readable/error semantics unchanged
+
+## Validation Notes
+
+This is a **compatibility refactor**, not a behavior change.
+
+Expected unchanged behavior:
+
+- same poll timeout semantics
+- same fd readability semantics
+- same error handling
+- same platform-specific ABI for `NfdsT`
+
+## Risks
+
+- namespace choice may affect readability if too close to `LibC`
+- accidental behavior drift if only some `POLL*` references are migrated
+- incorrect `NfdsT` sizing would create ABI issues on BSD/Darwin vs Linux
+
+## Suggested Commit Message
+
+`internalize poll bindings to avoid LibC conflicts`
+
+## Reference
+
+- `src/termisu/event/poller/poll.cr`
+- `src/termisu/reader.cr`
+- LavinMQ PR: `cloudamqp/lavinmq#1589`

--- a/thoughts/plans/js-e2e-parity-plan.md
+++ b/thoughts/plans/js-e2e-parity-plan.md
@@ -1,0 +1,143 @@
+# JS Example E2E Parity Plan
+
+## Goal
+
+Get JS examples to the point where the E2E harness can run them with comparable coverage to the Crystal examples on the CI-tested platforms.
+
+## Current State
+
+- Current E2E workflow builds Crystal example binaries only via `.github/actions/build-e2e-binaries/action.yml`.
+- `@termisu/core` now owns native target detection directly, so JS example launch wiring only needs `@termisu/core` plus the native packages.
+- Current E2E tests target these Crystal binaries:
+  - `bin/showcase`
+  - `bin/simple`
+  - `bin/colors`
+  - `bin/kmd`
+  - `bin/animation`
+- `javascript/core/examples/basic.ts` exists, but there is no JS example build/launch pipeline wired into E2E.
+- `ffi-bindings.yml` already builds the shared library and runs `bun run js:test`, which is a useful foundation for JS example execution.
+
+## E2E Parity Gaps
+
+### 1. Example surface mismatch
+
+Crystal examples with E2E coverage:
+
+- simple
+- showcase
+- colors
+- keyboard/mouse demo
+- animation
+
+JS examples currently present:
+
+- basic only
+
+### 2. No JS example launcher contract
+
+The E2E harness expects an executable program path under `bin/`.
+
+Needed decisions:
+
+- whether JS examples are launched through Bun directly
+- or wrapped as generated `bin/*` launch scripts
+- how native library path is injected at runtime during E2E
+
+### 3. No JS-specific E2E matrix in CI
+
+Current E2E workflow validates:
+
+- OS: Linux + macOS
+- shells: bash, zsh, fish
+- Crystal versions: 1.17.0 / 1.18.2 / 1.19.1
+
+No job currently runs JS examples under the same harness.
+
+## Proposed Example Parity Map
+
+### Phase 1: minimal parity
+
+- [ ] JS simple example matching the Crystal `simple` behavior
+- [ ] JS colors example matching the Crystal `colors` behavior
+- [ ] JS showcase example matching the Crystal `showcase` behavior
+
+### Phase 2: interactive parity
+
+- [ ] JS keyboard/mouse demo matching `keyboard_and_mouse.cr`
+- [ ] JS animation example matching `animation.cr`
+
+## Implementation Checklist
+
+### Phase 1: establish JS example runner shape
+
+- [ ] Decide executable contract for JS examples in E2E
+- [ ] Add a build or wrapper step that produces stable `bin/js-*` entrypoints
+- [ ] Ensure each JS example can locate the native library in CI
+- [ ] Keep launch semantics shell-safe for bash/zsh/fish jobs
+
+### Phase 2: add the first JS examples
+
+- [ ] Add `javascript/core/examples/simple.ts`
+- [ ] Add `javascript/core/examples/colors.ts`
+- [ ] Add `javascript/core/examples/showcase.ts`
+- [ ] Match visible text and lifecycle behavior closely enough for tui-test assertions
+
+### Phase 3: add JS E2E tests
+
+- [ ] Create JS versions of the current E2E specs or parameterize the existing ones
+- [ ] Reuse existing assertions where output is intentionally equivalent
+- [ ] Add JS-specific snapshots only where parity is intentionally approximate
+
+### Phase 4: CI integration
+
+- [ ] Extend `.github/actions/build-e2e-binaries/action.yml` or add a sibling action for JS example runners
+- [ ] Add JS example artifacts to `.github/workflows/e2e.yml`
+- [ ] Run JS E2E on the same OS/shell matrix as Crystal where practical
+- [ ] Upload JS traces/snapshots on failure
+
+### Phase 5: parity expansion
+
+- [ ] Add JS keyboard/mouse example + E2E tests
+- [ ] Add JS animation example + E2E tests
+- [ ] Compare expected drift between Crystal and JS implementations explicitly
+
+## Suggested Task Breakdown
+
+### Track A: Example implementation
+
+- [ ] Port `simple`
+- [ ] Port `colors`
+- [ ] Port `showcase`
+- [ ] Port `keyboard_and_mouse`
+- [ ] Port `animation`
+
+### Track B: Runner/build plumbing
+
+- [ ] Produce stable JS executables or wrappers under `bin/`
+- [ ] Inject `TERMISU_LIB_PATH` in a reproducible way for JS E2E
+- [ ] Verify Bun is available everywhere JS E2E runs
+
+### Track C: Test harness
+
+- [ ] Decide shared vs duplicated spec files
+- [ ] Introduce helpers for selecting Crystal vs JS program targets
+- [ ] Keep snapshots isolated per implementation if output diverges slightly
+
+## Recommended First Milestone
+
+Ship one JS E2E vertical slice before chasing full parity:
+
+- `simple.ts`
+- one JS-specific E2E spec based on `e2e/tests/simple.test.ts`
+- one CI job that builds native lib + runs the JS simple example under tui-test
+
+Once that works on Linux and macOS, expand to `colors` and `showcase`.
+
+## Validation Targets
+
+For the first parity milestone:
+
+- [ ] `bun run js:check`
+- [ ] `bun run e2e:check`
+- [ ] local JS example launch with shared library available
+- [ ] CI JS example E2E on Linux + macOS

--- a/thoughts/plans/js-release-readiness.md
+++ b/thoughts/plans/js-release-readiness.md
@@ -1,0 +1,138 @@
+# JS Release Readiness Plan
+
+## Goal
+
+Get the kept JS packages to an initial-release state where `@termisu/core` is publishable, native target packages are real delivery artifacts, and install/runtime behavior is validated on the CI-tested platforms.
+
+## Current Package Roles
+
+### Public package
+
+- `javascript/core` → `@termisu/core`
+
+### Published internal packages
+
+- `javascript/native/darwin/arm64` → `@termisu/native-darwin-arm64`
+- `javascript/native/darwin/x64` → `@termisu/native-darwin-x64`
+- `javascript/native/freebsd/arm64` → `@termisu/native-freebsd-arm64`
+- `javascript/native/freebsd/x64` → `@termisu/native-freebsd-x64`
+- `javascript/native/linux/arm64/gnu` → `@termisu/native-linux-arm64-gnu`
+- `javascript/native/linux/arm64/musl` → `@termisu/native-linux-arm64-musl`
+- `javascript/native/linux/x64/gnu` → `@termisu/native-linux-x64-gnu`
+- `javascript/native/linux/x64/musl` → `@termisu/native-linux-x64-musl`
+
+## Current State
+
+- `@termisu/core` resolves native libraries in this order:
+  1. explicit `libraryPath`
+  2. `TERMISU_LIB_PATH`
+  3. installed native package manifest lookup
+  4. repo-local `bin/` fallback
+- `@termisu/core` carries native packages as optional dependencies and owns target detection for Linux glibc vs musl, Darwin, and FreeBSD.
+- CI validates JS lint/format/typecheck/tests and Crystal/C ABI builds, but native npm package publication is not wired yet.
+- `publish-core.yml` publishes only `@termisu/core`.
+- Native packages currently look like metadata/package shells and still need actual binary payload wiring.
+
+## Release Gaps
+
+### 1. Native package contents are not fully defined
+
+Open decisions:
+
+- exact binary filename per OS (`.so` vs `.dylib`)
+- exact package layout (`libtermisu.*` at package root vs `bin/libtermisu.*`)
+- whether `manifest.json` should also record the shipped relative binary path
+
+### 2. Native package build/publish flow is missing
+
+Current workflows build a shared library into repo-local `bin/`, but do not:
+
+- copy that binary into each native package
+- verify each native package packs correctly
+- publish native packages before `@termisu/core`
+
+### 3. Installed-package runtime behavior needs pack/install validation
+
+Current tests cover resolution logic, but not the real post-pack install shape for:
+
+- `bun add @termisu/core`
+- installed optional native package layout
+- `import.meta.resolve("@termisu/native-*/manifest")` from a packed install
+
+### 4. Release orchestration is incomplete
+
+Needed but not yet present:
+
+- version sync between `@termisu/core` and native packages
+- publish order / dependency order
+- dist-tag strategy across all JS packages
+- provenance/public access for the full release set
+
+## Implementation Checklist
+
+### Phase 1: Lock package layout
+
+- [ ] Choose final native binary location inside each native package
+- [ ] Add binary-path field to `manifest.json` if needed
+- [ ] Update `javascript/core/src/native.ts` to match the final layout exactly
+- [ ] Document the package layout in `javascript/README.md`
+
+### Phase 2: Build real native package artifacts
+
+- [ ] Add a packaging script that copies built shared libraries into each native package
+- [ ] Ensure Linux packages receive the correct `.so` payload per target
+- [ ] Ensure macOS packages receive the correct `.dylib` payload per target
+- [ ] Decide whether FreeBSD native packages ship initially or remain deferred
+- [ ] Verify package `files`/`exports` include the binary payload and manifest
+
+### Phase 3: Add pack/install verification
+
+- [ ] Add a smoke check for `bun pm pack` or equivalent on `javascript/core`
+- [ ] Add the same smoke check for each native package
+- [ ] Add an install test that simulates `@termisu/core` + matching native package resolution
+- [ ] Verify missing optional native packages fail with actionable errors
+
+### Phase 4: Release workflow
+
+- [ ] Create a native-package publish workflow
+- [ ] Publish native packages before `@termisu/core`
+- [ ] Ensure `@termisu/core` version matches native package versions
+- [ ] Add prerelease/stable dist-tag rules for the native packages too
+- [ ] Add a release checklist doc for JS packages
+
+### Phase 5: Release scope decision
+
+- [ ] Decide the initial supported npm release matrix
+- [ ] Prefer a smaller first release if artifact generation is not ready for all targets
+- [ ] Mark unsupported/deferred targets clearly in docs and workflow config
+
+## Recommended Initial Release Scope
+
+Safest first release candidates:
+
+- Linux x64 GNU
+- Linux arm64 GNU
+- Darwin arm64
+- Darwin x64
+
+Optional defer candidates until artifact production is proven:
+
+- Linux musl targets
+- FreeBSD targets
+
+## Validation Targets
+
+Before the first npm release, these should pass in CI:
+
+- JS checks: `bun run js:check`
+- E2E checks: `bun run e2e:check`
+- C ABI workflow: `.github/workflows/ffi-bindings.yml`
+- package pack/install smoke checks for `@termisu/core` and native packages
+
+## Suggested Task Order
+
+1. Finalize native package binary layout.
+2. Add scripts to materialize binaries into native packages.
+3. Add pack/install verification.
+4. Add native-package publish workflow.
+5. Narrow or confirm the initial platform release matrix.


### PR DESCRIPTION
Brings the C ABI and the JavaScript binding up to date with the Crystal library. Additive only — no struct change, so the layout signature and `ABI_VERSION` both stay at **1**.

## Bracketed paste was Crystal-only

`enable_bracketed_paste` / `disable_bracketed_paste` / `bracketed_paste?` existed on the Crystal facade but had no exports, so C and JS callers could not turn the mode on at all.

`Key::PasteStart` / `PasteEnd` already reached those callers correctly — neither `ffi.h` nor the TS binding mirrors the key enum, `key_code` is a plain `int32_t` / `number` — so only the toggles were missing.

## The queries were missing for every input mode

`mouse_enabled?` and `enhanced_keyboard?` had the same gap and predate this feature: a C or JS caller could turn those modes on but never read them back, so it had to shadow the state locally. That shadow drifts the moment `with_mode` suspends and restores the mode, which it does for all three. Adding `bracketed_paste` alone would have inherited the inconsistency, so all three queries land together.

| added | |
|---|---|
| `termisu_enable_bracketed_paste` / `termisu_disable_bracketed_paste` | toggles |
| `termisu_mouse_enabled` / `termisu_enhanced_keyboard` / `termisu_bracketed_paste` | `uint8_t`, non-zero when on |

Exports go 27 → 32, and `exports.cr`, `ffi.h` and `native.ts` are byte-identical in their function lists.

## Also: a libm link regression (first commit)

`Float#ceil`, added in the paste-probe timeout work, was the only libm call in the library — it left `ceil` undefined in `libtermisu.so`, and the C ABI test links `-ltermisu` **without `-lm`** (`ffi-bindings.yml:78/80/116`). That would have gone red on the next C ABI run. Replaced with truncate-and-add-one, which also avoids rounding a live deadline down to a `0ms` wait.

Kept as its own commit so bisecting a link failure doesn't land in an ABI feature change.

## Notes

`syncUpdates()` in the TS binding now delegates to the same `queryFlag` helper the new queries use, rather than inlining a second copy of the u8-flag read. `docs-web/content/guide/mouse-keyboard.md` listed 2 of 3 input modes and now documents bracketed paste with a working consumer example.

## Verification

- 32 exports present in the built `.so`; no undefined `ceil`
- C ABI test compiles **and passes** using the exact CI link command
- end-to-end through the TS binding: `\e[?2004h` on enable, `\e[?2004l` on disable, queries tracking
- Crystal `1273 examples, 0 failures` · Bun `48 pass` · e2e `81 examples, 0 failures`
- `crystal tool format`, ameba `157/0`, biome lint/format, `tsc --noEmit`, `clang-format` all clean
