### PR TITLE
fix(build): link libiconv explicitly for the macOS ffi dylib

### DIFF
--- a/Hacefile.yml
+++ b/Hacefile.yml
@@ -122,7 +122,7 @@ tasks:
       crystal build src/termisu_ffi.cr --release --cross-compile -Dwithout_mt -o bin/libtermisu
       case "$(uname -s)" in
         FreeBSD) DL_LIB="-ldl" ; GC_LIB="-lgc-threaded" ; SYS_LIBS="-L/usr/local/lib -lm" ; SHARED_FLAG="-shared"     ; FFI_OUT="{{FFI_LIB}}" ;;
-        Darwin)  DL_LIB=""     ; GC_LIB="-lgc"          ; SYS_LIBS=""                    ; SHARED_FLAG="-dynamiclib" ; FFI_OUT="bin/libtermisu.dylib" ;;
+        Darwin)  DL_LIB=""     ; GC_LIB="-lgc"          ; SYS_LIBS="-liconv"             ; SHARED_FLAG="-dynamiclib" ; FFI_OUT="bin/libtermisu.dylib" ;;
         *)       DL_LIB="-ldl" ; GC_LIB="-lgc"          ; SYS_LIBS=""                    ; SHARED_FLAG="-shared"     ; FFI_OUT="{{FFI_LIB}}" ;;
       esac
       LIB_FLAGS="$(crystal env CRYSTAL_LIBRARY_PATH | tr ':' '\n' | sed 's#^#-L#' | paste -sd' ' -)"


### PR DESCRIPTION
## Summary

- `bin/hace ffi:build` fails to link on macOS with `ld: symbol(s) not found: _iconv_open`
- Crystal’s stdlib uses iconv, but the Darwin link line never passed `-liconv`
- Stock Apple toolchains don’t resolve libiconv implicitly (unlike Homebrew paths)
- Added `-liconv` to Darwin `SYS_LIBS` only — Linux (glibc) and FreeBSD already ship iconv in libc

## Validation

- `bin/hace ffi:build` succeeds and produces `bin/libtermisu.dylib` on macOS arm64
- `bun run js:test` against the new dylib: 48 pass, 0 fail