### PR TITLE
fix: make tty close idempotent

### DIFF
--- a/spec/termisu/tty_spec.cr
+++ b/spec/termisu/tty_spec.cr
@@ -31,5 +31,30 @@ describe Termisu::TTY do
       tty.close # Should not raise
       tty.close # Should not raise
     end
+
+    {% unless flag?(:openbsd) || flag?(:freebsd) %}
+      it "does not close a descriptor that reuses its input descriptor number" do
+        tty = Termisu::TTY.new
+        input_fd = tty.infd
+        tty.close
+
+        reused_fds = [] of Int32
+        begin
+          loop do
+            fd = LibC.open("/dev/null", LibC::O_RDONLY, 0)
+            raise IO::Error.from_errno("Failed to open /dev/null") if fd == -1
+            reused_fds << fd
+            break if fd == input_fd
+            raise "Could not reuse TTY input descriptor #{input_fd}" if fd > input_fd
+          end
+
+          tty.close
+          LibC.fcntl(input_fd, LibC::F_GETFD, 0).should_not eq(-1)
+        ensure
+          tty.try &.close
+          reused_fds.each { |fd| LibC.close(fd) }
+        end
+      end
+    {% end %}
   end
 end

--- a/src/termisu/tty.cr
+++ b/src/termisu/tty.cr
@@ -10,9 +10,10 @@ class Termisu::TTY
   private PATH = "/dev/tty"
 
   @out : File
-  @in : File | Int32
   @outfd : Int32
   @infd : Int32
+  @owns_input_fd : Bool
+  @closed : Bool = false
 
   {% begin %}
     {% bsd = flag?(:openbsd) || flag?(:freebsd) %}
@@ -27,15 +28,26 @@ class Termisu::TTY
   # Raises `IO::Error` if the TTY cannot be opened.
   def initialize
     @out = File.open(PATH, FILE_MODE)
-    @in = USE_RDWR ? @out : open_readonly_fd
     @outfd = @out.fd
-    @infd = USE_RDWR ? @outfd : @in.as(Int32)
+    @infd = USE_RDWR ? @outfd : open_readonly_fd
+    @owns_input_fd = !USE_RDWR
   end
 
   # Closes the TTY file descriptors.
   def close
-    close_output_fd
-    close_input_fd unless USE_RDWR
+    return if @closed
+
+    @closed = true
+    input_fd = @owns_input_fd ? @infd : -1
+    @owns_input_fd = false
+    @outfd = -1
+    @infd = -1
+
+    begin
+      close_output_fd
+    ensure
+      close_input_fd(input_fd)
+    end
   end
 
   def write(data : String)
@@ -63,7 +75,7 @@ class Termisu::TTY
     @out.try(&.close)
   end
 
-  private def close_input_fd
-    LibC.close(@in.as(Int32)) if @in.is_a?(Int32)
+  private def close_input_fd(fd : Int32)
+    LibC.close(fd) if fd >= 0
   end
 end


### PR DESCRIPTION
## Summary

- make `TTY#close` ownership-aware and idempotent
- invalidate cached descriptors before closing so reused descriptor numbers stay open
- add a regression that forces input descriptor-number reuse before a second close

## Testing

- `mise exec -- unbuffer crystal spec spec/termisu/tty_spec.cr spec/termisu/terminal/backend_spec.cr`
- `mise exec -- bin/hace format:check`
- `mise exec -- bin/hace ameba`
- `mise exec -- bin/hace spec`

## Compatibility

Shared FreeBSD/OpenBSD input and output descriptor behavior remains unchanged.
