### PR TITLE
fix: enforce input parser deadlines

### DIFF
--- a/spec/termisu/input/parser_spec.cr
+++ b/spec/termisu/input/parser_spec.cr
@@ -3,12 +3,20 @@ require "../../spec_helper"
 # Helper to write bytes to pipe and parse event.
 # Specific to parser tests - uses create_pipe from PipeHelpers.
 private def parse_sequence(bytes : Bytes) : Termisu::Event::Any?
+  parse_sequence_with_buffer(bytes, 128, 100)
+end
+
+# A tiny Reader buffer forces every continuation byte through the fd-read
+# boundary. This catches parser paths that accidentally assume the first fill
+# contains a whole terminal sequence.
+private def parse_sequence_with_buffer(bytes : Bytes, buffer_size : Int32,
+                                       timeout_ms : Int32) : Termisu::Event::Any?
   read_fd, write_fd = create_pipe
   begin
     LibC.write(write_fd, bytes, bytes.size)
-    reader = Termisu::Reader.new(read_fd)
+    reader = Termisu::Reader.new(read_fd, buffer_size)
     parser = Termisu::Input::Parser.new(reader)
-    parser.poll_event(100)
+    parser.poll_event(timeout_ms)
   ensure
     reader.try(&.close)
     LibC.close(read_fd)
@@ -63,6 +71,59 @@ end
 private class ParserRoundingProbe < Termisu::Input::Parser
   def ceil(remaining : Float64) : Int32
     ceil_ms(remaining)
+  end
+end
+
+# Deterministic reader used to prove that continuation waits share one deadline.
+# Byte N arrives N * gap_ms after parsing starts; waits advance a virtual clock
+# instead of sleeping, so the regression remains reliable on loaded builders.
+private class ParserDripReader < Termisu::Reader
+  getter now : MonotonicTime
+  getter consumed = 0
+
+  def initialize(@bytes : Bytes, @gap_ms : Int32)
+    super(-1)
+    @now = monotonic_now
+    @started_at = @now
+  end
+
+  def elapsed : Time::Span
+    @now - @started_at
+  end
+
+  def read_byte(timeout_ms : Int32) : UInt8?
+    wait_for_next_byte(timeout_ms, consume: true)
+  end
+
+  def peek_byte(timeout_ms : Int32) : UInt8?
+    wait_for_next_byte(timeout_ms, consume: false)
+  end
+
+  private def wait_for_next_byte(timeout_ms : Int32, consume : Bool) : UInt8?
+    return if @consumed >= @bytes.size
+
+    arrival = @started_at + (@consumed * @gap_ms).milliseconds
+    remaining = (arrival - @now).total_milliseconds
+    if remaining > timeout_ms
+      @now += timeout_ms.milliseconds
+      return
+    end
+
+    @now = arrival if arrival > @now
+    byte = @bytes[@consumed]
+    @consumed += 1 if consume
+    byte
+  end
+end
+
+private class ParserDripProbe < Termisu::Input::Parser
+  def initialize(reader : ParserDripReader)
+    @clock = reader
+    super(reader)
+  end
+
+  private def monotonic_now : MonotonicTime
+    @clock.now
   end
 end
 
@@ -843,6 +904,72 @@ describe Termisu::Input::Parser do
         if event.is_a?(Termisu::Event::Mouse)
           event.x.should be >= 1
           event.y.should be >= 1
+        end
+      end
+    end
+
+    context "parser deadlines" do
+      it "parses complete buffered sequences nonblockingly across every read boundary" do
+        utf8 = parse_sequence_with_buffer("€".to_slice, 1, 0)
+        utf8.should be_a(Termisu::Event::Key)
+        utf8.as(Termisu::Event::Key).char.should eq('€')
+
+        csi_u = parse_sequence_with_buffer("\e[97;1u".to_slice, 1, 0)
+        csi_u.should be_a(Termisu::Event::Key)
+        csi_u.as(Termisu::Event::Key).key.should eq(Termisu::Input::Key::LowerA)
+
+        ss3 = parse_sequence_with_buffer("\eOP".to_slice, 1, 0)
+        ss3.should be_a(Termisu::Event::Key)
+        ss3.as(Termisu::Event::Key).key.should eq(Termisu::Input::Key::F1)
+
+        sgr_mouse = parse_sequence_with_buffer("\e[<0;1;1M".to_slice, 1, 0)
+        sgr_mouse.should be_a(Termisu::Event::Mouse)
+
+        normal_mouse = parse_sequence_with_buffer(Bytes[0x1B, '['.ord, 'M'.ord, 32, 33, 33], 1, 0)
+        normal_mouse.should be_a(Termisu::Event::Mouse)
+      end
+
+      it "uses one deadline when continuation bytes drip in" do
+        reader = ParserDripReader.new("\e[1234A".to_slice, gap_ms: 4)
+        parser = ParserDripProbe.new(reader)
+
+        event = parser.poll_event(10)
+
+        event.should be_a(Termisu::Event::Key)
+        event.as(Termisu::Event::Key).key.should eq(Termisu::Input::Key::Unknown)
+        reader.consumed.should eq(3)
+        reader.elapsed.should eq(10.milliseconds)
+      end
+
+      it "bounds every truncated continuation path by one poll timeout" do
+        sequences = {
+          "UTF-8"        => Bytes[0xF0, 0x9F],
+          "Alt UTF-8"    => Bytes[0x1B, 0xC3],
+          "CSI"          => "\e[1;".to_slice,
+          "Kitty CSI-u"  => "\e[97;1".to_slice,
+          "SS3"          => "\eO".to_slice,
+          "SGR mouse"    => "\e[<0;1".to_slice,
+          "normal mouse" => Bytes[0x1B, '['.ord, 'M'.ord, 32],
+        }
+
+        sequences.each do |name, bytes|
+          read_fd, write_fd = create_pipe
+          begin
+            LibC.write(write_fd, bytes, bytes.size)
+            reader = Termisu::Reader.new(read_fd)
+            parser = Termisu::Input::Parser.new(reader)
+
+            elapsed = Time.measure do
+              event = parser.poll_event(10)
+              event.should be_a(Termisu::Event::Key), name
+              event.as(Termisu::Event::Key).key.should eq(Termisu::Input::Key::Unknown), name
+            end
+            elapsed.should be < 250.milliseconds, name
+          ensure
+            reader.try(&.close)
+            LibC.close(read_fd)
+            LibC.close(write_fd)
+          end
         end
       end
     end

--- a/spec/termisu/reader_spec.cr
+++ b/spec/termisu/reader_spec.cr
@@ -86,6 +86,44 @@ describe Termisu::Reader do
       end
     end
 
+    it "uses fd-ready and buffered bytes for zero-timeout operations" do
+      read_fd, write_fd = create_pipe
+      begin
+        LibC.write(write_fd, "hi".to_slice, 2)
+
+        reader = Termisu::Reader.new(read_fd)
+        reader.peek_byte(0).should eq('h'.ord.to_u8) # fd-ready fill
+        reader.peek_byte(0).should eq('h'.ord.to_u8) # buffered peek
+        reader.read_byte(0).should eq('h'.ord.to_u8)
+        reader.read_byte(0).should eq('i'.ord.to_u8) # buffered read
+        reader.read_byte(0).should be_nil
+        reader.peek_byte(0).should be_nil
+
+        reader.close
+      ensure
+        LibC.close(read_fd)
+        LibC.close(write_fd)
+      end
+    end
+
+    it "times out bounded byte operations on an empty pipe" do
+      read_fd, write_fd = create_pipe
+      begin
+        reader = Termisu::Reader.new(read_fd)
+
+        elapsed = Time.measure do
+          reader.read_byte(5).should be_nil
+          reader.peek_byte(5).should be_nil
+        end
+        elapsed.should be < 100.milliseconds
+
+        reader.close
+      ensure
+        LibC.close(read_fd)
+        LibC.close(write_fd)
+      end
+    end
+
     it "returns nil when read_bytes cannot fill the requested count" do
       read_fd, write_fd = create_pipe
       begin

--- a/src/termisu/input/parser.cr
+++ b/src/termisu/input/parser.cr
@@ -161,6 +161,10 @@ class Termisu::Input::Parser
   # what it has, hands the ESC back, and the next call resumes the probe.
   @paste_deadline : MonotonicTime? = nil
   @poll_deadline : MonotonicTime? = nil
+  # Absolute end-to-end deadline used by every byte of the current parse. A
+  # blocking poll may wait indefinitely for its first byte, but once parsing has
+  # started, an incomplete sequence is bounded by the escape ambiguity window.
+  @parse_deadline : MonotonicTime? = nil
 
   def initialize(@reader : Reader)
   end
@@ -187,13 +191,12 @@ class Termisu::Input::Parser
     bytes[0] = first_byte
 
     (1...len).each do |i|
-      # wait_for_data reuses the split-read tolerance so a char fragmented
-      # across two reads survives; peek + confirm before consuming so a
-      # non-continuation byte is left in the buffer rather than swallowed.
-      return nil unless @reader.wait_for_data(ESCAPE_TIMEOUT_MS)
-      b = @reader.peek_byte
+      # Peek + confirm before consuming so a non-continuation byte is left in
+      # the buffer rather than swallowed. Every continuation shares the poll's
+      # absolute deadline rather than receiving a fresh timeout.
+      b = peek_parse_byte
       return nil unless b && (b & 0xC0) == 0x80 # continuation 10xxxxxx
-      @reader.read_byte
+      read_parse_byte
       bytes[i] = b
     end
 
@@ -210,21 +213,24 @@ class Termisu::Input::Parser
   #
   # Returns an Event or nil if timeout/no data.
   def poll_event(timeout_ms : Int32 = -1) : Event::Any?
-    @poll_deadline = timeout_ms < 0 ? nil : monotonic_now + timeout_ms.milliseconds
+    now = monotonic_now
+    @poll_deadline = timeout_ms < 0 ? nil : now + timeout_ms.milliseconds
+    @parse_deadline = @poll_deadline
 
     # Bytes already taken off the fd while probing for an end marker come first,
     # and without consulting the fd: they have arrived, so no timeout applies.
     if byte = @pending.shift?
+      @parse_deadline ||= now + ESCAPE_TIMEOUT_MS.milliseconds
       return parse_byte(byte)
     end
 
-    unless @reader.wait_for_data(timeout_ms < 0 ? Int32::MAX : timeout_ms)
-      return
-    end
-
-    byte = @reader.read_byte
+    wait = timeout_ms < 0 ? Int32::MAX : timeout_ms
+    byte = @reader.read_byte(wait)
     return unless byte
 
+    # A blocking poll is unbounded only while waiting for its first byte. Once a
+    # possible multi-byte event starts, truncated input must not block forever.
+    @parse_deadline ||= monotonic_now + ESCAPE_TIMEOUT_MS.milliseconds
     parse_byte(byte)
   end
 
@@ -342,10 +348,9 @@ class Termisu::Input::Parser
     while tail.size < PASTE_END_TAIL.size
       byte = @pending.shift?
       unless byte
-        wait = paste_wait_ms
-        break if wait <= 0
-        break unless @reader.wait_for_data(wait)
-        byte = @reader.read_byte
+        # Reader consumes buffered bytes even for a zero wait, so a zero-timeout
+        # poll can finish a marker that arrived in an earlier buffer fill.
+        byte = @reader.read_byte(paste_wait_ms)
         break unless byte
       end
       tail << byte
@@ -381,27 +386,38 @@ class Termisu::Input::Parser
     remaining > whole ? whole + 1 : whole
   end
 
-  private def parse_escape_sequence : Event::Any
-    # Check if more data follows (escape sequence) or just ESC key
-    unless @reader.wait_for_data(ESCAPE_TIMEOUT_MS)
-      return Event::Key.new(Key::Escape)
-    end
+  # Reads or peeks one continuation byte within the current parse's absolute
+  # deadline. Reader deliberately checks its internal buffer before the timeout,
+  # which keeps zero-timeout polling useful for complete, already-buffered input.
+  private def read_parse_byte(max_wait_ms : Int32? = nil) : UInt8?
+    @reader.read_byte(parse_wait_ms(max_wait_ms))
+  end
 
-    byte = @reader.peek_byte
-    unless byte
-      return Event::Key.new(Key::Escape)
-    end
+  private def peek_parse_byte(max_wait_ms : Int32? = nil) : UInt8?
+    @reader.peek_byte(parse_wait_ms(max_wait_ms))
+  end
+
+  private def parse_wait_ms(max_wait_ms : Int32?) : Int32
+    wait = ms_until(@parse_deadline)
+    max_wait_ms ? {wait, max_wait_ms}.min : wait
+  end
+
+  private def parse_escape_sequence : Event::Any
+    # Check if more data follows (escape sequence) or just ESC key. The Escape
+    # ambiguity window may shorten, but never extend, the caller's deadline.
+    byte = peek_parse_byte(ESCAPE_TIMEOUT_MS)
+    return Event::Key.new(Key::Escape) unless byte
 
     case byte
-    when '['.ord.to_u8  # CSI sequence: \e[...
-      @reader.read_byte # consume '['
+    when '['.ord.to_u8 # CSI sequence: \e[...
+      read_parse_byte  # consume '['
       parse_csi_sequence
-    when 'O'.ord.to_u8  # SS3 sequence: \eO... (F1-F4, some arrows)
-      @reader.read_byte # consume 'O'
+    when 'O'.ord.to_u8 # SS3 sequence: \eO... (F1-F4, some arrows)
+      read_parse_byte  # consume 'O'
       parse_ss3_sequence
     else
       # Alt+key: \e followed by printable char (UTF-8 capable)
-      @reader.read_byte # consume the (first) char byte
+      read_parse_byte # consume the (first) char byte
       c = read_utf8_char(byte)
       key = c ? (Key.from_char(c) || Key::Unknown) : Key::Unknown
       Event::Key.new(key, Modifier::Alt, char: c)
@@ -413,7 +429,7 @@ class Termisu::Input::Parser
   # CSI format: \e [ <params> <intermediate> <final>
   # Final chars are 0x40-0x7E (@A-Z[\]^_`a-z{|}~)
   private def parse_csi_sequence : Event::Any
-    first = @reader.read_byte
+    first = read_parse_byte
     return Event::Key.new(Key::Unknown) unless first
 
     # SGR mouse: \e[<...
@@ -428,7 +444,7 @@ class Termisu::Input::Parser
     # fast path below — otherwise '[' is consumed as a final byte and the
     # trailing key letter is lost.
     if first == '['.ord
-      final = @reader.read_byte
+      final = read_parse_byte
       return Event::Key.new(Key::Unknown) unless final
 
       key = LINUX_CONSOLE_KEYS["[[#{final.unsafe_chr}"]? || Key::Unknown
@@ -443,7 +459,7 @@ class Termisu::Input::Parser
     buffer = String::Builder.new
     buffer << first.chr
 
-    while byte = @reader.read_byte
+    while byte = read_parse_byte
       char = byte.chr
 
       if byte >= 0x40 && byte <= 0x7E
@@ -682,7 +698,7 @@ class Termisu::Input::Parser
   #
   # SS3 sequences are used for F1-F4 and some arrow keys.
   private def parse_ss3_sequence : Event::Any
-    byte = @reader.read_byte
+    byte = read_parse_byte
     unless byte
       return Event::Key.new(Key::Unknown)
     end
@@ -711,7 +727,7 @@ class Termisu::Input::Parser
     buf = uninitialized UInt8[MAX_SEQUENCE_LENGTH]
     len = 0
 
-    while byte = @reader.read_byte
+    while byte = read_parse_byte
       case byte
       when 'M'.ord then return {String.new(buf.to_slice[0, len]), false}
       when 'm'.ord then return {String.new(buf.to_slice[0, len]), true}
@@ -759,9 +775,9 @@ class Termisu::Input::Parser
   # Format: \e[MCbCxCy (6 bytes total, Cb/Cx/Cy are raw bytes + 32)
   private def parse_normal_mouse : Event::Any
     # Read 3 more bytes: Cb, Cx, Cy
-    cb_byte = @reader.read_byte
-    cx_byte = @reader.read_byte
-    cy_byte = @reader.read_byte
+    cb_byte = read_parse_byte
+    cx_byte = read_parse_byte
+    cy_byte = read_parse_byte
 
     unless cb_byte && cx_byte && cy_byte
       return Event::Key.new(Key::Unknown)

--- a/src/termisu/reader.cr
+++ b/src/termisu/reader.cr
@@ -48,12 +48,20 @@ class Termisu::Reader
   # This is a non-blocking operation when the terminal is in raw mode.
   def read_byte : UInt8?
     fill_buffer if @buffer_pos >= @buffer_len
-    return if @buffer_pos >= @buffer_len
+    consume_buffered_byte
+  end
 
-    byte = @buffer[@buffer_pos]
-    @buffer_pos += 1
+  # Reads a single byte, waiting at most `timeout_ms` for the file descriptor.
+  #
+  # Bytes already in the internal buffer are consumed even when the timeout is
+  # zero. This lets callers apply an absolute deadline without abandoning bytes
+  # that arrived in the same read as an earlier byte.
+  def read_byte(timeout_ms : Int32) : UInt8?
+    return consume_buffered_byte if @buffer_pos < @buffer_len
+    return unless wait_for_data(timeout_ms)
 
-    byte
+    fill_buffer
+    consume_buffered_byte
   end
 
   # Reads exactly `count` bytes from the input.
@@ -79,9 +87,17 @@ class Termisu::Reader
   # Returns `nil` if no data is available.
   def peek_byte : UInt8?
     fill_buffer if @buffer_pos >= @buffer_len
-    return if @buffer_pos >= @buffer_len
+    peek_buffered_byte
+  end
 
-    @buffer[@buffer_pos]
+  # Peeks at the next byte, waiting at most `timeout_ms` for the file descriptor.
+  # Buffered bytes remain visible after the timeout has expired.
+  def peek_byte(timeout_ms : Int32) : UInt8?
+    return peek_buffered_byte if @buffer_pos < @buffer_len
+    return unless wait_for_data(timeout_ms)
+
+    fill_buffer
+    peek_buffered_byte
   end
 
   # Checks if data is available for reading.
@@ -229,6 +245,20 @@ class Termisu::Reader
       # ENOMEM: Unable to allocate memory
       raise Termisu::IOError.select_failed(errno)
     end
+  end
+
+  private def consume_buffered_byte : UInt8?
+    return if @buffer_pos >= @buffer_len
+
+    byte = @buffer[@buffer_pos]
+    @buffer_pos += 1
+    byte
+  end
+
+  private def peek_buffered_byte : UInt8?
+    return if @buffer_pos >= @buffer_len
+
+    @buffer[@buffer_pos]
   end
 
   # Clears any buffered data.


### PR DESCRIPTION
## Summary
- apply one absolute monotonic poll deadline across UTF-8, CSI/Kitty, SS3, mouse, and related escape continuations
- add deadline-aware Reader byte/peek operations that still consume buffered and fd-ready bytes at zero timeout
- cover split boundaries, truncated input, and deterministic multi-byte drip-feed behavior

## Testing
- `unbuffer mise exec -- crystal spec spec/termisu/reader_spec.cr spec/termisu/input spec/termisu/event/source/input_spec.cr` (239 examples)
- `mise exec -- bin/hace format:check`
- `mise exec -- bin/hace ameba` (157 files)
- `mise exec -- bin/hace spec` (1279 examples, 1 pending)

## Compatibility
No breaking API changes. Existing no-argument Reader operations are unchanged; new timeout overloads preserve nonblocking zero-timeout behavior for bytes that are already buffered or fd-ready.
