### PR TITLE
fix: make terminal lifecycle failure-atomic

### DIFF
--- a/spec/support/test_helpers.cr
+++ b/spec/support/test_helpers.cr
@@ -3,6 +3,48 @@
 # Contains utility classes that aid in testing but aren't
 # mock implementations of production code.
 module TestHelpers
+  class RaisingLogIO < IO
+    def read(slice : Bytes) : Int32
+      0
+    end
+
+    def write(slice : Bytes) : Nil
+      raise IO::Error.new("injected logging failure")
+    end
+  end
+
+  def with_raising_lifecycle_logs(&)
+    was_backend = Termisu::Logging.backend
+    was_log_file = Termisu::Logging.log_file
+    was_async = Termisu::Logging.async_mode?
+    was_configured = Termisu::Logging.configured?
+
+    begin
+      # Keep Logging.close inside the block from detaching or closing the
+      # process-wide configuration that this fault injector must preserve.
+      Termisu::Logging.backend = nil
+      Termisu::Logging.log_file = nil
+      Termisu::Logging.async_mode = false
+      Termisu::Logging.configured = true
+      backend = ::Log::IOBackend.new(
+        io: RaisingLogIO.new,
+        dispatcher: ::Log::DispatchMode::Direct,
+      )
+      ::Log.builder.bind("*", ::Log::Severity::Trace, backend)
+
+      begin
+        yield
+      ensure
+        ::Log.builder.unbind("*", ::Log::Severity::Trace, backend)
+      end
+    ensure
+      Termisu::Logging.backend = was_backend
+      Termisu::Logging.log_file = was_log_file
+      Termisu::Logging.async_mode = was_async
+      Termisu::Logging.configured = was_configured
+    end
+  end
+
   # Helper class to hold mutable size values for testing.
   #
   # Crystal closures capture variables by reference, so modifying

--- a/spec/termisu/backend_spec.cr
+++ b/spec/termisu/backend_spec.cr
@@ -1,5 +1,11 @@
 require "../spec_helper"
 
+private class RestoreFailureBackend < Termisu::Terminal::Backend
+  def disable_raw_mode
+    raise "termios restore failed"
+  end
+end
+
 describe Termisu::Renderer do
   describe "abstract interface" do
     it "tracks method calls correctly" do
@@ -127,6 +133,15 @@ describe Termisu::Terminal::Backend do
 
       # Multiple closes should be safe
       backend.close
+      backend.close
+    end
+
+    it "closes descriptors when termios restoration fails and remains idempotent" do
+      backend = RestoreFailureBackend.new
+
+      expect_raises(Exception, "termios restore failed") { backend.close }
+      expect_raises(IO::Error) { backend.write("closed") }
+
       backend.close
     end
   end

--- a/spec/termisu/event/loop_spec.cr
+++ b/spec/termisu/event/loop_spec.cr
@@ -1,6 +1,73 @@
 require "../../spec_helper"
 require "../../../src/termisu/time_compat"
 
+private class FaultInjectingSource < Termisu::Event::Source
+  getter calls = [] of String
+  @running = Atomic(Bool).new(false)
+
+  def initialize(
+    @source_name : String,
+    @start_error : String? = nil,
+    @stop_error : String? = nil,
+    @all_calls : Array(String)? = nil,
+  )
+  end
+
+  def start(output : Channel(Termisu::Event::Any)) : Nil
+    @calls << "start"
+    @all_calls.try { |calls| calls << "#{name}:start" }
+    @running.set(true)
+    @start_error.try { |error| raise error }
+  end
+
+  def stop : Nil
+    @calls << "stop"
+    @all_calls.try { |calls| calls << "#{name}:stop" }
+    @running.set(false)
+    @stop_error.try { |error| raise error }
+  end
+
+  def running? : Bool
+    @running.get
+  end
+
+  def name : String
+    @source_name
+  end
+end
+
+private class YieldingStartSource < Termisu::Event::Source
+  @running = Atomic(Bool).new(false)
+  @start_entered = Channel(Nil).new(1)
+  @continue_start = Channel(Nil).new(1)
+
+  def start(output : Channel(Termisu::Event::Any)) : Nil
+    @running.set(true)
+    @start_entered.send(nil)
+    @continue_start.receive
+  end
+
+  def stop : Nil
+    @running.set(false)
+  end
+
+  def running? : Bool
+    @running.get
+  end
+
+  def name : String
+    "yielding-start"
+  end
+
+  def wait_until_starting : Nil
+    @start_entered.receive
+  end
+
+  def continue_start : Nil
+    @continue_start.send(nil)
+  end
+end
+
 describe Termisu::Event::Loop do
   describe "#initialize" do
     it "creates with default buffer size" do
@@ -150,6 +217,132 @@ describe Termisu::Event::Loop do
 
       loop.stop
     end
+
+    it "rolls back every attempted source in reverse order when startup fails" do
+      all_calls = [] of String
+      first = FaultInjectingSource.new("first", all_calls: all_calls)
+      failing = FaultInjectingSource.new(
+        "failing",
+        start_error: "startup failed",
+        stop_error: "rollback failed",
+        all_calls: all_calls,
+      )
+      unattempted = FaultInjectingSource.new("unattempted", all_calls: all_calls)
+      loop = Termisu::Event::Loop.new
+      loop.add_source(first).add_source(failing).add_source(unattempted)
+
+      error = expect_raises(Exception, "startup failed") { loop.start }
+
+      error.message.should eq("startup failed")
+      loop.running?.should be_false
+      first.calls.should eq(["start", "stop"])
+      failing.calls.should eq(["start", "stop"])
+      unattempted.calls.should be_empty
+      all_calls.should eq(["first:start", "failing:start", "failing:stop", "first:stop"])
+      first.running?.should be_false
+      failing.running?.should be_false
+      loop.output.closed?.should be_true
+
+      select
+      when event = loop.output.receive?
+        event.should be_nil
+      when timeout(100.milliseconds)
+        fail "Timeout waiting for failed loop output to close"
+      end
+    end
+
+    it "serializes stop with the complete source startup transition" do
+      yielding = YieldingStartSource.new
+      following = FaultInjectingSource.new("following")
+      loop = Termisu::Event::Loop.new
+      loop.add_source(yielding).add_source(following)
+      start_done = Channel(Nil).new(1)
+      stop_started = Channel(Nil).new(1)
+      stop_done = Channel(Nil).new(1)
+
+      spawn do
+        loop.start
+        start_done.send(nil)
+      end
+      yielding.wait_until_starting
+
+      spawn do
+        stop_started.send(nil)
+        loop.stop
+        stop_done.send(nil)
+      end
+      stop_started.receive
+
+      stopped_during_start = select
+      when stop_done.receive
+        true
+      when timeout(30.milliseconds)
+        false
+      end
+
+      yielding.continue_start
+      start_done.receive
+      stop_done.receive unless stopped_during_start
+
+      stopped_during_start.should be_false
+      loop.running?.should be_false
+      yielding.running?.should be_false
+      following.running?.should be_false
+      following.calls.should eq(["start", "stop"])
+      loop.output.closed?.should be_true
+    end
+
+    it "does not let direct logging failures change source lifecycle" do
+      source = FaultInjectingSource.new("logged")
+      loop = Termisu::Event::Loop.new
+      loop.add_source(source)
+
+      with_raising_lifecycle_logs do
+        loop.start
+        loop.running?.should be_true
+        source.running?.should be_true
+
+        loop.stop
+      end
+
+      loop.running?.should be_false
+      source.running?.should be_false
+      loop.output.closed?.should be_true
+      source.calls.should eq(["start", "stop"])
+
+      # Cleanup completed despite the logger, so retries remain no-ops.
+      loop.stop
+      source.calls.should eq(["start", "stop"])
+    end
+
+    it "preserves existing logging when fault injection block raises" do
+      backend = ::Log::MemoryBackend.new
+      logger = ::Log.for("termisu.spec.lifecycle")
+      builder = ::Log.builder
+      was_configured = Termisu::Logging.configured?
+
+      begin
+        Termisu::Logging.configured = true
+        builder.bind("*", ::Log::Severity::Info, backend)
+
+        begin
+          expect_raises(Exception, "injected block failure") do
+            with_raising_lifecycle_logs { raise "injected block failure" }
+          end
+
+          logger.debug { "filtered debug message" }
+          logger.info { "logging remains configured" }
+
+          Termisu::Logging.configured?.should be_true
+          backend.entries.map(&.severity).should eq([::Log::Severity::Info])
+          backend.entries.map(&.message).should eq(["logging remains configured"])
+        ensure
+          builder.unbind("*", ::Log::Severity::Info, backend)
+        end
+      ensure
+        Termisu::Logging.configured = was_configured
+      end
+    end
   end
 
   describe "#stop" do
@@ -221,6 +414,26 @@ describe Termisu::Event::Loop do
 
       # Should complete within shutdown timeout + buffer
       elapsed.should be < 200.milliseconds
+    end
+
+    it "stops every source and closes output while preserving the first failure" do
+      first = FaultInjectingSource.new("first", stop_error: "first stop failed")
+      second = FaultInjectingSource.new("second", stop_error: "second stop failed")
+      loop = Termisu::Event::Loop.new
+      loop.add_source(first).add_source(second)
+      loop.start
+
+      expect_raises(Exception, "first stop failed") { loop.stop }
+
+      first.calls.should eq(["start", "stop"])
+      second.calls.should eq(["start", "stop"])
+      loop.running?.should be_false
+      loop.output.closed?.should be_true
+
+      # A failed close still completes the lifecycle and remains idempotent.
+      loop.stop
+      first.calls.should eq(["start", "stop"])
+      second.calls.should eq(["start", "stop"])
     end
   end
 

--- a/spec/termisu/terminal_spec.cr
+++ b/spec/termisu/terminal_spec.cr
@@ -14,13 +14,72 @@ end
 
 private class FailingExitFlushTerminal < Termisu::Terminal
   property? fail_next_flush = false
+  getter writes = [] of String
+
+  def write(data : String)
+    @writes << data
+  end
 
   def flush
     if @fail_next_flush
       @fail_next_flush = false
       raise IO::Error.new("alternate screen exit failed")
     end
+  end
+end
+
+private class InitializationFailureBackend < Termisu::Terminal::Backend
+  getter close_calls : Int32 = 0
+
+  def size : {Int32, Int32}
+    raise "size failed"
+  end
+
+  def close
+    @close_calls += 1
     super
+    raise "cleanup failed"
+  end
+end
+
+private class RecordingCloseBackend < Termisu::Terminal::Backend
+  getter close_calls : Int32 = 0
+
+  def close
+    @close_calls += 1
+    super
+  end
+end
+
+private class LoggingLifecycleTerminal < Termisu::Terminal
+  def write(data : String)
+  end
+
+  def flush
+  end
+end
+
+private class FaultInjectingTerminal < Termisu::Terminal
+  getter cleanup_calls = [] of String
+
+  def disable_mouse
+    @cleanup_calls << "mouse"
+    raise "mouse cleanup failed"
+  end
+
+  def disable_enhanced_keyboard
+    @cleanup_calls << "keyboard"
+    raise "keyboard cleanup failed"
+  end
+
+  def disable_bracketed_paste
+    @cleanup_calls << "paste"
+    raise "paste cleanup failed"
+  end
+
+  def exit_alternate_screen
+    @cleanup_calls << "screen"
+    raise "screen cleanup failed"
   end
 end
 
@@ -32,6 +91,18 @@ describe Termisu::Terminal do
       terminal.outfd.should be >= 0
     ensure
       terminal.try &.close
+    end
+
+    it "closes its backend without replacing the initialization failure" do
+      backend = InitializationFailureBackend.new
+
+      expect_raises(Exception, "size failed") do
+        Termisu::Terminal.new(backend: backend, terminfo: Termisu::Terminfo.new)
+      end
+
+      backend.close_calls.should eq(1)
+      # Backend close completed despite its injected post-close failure.
+      expect_raises(IO::Error) { backend.write("closed") }
     end
   end
 
@@ -155,6 +226,40 @@ describe Termisu::Terminal do
 
       # Cleanup and descriptor closure are not retried by repeated close.
       terminal.close
+    ensure
+      terminal.try &.close
+    end
+
+    it "attempts every stage and preserves the first failure" do
+      backend = RecordingCloseBackend.new
+      terminal = FaultInjectingTerminal.new(backend: backend, terminfo: Termisu::Terminfo.new)
+
+      expect_raises(Exception, "mouse cleanup failed") { terminal.close }
+
+      terminal.cleanup_calls.should eq(["mouse", "keyboard", "paste", "screen"])
+      backend.close_calls.should eq(1)
+      expect_raises(IO::Error) { backend.write("closed") }
+
+      # Cleanup was completed, so repeated close is a no-op even after failure.
+      terminal.close
+      backend.close_calls.should eq(1)
+    end
+
+    it "restores modes and closes the backend when direct logging fails" do
+      backend = RecordingCloseBackend.new
+      terminal = LoggingLifecycleTerminal.new(backend: backend, terminfo: Termisu::Terminfo.new)
+      terminal.enable_raw_mode
+      terminal.enter_alternate_screen
+
+      with_raising_lifecycle_logs { terminal.close }
+
+      terminal.raw_mode?.should be_false
+      terminal.alternate_screen?.should be_false
+      backend.close_calls.should eq(1)
+      expect_raises(IO::Error) { backend.write("closed") }
+
+      terminal.close
+      backend.close_calls.should eq(1)
     ensure
       terminal.try &.close
     end
@@ -347,6 +452,29 @@ describe Termisu::Terminal do
       terminal.with_mode(Termisu::Terminal::Mode.cooked, preserve_screen: false) do
         terminal.current_mode.should eq(Termisu::Terminal::Mode.cooked)
       end
+    ensure
+      terminal.try &.close
+    end
+
+    it "switches modes and restores terminal state when direct logging fails" do
+      terminal = CaptureTerminal.new(sync_updates: false)
+      terminal.enable_raw_mode
+      terminal.enter_alternate_screen
+      terminal.enable_mouse
+      terminal.enable_bracketed_paste
+
+      with_raising_lifecycle_logs do
+        terminal.with_mode(Termisu::Terminal::Mode.cooked) do
+          terminal.alternate_screen?.should be_false
+          terminal.mouse_enabled?.should be_false
+          terminal.bracketed_paste?.should be_false
+        end
+      end
+
+      terminal.raw_mode?.should be_true
+      terminal.alternate_screen?.should be_true
+      terminal.mouse_enabled?.should be_true
+      terminal.bracketed_paste?.should be_true
     ensure
       terminal.try &.close
     end

--- a/spec/termisu_spec.cr
+++ b/spec/termisu_spec.cr
@@ -57,6 +57,52 @@ private class FailingCloseTerminal < CaptureTerminal
   end
 end
 
+private class LifecycleTerminal < CaptureTerminal
+  class_property? fail_close : Bool = false
+
+  def close
+    super
+    @backend.close
+    raise "terminal cleanup failed" if self.class.fail_close?
+  end
+end
+
+private class LifecycleEventLoop < Termisu::Event::Loop
+  class_property? fail_start : Bool = false
+  class_property? fail_stop : Bool = false
+  getter stop_calls : Int32 = 0
+
+  def start : self
+    super
+    raise "source startup failed" if self.class.fail_start?
+    self
+  end
+
+  def stop : self
+    @stop_calls += 1
+    super
+    raise "event stop failed" if self.class.fail_stop?
+    self
+  end
+end
+
+private class LifecycleTermisu < Termisu
+  class_property last_terminal : LifecycleTerminal?
+  class_property last_event_loop : LifecycleEventLoop?
+
+  protected def build_terminal(sync_updates : Bool) : Termisu::Terminal
+    terminal = LifecycleTerminal.new(sync_updates: sync_updates)
+    self.class.last_terminal = terminal
+    terminal
+  end
+
+  protected def build_event_loop : Termisu::Event::Loop
+    event_loop = LifecycleEventLoop.new
+    self.class.last_event_loop = event_loop
+    event_loop
+  end
+end
+
 # Build the public facade around controlled collaborators so mode coordination
 # can be tested independently of its normal initialization lifecycle.
 class Termisu
@@ -127,6 +173,25 @@ describe Termisu do
         second.try(&.close)
         third.try(&.close)
       end
+
+      it "rolls back sources and terminal state without replacing the startup failure" do
+        LifecycleEventLoop.fail_start = true
+        LifecycleTerminal.fail_close = true
+
+        expect_raises(Exception, "source startup failed") do
+          LifecycleTermisu.new(sync_updates: false)
+        end
+
+        terminal = LifecycleTermisu.last_terminal || fail "terminal was not built"
+        event_loop = LifecycleTermisu.last_event_loop || fail "event loop was not built"
+        terminal.closed?.should be_true
+        terminal.raw_mode?.should be_false
+        event_loop.running?.should be_false
+        event_loop.stop_calls.should eq(1)
+      ensure
+        LifecycleEventLoop.fail_start = false
+        LifecycleTerminal.fail_close = false
+      end
     else
       it "raises IO::Error without a controlling TTY" do
         expect_raises(IO::Error) do
@@ -181,6 +246,30 @@ describe Termisu do
       lease.try &.release
       LibC.close(read_fd) if read_fd
       LibC.close(write_fd) if write_fd
+    end
+
+    if controlling_tty?
+      it "ignores logging failures, preserves shutdown errors, and remains idempotent" do
+        termisu = LifecycleTermisu.new(sync_updates: false)
+        event_loop = LifecycleTermisu.last_event_loop || fail "event loop was not built"
+        terminal = LifecycleTermisu.last_terminal || fail "terminal was not built"
+        LifecycleEventLoop.fail_stop = true
+
+        with_raising_lifecycle_logs do
+          expect_raises(Exception, "event stop failed") { termisu.close }
+        end
+
+        terminal.closed?.should be_true
+        terminal.raw_mode?.should be_false
+        event_loop.stop_calls.should eq(1)
+
+        termisu.close
+        event_loop.stop_calls.should eq(1)
+      ensure
+        LifecycleEventLoop.fail_stop = false
+      end
+    else
+      pending "exercises close failure injection (no controlling TTY)"
     end
   end
 

--- a/src/termisu.cr
+++ b/src/termisu.cr
@@ -78,50 +78,72 @@ class Termisu
     resize_source: Event::Source::Resize,
     event_loop: Event::Loop,
   )
-    Logging.setup
-    Log.info { "Initializing Termisu v#{VERSION}" }
+    terminal = nil.as(Terminal?)
+    reader = nil.as(Reader?)
+    input_parser = nil.as(Input::Parser?)
+    input_source = nil.as(Event::Source::Input?)
+    resize_source = nil.as(Event::Source::Resize?)
+    event_loop = nil.as(Event::Loop?)
 
-    # Resolve terminfo before opening the TTY so this failure path has no
-    # partially-created backend to clean up.
+    begin
+      Logging.setup
+      lifecycle_log { Log.info { "Initializing Termisu v#{VERSION}" } }
+
+      terminal = build_terminal(sync_updates)
+      reader = Reader.new(terminal.infd)
+      input_parser = Input::Parser.new(reader)
+
+      lifecycle_log { Log.debug { "Terminal size: #{terminal.size}" } }
+
+      # Create async event sources before acquiring terminal modes.
+      input_source = Event::Source::Input.new(reader, input_parser)
+      # Must be query_size (live ioctl), not size (cached) - the resize
+      # source detects changes by re-querying the terminal dimensions.
+      resize_terminal = terminal
+      resize_source = Event::Source::Resize.new(-> { resize_terminal.query_size })
+
+      event_loop = build_event_loop
+      event_loop.add_source(input_source)
+      event_loop.add_source(resize_source)
+
+      terminal.enable_raw_mode
+      event_loop.start
+
+      lifecycle_log { Log.debug { "Event loop started with sources: #{event_loop.source_names}" } }
+
+      terminal.enter_alternate_screen
+      lifecycle_log { Log.debug { "Raw mode enabled, alternate screen entered" } }
+    rescue error
+      event_loop.try(&.stop) rescue nil
+      reader.try(&.close) rescue nil
+      terminal.try(&.close) rescue nil
+      Logging.flush rescue nil
+      Logging.close
+      raise error
+    end
+
+    if terminal && reader && input_parser && input_source && resize_source && event_loop
+      {
+        terminal:      terminal,
+        reader:        reader,
+        input_parser:  input_parser,
+        input_source:  input_source,
+        resize_source: resize_source,
+        event_loop:    event_loop,
+      }
+    else
+      raise Termisu::Error.new("Termisu initialization completed without all components")
+    end
+  end
+
+  protected def build_terminal(sync_updates : Bool) : Terminal
+    # Resolve terminfo before opening the TTY so failure cannot leak a backend.
     terminfo = Terminfo.new
-    terminal = Terminal.new(terminfo: terminfo, sync_updates: sync_updates)
-    reader = Reader.new(terminal.infd)
-    input_parser = Input::Parser.new(reader)
+    Terminal.new(terminfo: terminfo, sync_updates: sync_updates)
+  end
 
-    Log.debug { "Terminal size: #{terminal.size}" }
-
-    terminal.enable_raw_mode
-
-    input_source = Event::Source::Input.new(reader, input_parser)
-    # Must be query_size (live ioctl), not size (cached) - the resize
-    # source detects changes by re-querying the terminal dimensions.
-    resize_source = Event::Source::Resize.new(-> { terminal.as(Terminal).query_size })
-
-    event_loop = Event::Loop.new
-    event_loop.add_source(input_source)
-    event_loop.add_source(resize_source)
-    event_loop.start
-
-    Log.debug { "Event loop started with sources: #{event_loop.source_names}" }
-
-    terminal.enter_alternate_screen
-    Log.debug { "Raw mode enabled, alternate screen entered" }
-
-    {
-      terminal:      terminal,
-      reader:        reader,
-      input_parser:  input_parser,
-      input_source:  input_source,
-      resize_source: resize_source,
-      event_loop:    event_loop,
-    }
-  rescue ex
-    event_loop.try(&.stop) rescue nil
-    reader.try(&.close) rescue nil
-    terminal.try(&.close) rescue nil
-    Logging.flush rescue nil
-    Logging.close rescue nil
-    raise ex
+  protected def build_event_loop : Event::Loop
+    Event::Loop.new
   end
 
   # Closes Termisu and cleans up all resources.
@@ -137,14 +159,14 @@ class Termisu
   def close
     return unless @closed.compare_and_set(false, true)[1]
 
-    Log.info { "Closing Termisu" }
+    lifecycle_log { Log.info { "Closing Termisu" } }
 
     # Keep ownership until every process-global and terminal resource has been
     # shut down. Preserve the first failure while still running every cleanup
     # step and releasing the ownership lease.
     error = capture_cleanup_error(nil) do
       @event_loop.stop
-      Log.debug { "Event loop stopped" }
+      lifecycle_log { Log.debug { "Event loop stopped" } }
     end
     error = capture_cleanup_error(error) { @reader.close }
     error = capture_cleanup_error(error) { @terminal.close }
@@ -159,6 +181,12 @@ class Termisu
     error
   rescue ex
     error || ex
+  end
+
+  private def lifecycle_log(&) : Nil
+    yield
+  rescue
+    # Logging must never change lifecycle state or prevent cleanup.
   end
 
   # --- Terminal Operations ---

--- a/src/termisu/event/loop.cr
+++ b/src/termisu/event/loop.cr
@@ -58,6 +58,7 @@ class Termisu::Event::Loop
   @sources : Array(Source)
   @output : Channel(Any)
   @running : Atomic(Bool)
+  @lifecycle_lock : Mutex
 
   # Creates a new Event::Loop with the specified buffer size.
   #
@@ -67,6 +68,7 @@ class Termisu::Event::Loop
     @sources = [] of Source
     @output = Channel(Any).new(buffer_size)
     @running = Atomic(Bool).new(false)
+    @lifecycle_lock = Mutex.new(:reentrant)
     Log.debug { "Event::Loop created with buffer_size=#{buffer_size}" }
   end
 
@@ -77,12 +79,14 @@ class Termisu::Event::Loop
   #
   # Returns self for method chaining.
   def add_source(source : Source) : self
-    @sources << source
-    Log.debug { "Added source: #{source.name}" }
+    @lifecycle_lock.synchronize do
+      @sources << source
+      Log.debug { "Added source: #{source.name}" }
 
-    if @running.get
-      source.start(@output)
-      Log.debug { "Auto-started source: #{source.name}" }
+      if @running.get
+        source.start(@output)
+        Log.debug { "Auto-started source: #{source.name}" }
+      end
     end
 
     self
@@ -95,13 +99,15 @@ class Termisu::Event::Loop
   #
   # Returns self for method chaining.
   def remove_source(source : Source) : self
-    if @sources.includes?(source)
-      if source.running?
-        source.stop
-        Log.debug { "Stopped source before removal: #{source.name}" }
+    @lifecycle_lock.synchronize do
+      if @sources.includes?(source)
+        if source.running?
+          source.stop
+          Log.debug { "Stopped source before removal: #{source.name}" }
+        end
+        @sources.delete(source)
+        Log.debug { "Removed source: #{source.name}" }
       end
-      @sources.delete(source)
-      Log.debug { "Removed source: #{source.name}" }
     end
 
     self
@@ -114,16 +120,34 @@ class Termisu::Event::Loop
   #
   # Returns self for method chaining.
   def start : self
-    return self unless @running.compare_and_set(false, true)
+    @lifecycle_lock.synchronize do
+      _, started = @running.compare_and_set(false, true)
+      return self unless started
 
-    Log.info { "Starting Event::Loop with #{@sources.size} source(s)" }
+      lifecycle_log { Log.info { "Starting Event::Loop with #{@sources.size} source(s)" } }
 
-    @sources.each do |source|
-      source.start(@output)
-      Log.debug { "Started source: #{source.name}" }
+      attempted = [] of Source
+      begin
+        @sources.each do |source|
+          # Include the source before starting it: a failed start may still have
+          # acquired resources which its stop method must release.
+          attempted << source
+          source.start(@output)
+          lifecycle_log { Log.debug { "Started source: #{source.name}" } }
+        end
+      rescue error
+        @running.set(false)
+        attempted.reverse_each do |source|
+          # Preserve the startup failure while still rolling back every source.
+          source.stop rescue nil
+        end
+        # A close failure must not replace the original startup failure.
+        @output.close rescue nil
+        raise error
+      end
+
+      lifecycle_log { Log.debug { "All sources started: #{source_names}" } }
     end
-
-    Log.debug { "All sources started: #{source_names}" }
 
     self
   end
@@ -141,24 +165,42 @@ class Termisu::Event::Loop
   #
   # Returns self for method chaining.
   def stop : self
-    return self unless @running.compare_and_set(true, false)
+    @lifecycle_lock.synchronize do
+      _, stopped = @running.compare_and_set(true, false)
+      return self unless stopped
 
-    Log.info { "Stopping Event::Loop" }
+      lifecycle_log { Log.info { "Stopping Event::Loop" } }
 
-    @sources.each do |source|
-      source.stop
-      Log.debug { "Stopped source: #{source.name}" }
+      first_error = nil.as(Exception?)
+      @sources.each do |source|
+        error = begin
+          source.stop
+          lifecycle_log { Log.debug { "Stopped source: #{source.name}" } }
+          nil
+        rescue ex
+          ex
+        end
+        first_error ||= error
+      end
+
+      # Brief yield to allow fibers to exit gracefully
+      # This prevents Channel::ClosedError in well-behaved sources
+      sleep SHUTDOWN_TIMEOUT_MS.milliseconds / 10
+      Fiber.yield
+
+      @output.close unless @output.closed?
+      lifecycle_log { Log.debug { "Output channel closed" } }
+
+      raise first_error if first_error
     end
 
-    # Brief yield to allow fibers to exit gracefully
-    # This prevents Channel::ClosedError in well-behaved sources
-    sleep SHUTDOWN_TIMEOUT_MS.milliseconds / 10
-    Fiber.yield
-
-    @output.close unless @output.closed?
-    Log.debug { "Output channel closed" }
-
     self
+  end
+
+  private def lifecycle_log(&) : Nil
+    yield
+  rescue
+    # Logging must never change lifecycle state or prevent cleanup.
   end
 
   # Returns true if the event loop is currently running.
@@ -180,6 +222,6 @@ class Termisu::Event::Loop
   #
   # Useful for logging and debugging.
   def source_names : Array(String)
-    @sources.map(&.name)
+    @lifecycle_lock.synchronize { @sources.map(&.name) }
   end
 end

--- a/src/termisu/event/source.cr
+++ b/src/termisu/event/source.cr
@@ -79,6 +79,12 @@ abstract class Termisu::Event::Source
   # Examples: "input", "resize", "timer", "custom-network"
   abstract def name : String
 
+  protected def lifecycle_log(&) : Nil
+    yield
+  rescue
+    # Logging must never change lifecycle state or prevent cleanup.
+  end
+
   protected def send_nonblocking(output : Channel(Event::Any), event : Event::Any) : Bool
     select
     when output.send(event)

--- a/src/termisu/event/source/input.cr
+++ b/src/termisu/event/source/input.cr
@@ -78,7 +78,7 @@ class Termisu::Event::Source::Input < Termisu::Event::Source
       run_loop
     end
 
-    Log.debug { "Input source started" }
+    lifecycle_log { Log.debug { "Input source started" } }
   end
 
   # Stops polling for input events.
@@ -88,7 +88,7 @@ class Termisu::Event::Source::Input < Termisu::Event::Source
   # stop operations.
   def stop : Nil
     return unless @running.compare_and_set(true, false)
-    Log.debug { "Input source stopped" }
+    lifecycle_log { Log.debug { "Input source stopped" } }
   end
 
   # Returns true if the input source is currently running.

--- a/src/termisu/event/source/resize.cr
+++ b/src/termisu/event/source/resize.cr
@@ -133,7 +133,7 @@ class Termisu::Event::Source::Resize < Termisu::Event::Source
       run_loop(generation)
     end
 
-    Log.debug { "Resize source started, initial size: #{initial_width}x#{initial_height}" }
+    lifecycle_log { Log.debug { "Resize source started, initial size: #{initial_width}x#{initial_height}" } }
   end
 
   # Stops monitoring for resize events.
@@ -153,7 +153,7 @@ class Termisu::Event::Source::Resize < Termisu::Event::Source
     # on its next poll cycle, up to one @poll_interval delay)
     Fiber.yield
 
-    Log.debug { "Resize source stopped" }
+    lifecycle_log { Log.debug { "Resize source stopped" } }
   end
 
   # Returns true if the resize source is currently running.

--- a/src/termisu/event/source/system_timer.cr
+++ b/src/termisu/event/source/system_timer.cr
@@ -96,7 +96,7 @@ class Termisu::Event::Source::SystemTimer < Termisu::Event::Source
       run_loop(run_token)
     end
 
-    Log.debug { "SystemTimer started with interval=#{@interval} using #{poller.class.name}" }
+    lifecycle_log { Log.debug { "SystemTimer started with interval=#{@interval} using #{poller.class.name}" } }
   end
 
   # Stops generating tick events and releases resources.
@@ -110,7 +110,7 @@ class Termisu::Event::Source::SystemTimer < Termisu::Event::Source
     @poller = nil
     @timer_handle = nil
 
-    Log.debug { "SystemTimer stopped" }
+    lifecycle_log { Log.debug { "SystemTimer stopped" } }
   end
 
   # Returns true if the timer is currently running.

--- a/src/termisu/event/source/timer.cr
+++ b/src/termisu/event/source/timer.cr
@@ -91,7 +91,7 @@ class Termisu::Event::Source::Timer < Termisu::Event::Source
       run_loop(run_token)
     end
 
-    Log.debug { "Timer started with interval=#{@interval}" }
+    lifecycle_log { Log.debug { "Timer started with interval=#{@interval}" } }
   end
 
   # Stops generating tick events.
@@ -107,7 +107,7 @@ class Termisu::Event::Source::Timer < Termisu::Event::Source
     # but the stale token makes it exit instead of double-ticking.
     advance_run_token
 
-    Log.debug { "Timer stopped" }
+    lifecycle_log { Log.debug { "Timer stopped" } }
   end
 
   # Returns true if the timer is currently running.

--- a/src/termisu/terminal.cr
+++ b/src/termisu/terminal.cr
@@ -57,21 +57,35 @@ class Termisu::Terminal < Termisu::Renderer
   # - `terminfo` - Terminfo instance for capability strings (default: Terminfo.new)
   # - `sync_updates` - Enable DEC mode 2026 synchronized updates (default: true)
   def initialize(
-    @backend : Terminal::Backend = Terminal::Backend.new,
-    @terminfo : Terminfo = Terminfo.new,
+    backend : Terminal::Backend? = nil,
+    terminfo : Terminfo? = nil,
     *,
     @sync_updates : Bool = true,
   )
-    @buffer = initial_buffer
-    Log.debug { "Terminal initialized: #{@buffer.width}x#{@buffer.height}, sync_updates: #{@sync_updates}" }
+    @backend = backend || Terminal::Backend.new
+    @terminfo = terminfo || build_terminfo
+    @buffer = build_buffer
+    lifecycle_log do
+      Log.debug { "Terminal initialized: #{@buffer.width}x#{@buffer.height}, sync_updates: #{@sync_updates}" }
+    end
   end
 
-  private def initial_buffer : Buffer
+  private def build_terminfo : Terminfo
+    Terminfo.new
+  rescue error
+    close_backend_after_initialization_failure(error)
+  end
+
+  private def build_buffer : Buffer
     width, height = size
     Buffer.new(width, height)
-  rescue ex
+  rescue error
+    close_backend_after_initialization_failure(error)
+  end
+
+  private def close_backend_after_initialization_failure(error : Exception) : NoReturn
     @backend.close rescue nil
-    raise ex
+    raise error
   end
 
   # Enters alternate screen mode.
@@ -81,7 +95,7 @@ class Termisu::Terminal < Termisu::Renderer
   # render state since we're entering a fresh screen.
   def enter_alternate_screen
     return if @alternate_screen
-    Log.debug { "Entering alternate screen" }
+    lifecycle_log { Log.debug { "Entering alternate screen" } }
 
     # Record the transition before emitting anything so a partial write is
     # always paired with a best-effort exit during rollback.
@@ -106,7 +120,7 @@ class Termisu::Terminal < Termisu::Renderer
   # main screen which may have different state.
   def exit_alternate_screen
     return unless @alternate_screen
-    Log.debug { "Exiting alternate screen" }
+    lifecycle_log { Log.debug { "Exiting alternate screen" } }
 
     # Clear first so shutdown is exactly-once even when output fails. Continue
     # through every restoration step and report the first error afterwards.
@@ -479,13 +493,13 @@ class Termisu::Terminal < Termisu::Renderer
 
   # Enables raw mode on the terminal.
   def enable_raw_mode
-    Log.debug { "Enabling raw mode" }
+    lifecycle_log { Log.debug { "Enabling raw mode" } }
     @backend.enable_raw_mode
   end
 
   # Disables raw mode on the terminal.
   def disable_raw_mode
-    Log.debug { "Disabling raw mode" }
+    lifecycle_log { Log.debug { "Disabling raw mode" } }
     @backend.disable_raw_mode
   end
 
@@ -548,7 +562,7 @@ class Termisu::Terminal < Termisu::Renderer
   # # Previous mode and screen state restored
   # ```
   def with_mode(mode : Terminal::Mode, preserve_screen : Bool = false, &)
-    Log.debug { "Entering with_mode: #{mode}, preserve_screen: #{preserve_screen}" }
+    lifecycle_log { Log.debug { "Entering with_mode: #{mode}, preserve_screen: #{preserve_screen}" } }
     user_interactive = mode.canonical? || mode.echo?
 
     # Track state to restore
@@ -587,7 +601,7 @@ class Termisu::Terminal < Termisu::Renderer
     # Switch mode via backend (handles termios and tracking)
     with_backend_mode(mode) { yield }
   ensure
-    Log.debug { "Exiting with_mode, restoring state" }
+    lifecycle_log { Log.debug { "Exiting with_mode, restoring state" } }
     if was_in_alternate && !@alternate_screen
       enter_alternate_screen
     end
@@ -672,7 +686,7 @@ class Termisu::Terminal < Termisu::Renderer
   def close
     return unless @terminal_closed.compare_and_set(false, true)[1]
 
-    Log.debug { "Closing terminal" }
+    lifecycle_log { Log.debug { "Closing terminal" } }
     error = capture_cleanup_error(nil) { disable_mouse }
     error = capture_cleanup_error(error) { disable_enhanced_keyboard }
     error = capture_cleanup_error(error) { disable_bracketed_paste }
@@ -688,6 +702,12 @@ class Termisu::Terminal < Termisu::Renderer
     error
   rescue ex
     error || ex
+  end
+
+  private def lifecycle_log(&) : Nil
+    yield
+  rescue
+    # Logging must never change lifecycle state or prevent cleanup.
   end
 
   # --- Cell Buffer Operations ---
@@ -886,7 +906,7 @@ class Termisu::Terminal < Termisu::Renderer
   # Disables both SGR and normal mouse protocols.
   def disable_mouse
     return unless @mouse_enabled
-    Log.debug { "Disabling mouse tracking" }
+    lifecycle_log { Log.debug { "Disabling mouse tracking" } }
     @mouse_enabled = false
     apply_mouse_state false
     flush
@@ -931,7 +951,7 @@ class Termisu::Terminal < Termisu::Renderer
   # are indistinguishable.
   def disable_enhanced_keyboard
     return unless @enhanced_keyboard
-    Log.debug { "Disabling enhanced keyboard protocol" }
+    lifecycle_log { Log.debug { "Disabling enhanced keyboard protocol" } }
     @enhanced_keyboard = false
     apply_enhanced_keyboard_state false
     flush
@@ -979,7 +999,7 @@ class Termisu::Terminal < Termisu::Renderer
   # Pasted text goes back to arriving as plain input with no boundary markers.
   def disable_bracketed_paste
     return unless @bracketed_paste
-    Log.debug { "Disabling bracketed paste" }
+    lifecycle_log { Log.debug { "Disabling bracketed paste" } }
     @bracketed_paste = false
     apply_bracketed_paste_state false
     flush

--- a/src/termisu/terminal/backend.cr
+++ b/src/termisu/terminal/backend.cr
@@ -180,11 +180,22 @@ class Termisu::Terminal::Backend
   def close
     return unless @closed.compare_and_set(false, true)[1]
 
+    restore_error = nil.as(Exception?)
     begin
       disable_raw_mode
-    ensure
-      @tty.close
+    rescue ex
+      restore_error = ex
     end
+
+    begin
+      @tty.close
+    rescue error
+      # Restoring termios is the first failure to report, but descriptor
+      # closure is always attempted and is reported when restoration worked.
+      restore_error ||= error
+    end
+
+    raise restore_error if restore_error
   end
 end
 


### PR DESCRIPTION
## Summary
- stage terminal and event-loop acquisition so partial initialization unwinds in reverse order
- attempt all shutdown stages while preserving the first cleanup error and keeping close idempotent
- make lifecycle logging best-effort so direct logging failures cannot strand sources, terminal modes, or descriptors
- add focused fault-injection coverage for startup, shutdown, termios, descriptor, and logging failures

## Testing
- `mise exec -- unbuffer crystal spec spec/termisu_spec.cr spec/termisu/terminal_spec.cr spec/termisu/event/loop_spec.cr --no-color` (129 examples, 0 failures, 1 pending)
- `mise exec -- bin/hace format:check`
- `mise exec -- bin/hace ameba` (157 files, 0 failures)
- `mise exec -- bin/hace spec` (1284 examples, 0 failures, 1 pending)
- `mise exec -- bin/hace e2e` (81 examples, 0 failures)

## Compatibility
No public API changes. Multi-instance terminal ownership remains unchanged and is intentionally out of scope.
