### PR TITLE
fix: enforce single terminal ownership

### DIFF
--- a/spec/termisu/ffi_spec.cr
+++ b/spec/termisu/ffi_spec.cr
@@ -31,6 +31,125 @@ private def ffi_cell_op(x : Int32, y : Int32, codepoint : Int32) : Termisu::FFI:
   op
 end
 
+private def assert_ffi_blocking_poll_cancelled(*, destroy : Bool) : Nil
+  handle = termisu_create(0_u8)
+  handle.should_not eq(0_u64)
+  context = Termisu::FFI::Registry.fetch(handle) || fail("created FFI context was not registered")
+  poll_status = Atomic(Int32).new(Int32::MIN)
+
+  poll_thread = Thread.new do
+    event = uninitialized Termisu::FFI::ABI::Event
+    poll_status.set(termisu_poll_event(handle, -1, pointerof(event)))
+  end
+
+  deadline = monotonic_now + 5.seconds
+  until context.operations_in_flight?
+    raise "exported blocking poll did not start" if monotonic_now >= deadline
+    sleep 1.millisecond
+  end
+
+  # Invoke the exported shutdown concurrently with the poll. A regression here
+  # blocks this call indefinitely instead of reaching the assertions below.
+  shutdown_status = destroy ? termisu_destroy(handle) : termisu_close(handle)
+
+  poll_thread.join
+  shutdown_status.should eq(Termisu::FFI::Status::Ok.value)
+  poll_status.get.should eq(Termisu::FFI::Status::Timeout.value)
+ensure
+  termisu_destroy(handle) if handle && handle != 0_u64
+end
+
+private def run_ffi_scheduler_close_scenario(scenario : String) : Nil
+  context = Termisu::FFI::Context.new(sync_updates: false)
+
+  case scenario
+  when "in_flight"
+    operation_started = Atomic(Bool).new(false)
+    release_operation = Atomic(Bool).new(false)
+    operation_finished = Atomic(Bool).new(false)
+
+    spawn do
+      context.with_operation do
+        operation_started.set(true)
+        until release_operation.get
+          Fiber.yield
+        end
+      end
+      operation_finished.set(true)
+    end
+    until operation_started.get
+      Fiber.yield
+    end
+
+    spawn { release_operation.set(true) }
+    context.close
+    raise "in-flight operation fiber did not finish" unless operation_finished.get
+  when "contended"
+    operation_started = Atomic(Bool).new(false)
+    release_operation = Atomic(Bool).new(false)
+    winner_finished = Atomic(Bool).new(false)
+    loser_finished = Atomic(Bool).new(false)
+
+    spawn do
+      context.with_operation do
+        operation_started.set(true)
+        until release_operation.get
+          Fiber.yield
+        end
+      end
+    end
+    until operation_started.get
+      Fiber.yield
+    end
+
+    spawn do
+      context.close
+      winner_finished.set(true)
+    end
+    while context.with_operation { true }
+      Fiber.yield
+    end
+
+    # Queue the losing close ahead of the releaser. It must yield its fiber so
+    # the operation and winning close can finish and publish @closed.
+    spawn do
+      context.close
+      loser_finished.set(true)
+    end
+    spawn { release_operation.set(true) }
+
+    until winner_finished.get && loser_finished.get
+      Fiber.yield
+    end
+  else
+    raise "unknown FFI scheduler close scenario: #{scenario}"
+  end
+ensure
+  context.try &.close
+end
+
+private def assert_ffi_scheduler_close_completes(scenario : String) : Nil
+  executable = Process.executable_path || fail("cannot locate the spec executable")
+  process = Process.new(executable, ["--example", "__ffi_scheduler_close_child__"],
+    env: {"TERMISU_FFI_SCHEDULER_CLOSE_SCENARIO" => scenario})
+  finished = Channel(Process::Status).new
+  spawn { finished.send(process.wait) }
+
+  status = select
+  when child_status = finished.receive
+    child_status
+  when timeout(3.seconds)
+    process.signal(Signal::KILL)
+    finished.receive
+    fail "FFI scheduler close scenario #{scenario.inspect} timed out"
+  end
+  status.success?.should be_true
+end
+
+if scenario = ENV["TERMISU_FFI_SCHEDULER_CLOSE_SCENARIO"]?
+  run_ffi_scheduler_close_scenario(scenario)
+end
+
 describe "Termisu C ABI" do
   it "exposes the expected ABI version" do
     termisu_abi_version.should eq(1_u32)
@@ -238,8 +357,108 @@ describe "Termisu C ABI" do
     handle.should_not eq(0_u64)
 
     termisu_close(handle).should eq(Termisu::FFI::Status::Ok.value)
+    size = uninitialized Termisu::FFI::ABI::Size
+    termisu_size(handle, pointerof(size)).should eq(Termisu::FFI::Status::InvalidHandle.value)
     termisu_destroy(handle).should eq(Termisu::FFI::Status::Ok.value)
     termisu_destroy(handle).should eq(Termisu::FFI::Status::InvalidHandle.value)
+  end
+
+  it "waits for in-flight FFI operations before releasing ownership" do
+    handle = termisu_create(0_u8)
+    handle.should_not eq(0_u64)
+    context = Termisu::FFI::Registry.fetch(handle) || fail("created FFI context was not registered")
+
+    operation_started = Atomic(Bool).new(false)
+    release_operation = Atomic(Bool).new(false)
+    operation_succeeded = Atomic(Bool).new(false)
+    successor_attempt = Atomic(UInt64).new(UInt64::MAX)
+
+    operation_thread = Thread.new do
+      result = context.with_operation do |_leased|
+        operation_started.set(true)
+        until release_operation.get
+          Thread.yield
+        end
+        true
+      end
+      operation_succeeded.set(result == true)
+    end
+    until operation_started.get
+      Thread.yield
+    end
+
+    observer_thread = Thread.new do
+      # Wait until destroy has closed the operation gate. Calls that fetched
+      # the context before this point remain in its in-flight count.
+      deadline = monotonic_now + 2.seconds
+      while context.with_operation { true }
+        raise "destroy did not begin closing the FFI context" if monotonic_now >= deadline
+        Thread.yield
+      end
+
+      # Destroy must retain terminal ownership while the operation drains.
+      successor_attempt.set(termisu_create(0_u8))
+    ensure
+      release_operation.set(true)
+    end
+
+    termisu_destroy(handle).should eq(Termisu::FFI::Status::Ok.value)
+    operation_thread.join
+    observer_thread.join
+    operation_succeeded.get.should be_true
+    successor_attempt.get.should eq(0_u64)
+
+    size = uninitialized Termisu::FFI::ABI::Size
+    termisu_size(handle, pointerof(size)).should eq(Termisu::FFI::Status::InvalidHandle.value)
+
+    successor = termisu_create(0_u8)
+    successor.should_not eq(0_u64)
+    termisu_destroy(successor).should eq(Termisu::FFI::Status::Ok.value)
+  ensure
+    release_operation.try &.set(true)
+    operation_thread.try &.join
+    observer_thread.try &.join
+    termisu_destroy(handle) if handle && handle != 0_u64
+    termisu_destroy(successor) if successor && successor != 0_u64
+  end
+
+  it "lets same-scheduler operation fibers drain during close" do
+    assert_ffi_scheduler_close_completes("in_flight")
+  end
+
+  it "lets same-scheduler close fibers complete when they contend" do
+    assert_ffi_scheduler_close_completes("contended")
+  end
+
+  it "cancels real blocking C ABI polls before close and destroy drain operations" do
+    assert_ffi_blocking_poll_cancelled(destroy: false)
+    assert_ffi_blocking_poll_cancelled(destroy: true)
+  end
+
+  it "enforces terminal ownership across FFI handles" do
+    first = termisu_create(0_u8)
+    first.should_not eq(0_u64)
+
+    termisu_create(0_u8).should eq(0_u64)
+    termisu_error_message.should contain("already controlled")
+
+    termisu_close(first).should eq(Termisu::FFI::Status::Ok.value)
+    second = termisu_create(0_u8)
+    second.should_not eq(0_u64)
+
+    # Destroying the already-closed old handle cannot release the new owner.
+    termisu_destroy(first).should eq(Termisu::FFI::Status::Ok.value)
+    termisu_create(0_u8).should eq(0_u64)
+    termisu_error_message.should contain("already controlled")
+
+    termisu_destroy(second).should eq(Termisu::FFI::Status::Ok.value)
+    third = termisu_create(0_u8)
+    third.should_not eq(0_u64)
+    termisu_destroy(third).should eq(Termisu::FFI::Status::Ok.value)
+  ensure
+    termisu_destroy(first) if first && first != 0_u64
+    termisu_destroy(second) if second && second != 0_u64
+    termisu_destroy(third) if third && third != 0_u64
   end
 
   it "truncates copied error messages safely" do

--- a/spec/termisu/log_spec.cr
+++ b/spec/termisu/log_spec.cr
@@ -1,0 +1,80 @@
+require "../spec_helper"
+require "file/tempfile"
+
+private class TrackingLogDispatcher
+  include ::Log::Dispatcher
+
+  getter close_count : Int32 = 0
+  getter? file_open_during_close : Bool = false
+
+  def initialize(@delegate : ::Log::Dispatcher, @file : File)
+  end
+
+  def dispatch(entry : ::Log::Entry, backend : ::Log::Backend) : Nil
+    @delegate.dispatch(entry, backend)
+  end
+
+  def close : Nil
+    @close_count += 1
+    @file_open_during_close = !@file.closed?
+    @delegate.close
+    @file_open_during_close &&= !@file.closed?
+  end
+end
+
+describe Termisu::Logging do
+  it "closes each retained backend exactly once before its file across setup cycles" do
+    previous_level = ENV["TERMISU_LOG_LEVEL"]?
+    previous_file = ENV["TERMISU_LOG_FILE"]?
+    previous_sync = ENV["TERMISU_LOG_SYNC"]?
+    temp = File.tempfile("termisu-logging", ".log")
+    path = temp.path
+    temp.close
+
+    ENV["TERMISU_LOG_LEVEL"] = "debug"
+    ENV["TERMISU_LOG_FILE"] = path
+    ENV["TERMISU_LOG_SYNC"] = "false"
+
+    2.times do |cycle|
+      Termisu::Logging.setup
+      file = Termisu::Logging.log_file || fail("logging did not open its file")
+      backend = Termisu::Logging.backend || fail("logging did not retain its backend")
+      dispatcher = TrackingLogDispatcher.new(backend.dispatcher, file)
+      backend.dispatcher = dispatcher
+
+      Termisu::Log.info { "logging lifecycle cycle #{cycle}" }
+      Termisu::Logging.close
+      Termisu::Logging.close
+
+      dispatcher.close_count.should eq(1)
+      dispatcher.file_open_during_close?.should be_true
+      file.closed?.should be_true
+      Termisu::Logging.backend.should be_nil
+      Termisu::Logging.log_file.should be_nil
+      Termisu::Logging.configured?.should be_false
+    end
+
+    contents = File.read(path)
+    contents.should contain("logging lifecycle cycle 0")
+    contents.should contain("logging lifecycle cycle 1")
+  ensure
+    Termisu::Logging.close
+    File.delete(path) if path && File.exists?(path)
+
+    if previous_level
+      ENV["TERMISU_LOG_LEVEL"] = previous_level
+    else
+      ENV.delete("TERMISU_LOG_LEVEL")
+    end
+    if previous_file
+      ENV["TERMISU_LOG_FILE"] = previous_file
+    else
+      ENV.delete("TERMISU_LOG_FILE")
+    end
+    if previous_sync
+      ENV["TERMISU_LOG_SYNC"] = previous_sync
+    else
+      ENV.delete("TERMISU_LOG_SYNC")
+    end
+  end
+end

--- a/spec/termisu/terminal_spec.cr
+++ b/spec/termisu/terminal_spec.cr
@@ -1,5 +1,29 @@
 require "../spec_helper"
 
+private class FailingAlternateScreenTerminal < CaptureTerminal
+  property? fail_next_flush = false
+
+  def flush
+    if @fail_next_flush
+      @fail_next_flush = false
+      raise IO::Error.new("alternate screen flush failed")
+    end
+    super
+  end
+end
+
+private class FailingExitFlushTerminal < Termisu::Terminal
+  property? fail_next_flush = false
+
+  def flush
+    if @fail_next_flush
+      @fail_next_flush = false
+      raise IO::Error.new("alternate screen exit failed")
+    end
+    super
+  end
+end
+
 describe Termisu::Terminal do
   describe ".new" do
     it "opens /dev/tty and provides valid file descriptors" do
@@ -109,6 +133,48 @@ describe Termisu::Terminal do
       # Multiple closes should be safe
       terminal.close
       terminal.close
+    end
+
+    it "restores raw mode and closes descriptors after alternate-screen output fails" do
+      terminal = FailingExitFlushTerminal.new(sync_updates: false)
+      terminal.enable_raw_mode
+      terminal.enter_alternate_screen
+      infd = terminal.infd
+      outfd = terminal.outfd
+      terminal.fail_next_flush = true
+
+      expect_raises(IO::Error, "alternate screen exit failed") do
+        terminal.close
+      end
+
+      terminal.raw_mode?.should be_false
+      LibC.fcntl(infd, LibC::F_GETFL, 0).should eq(-1)
+      Errno.value.should eq(Errno::EBADF)
+      LibC.fcntl(outfd, LibC::F_GETFL, 0).should eq(-1)
+      Errno.value.should eq(Errno::EBADF)
+
+      # Cleanup and descriptor closure are not retried by repeated close.
+      terminal.close
+    ensure
+      terminal.try &.close
+    end
+  end
+
+  describe "alternate-screen rollback" do
+    it "exits a partially-entered alternate screen and preserves the original error" do
+      terminal = FailingAlternateScreenTerminal.new(sync_updates: false)
+      terminfo = Termisu::Terminfo.new
+      terminal.fail_next_flush = true
+
+      expect_raises(IO::Error, "alternate screen flush failed") do
+        terminal.enter_alternate_screen
+      end
+
+      terminal.alternate_screen?.should be_false
+      terminal.output.should contain(terminfo.enter_ca_seq)
+      terminal.output.should contain(terminfo.exit_ca_seq)
+    ensure
+      terminal.try &.close
     end
   end
 

--- a/spec/termisu_spec.cr
+++ b/spec/termisu_spec.cr
@@ -36,6 +36,27 @@ private class PausableInputSource < Termisu::Event::Source::Input
   end
 end
 
+private class FailingStopEventLoop < Termisu::Event::Loop
+  getter stop_count : Int32 = 0
+
+  def stop : self
+    @stop_count += 1
+    raise IO::Error.new("event loop stop failed")
+  end
+end
+
+private class FailingCloseTerminal < CaptureTerminal
+  getter close_count : Int32 = 0
+
+  def close : Nil
+    return super if closed?
+
+    @close_count += 1
+    super
+    raise IO::Error.new("terminal close failed")
+  end
+end
+
 # Build the public facade around controlled collaborators so mode coordination
 # can be tested independently of its normal initialization lifecycle.
 class Termisu
@@ -47,6 +68,8 @@ class Termisu
     @resize_source : Event::Source::Resize,
     @event_loop : Event::Loop,
   )
+    @ownership = TerminalOwnership.acquire
+    @closed = Atomic(Bool).new(false)
     @timer_source = nil
   end
 end
@@ -64,12 +87,100 @@ describe Termisu do
     # than swallowed at runtime.
     if controlling_tty?
       pending "raises IO::Error without a controlling TTY (this process has one)"
+
+      it "allows only one live owner and does not release a newer owner's lease" do
+        first = Termisu.new(sync_updates: false)
+
+        expect_raises(Termisu::TerminalInUseError, "already controlled") do
+          Termisu.new(sync_updates: false)
+        end
+        # A failed acquisition must not release the first instance's lease.
+        expect_raises(Termisu::TerminalInUseError) do
+          Termisu.new(sync_updates: false)
+        end
+
+        first.close
+        second = Termisu.new(sync_updates: false)
+        Termisu::Logging.configured?.should be_true
+        successor_backend = Termisu::Logging.backend
+        successor_log_file = Termisu::Logging.log_file
+
+        # Concurrent stale closes must neither release the second instance's
+        # lease nor tear down its process-global logging backend.
+        stale_closers = [] of Thread
+        8.times { stale_closers << Thread.new { first.close } }
+        stale_closers.each(&.join)
+        Termisu::Logging.configured?.should be_true
+        Termisu::Logging.backend.should be(successor_backend)
+        Termisu::Logging.log_file.should be(successor_log_file)
+        successor_log_file.try(&.closed?.should be_false)
+        Termisu::Log.info { "Successor logging remains usable after stale closes" }
+        expect_raises(Termisu::TerminalInUseError) do
+          Termisu.new(sync_updates: false)
+        end
+
+        second.close
+        third = Termisu.new(sync_updates: false)
+        third.close
+      ensure
+        first.try(&.close)
+        second.try(&.close)
+        third.try(&.close)
+      end
     else
       it "raises IO::Error without a controlling TTY" do
         expect_raises(IO::Error) do
           Termisu.new
         end
       end
+    end
+
+    it "releases ownership when construction fails" do
+      previous_term = ENV["TERM"]?
+      ENV.delete("TERM")
+
+      2.times do
+        expect_raises(Termisu::Error, "TERM environment variable not set") do
+          Termisu.new
+        end
+      end
+    ensure
+      if previous_term
+        ENV["TERM"] = previous_term
+      else
+        ENV.delete("TERM")
+      end
+    end
+  end
+
+  describe "#close" do
+    it "preserves the first failure while completing cleanup and releasing ownership" do
+      read_fd, write_fd = create_pipe
+      reader = Termisu::Reader.new(read_fd)
+      parser = Termisu::Input::Parser.new(reader)
+      input_source = PausableInputSource.new(reader, parser)
+      resize_source = Termisu::Event::Source::Resize.new(-> { {80, 24} })
+      event_loop = FailingStopEventLoop.new
+      terminal = FailingCloseTerminal.new(sync_updates: false)
+      termisu = Termisu.new(terminal, reader, parser, input_source, resize_source, event_loop)
+
+      expect_raises(IO::Error, "event loop stop failed") do
+        termisu.close
+      end
+
+      event_loop.stop_count.should eq(1)
+      terminal.close_count.should eq(1)
+      terminal.closed?.should be_true
+
+      lease = Termisu::TerminalOwnership.acquire
+      lease.release
+    ensure
+      termisu.try &.close
+      terminal.try &.close
+      reader.try &.close
+      lease.try &.release
+      LibC.close(read_fd) if read_fd
+      LibC.close(write_fd) if write_fd
     end
   end
 
@@ -105,7 +216,7 @@ describe Termisu do
         input_source.start_count.should eq(starts_before + (should_pause ? 1 : 0))
       end
     ensure
-      terminal.try &.close
+      termisu.try &.close
       LibC.close(read_fd) if read_fd
       LibC.close(write_fd) if write_fd
     end
@@ -138,7 +249,7 @@ describe Termisu do
       input_source.start_count.should eq(2)
       input_source.stop_count.should eq(1)
     ensure
-      terminal.try &.close
+      termisu.try &.close
       LibC.close(read_fd) if read_fd
       LibC.close(write_fd) if write_fd
     end

--- a/src/termisu.cr
+++ b/src/termisu.cr
@@ -23,6 +23,16 @@
 # termisu.close
 # ```
 class Termisu
+  @ownership : TerminalOwnership
+  @closed : Atomic(Bool)
+  @terminal : Terminal
+  @reader : Reader
+  @input_parser : Input::Parser
+  @input_source : Event::Source::Input
+  @resize_source : Event::Source::Resize
+  @event_loop : Event::Loop
+  @timer_source : Event::Source::Timer | Event::Source::SystemTimer | Nil
+
   # Initializes Termisu with all required components.
   #
   # Sets up terminal I/O, rendering, input reader, and async event system.
@@ -30,47 +40,88 @@ class Termisu
   #
   # The Event::Loop is started with Input and Resize sources by default.
   # Timer source is optional and can be enabled with `enable_timer`.
+  # Raises `TerminalInUseError` if another live Termisu instance already owns
+  # the process's controlling terminal.
   #
   # Parameters:
   # - `sync_updates` - Enable DEC mode 2026 synchronized updates (default: true).
   #   When enabled, render operations are wrapped in BSU/ESU sequences to
   #   prevent screen tearing. Unsupported terminals ignore these sequences.
   def initialize(*, sync_updates : Bool = true)
-    Logging.setup
+    @ownership = TerminalOwnership.acquire
+    @closed = Atomic(Bool).new(false)
 
+    resources = begin
+      initialize_resources(sync_updates)
+    rescue ex
+      @ownership.release
+      raise ex
+    end
+
+    @terminal = resources[:terminal]
+    @reader = resources[:reader]
+    @input_parser = resources[:input_parser]
+    @input_source = resources[:input_source]
+    @resize_source = resources[:resize_source]
+    @event_loop = resources[:event_loop]
+    @timer_source = nil.as((Event::Source::Timer | Event::Source::SystemTimer)?)
+  end
+
+  # Builds all terminal resources transactionally. Keeping partially-created
+  # values local lets a failed constructor unwind them before the ownership
+  # lease is released by initialize.
+  private def initialize_resources(sync_updates : Bool) : NamedTuple(
+    terminal: Terminal,
+    reader: Reader,
+    input_parser: Input::Parser,
+    input_source: Event::Source::Input,
+    resize_source: Event::Source::Resize,
+    event_loop: Event::Loop,
+  )
+    Logging.setup
     Log.info { "Initializing Termisu v#{VERSION}" }
 
-    @terminal = Terminal.new(sync_updates: sync_updates)
-    @reader = Reader.new(@terminal.infd)
-    @input_parser = Input::Parser.new(@reader)
+    # Resolve terminfo before opening the TTY so this failure path has no
+    # partially-created backend to clean up.
+    terminfo = Terminfo.new
+    terminal = Terminal.new(terminfo: terminfo, sync_updates: sync_updates)
+    reader = Reader.new(terminal.infd)
+    input_parser = Input::Parser.new(reader)
 
-    Log.debug { "Terminal size: #{@terminal.size}" }
+    Log.debug { "Terminal size: #{terminal.size}" }
 
-    @terminal.enable_raw_mode
+    terminal.enable_raw_mode
 
-    # Create async event sources
-    @input_source = Event::Source::Input.new(@reader, @input_parser)
+    input_source = Event::Source::Input.new(reader, input_parser)
     # Must be query_size (live ioctl), not size (cached) - the resize
     # source detects changes by re-querying the terminal dimensions.
-    @resize_source = Event::Source::Resize.new(-> { @terminal.query_size })
+    resize_source = Event::Source::Resize.new(-> { terminal.as(Terminal).query_size })
 
-    # Timer source is optional (nil by default)
-    # Can be either sleep-based Timer or kernel-level SystemTimer
-    @timer_source = nil.as((Event::Source::Timer | Event::Source::SystemTimer)?)
+    event_loop = Event::Loop.new
+    event_loop.add_source(input_source)
+    event_loop.add_source(resize_source)
+    event_loop.start
 
-    # Create and configure event loop
-    @event_loop = Event::Loop.new
-    @event_loop.add_source(@input_source)
-    @event_loop.add_source(@resize_source)
+    Log.debug { "Event loop started with sources: #{event_loop.source_names}" }
 
-    # Start event loop before entering alternate screen
-    @event_loop.start
-
-    Log.debug { "Event loop started with sources: #{@event_loop.source_names}" }
-
-    @terminal.enter_alternate_screen
-
+    terminal.enter_alternate_screen
     Log.debug { "Raw mode enabled, alternate screen entered" }
+
+    {
+      terminal:      terminal,
+      reader:        reader,
+      input_parser:  input_parser,
+      input_source:  input_source,
+      resize_source: resize_source,
+      event_loop:    event_loop,
+    }
+  rescue ex
+    event_loop.try(&.stop) rescue nil
+    reader.try(&.close) rescue nil
+    terminal.try(&.close) rescue nil
+    Logging.flush rescue nil
+    Logging.close rescue nil
+    raise ex
   end
 
   # Closes Termisu and cleans up all resources.
@@ -84,17 +135,30 @@ class Termisu
   # The event loop is stopped first to ensure fibers that might be using
   # the reader are terminated before the reader is closed.
   def close
+    return unless @closed.compare_and_set(false, true)[1]
+
     Log.info { "Closing Termisu" }
 
-    # Stop event loop first - this stops all sources and their fibers
-    @event_loop.stop
-    Log.debug { "Event loop stopped" }
+    # Keep ownership until every process-global and terminal resource has been
+    # shut down. Preserve the first failure while still running every cleanup
+    # step and releasing the ownership lease.
+    error = capture_cleanup_error(nil) do
+      @event_loop.stop
+      Log.debug { "Event loop stopped" }
+    end
+    error = capture_cleanup_error(error) { @reader.close }
+    error = capture_cleanup_error(error) { @terminal.close }
+    error = capture_cleanup_error(error) { Logging.flush }
+    error = capture_cleanup_error(error) { Logging.close }
+    error = capture_cleanup_error(error) { @ownership.release }
+    raise error if error
+  end
 
-    @reader.close
-    @terminal.close
-
-    Logging.flush
-    Logging.close
+  private def capture_cleanup_error(error : Exception?, &) : Exception?
+    yield
+    error
+  rescue ex
+    error || ex
   end
 
   # --- Terminal Operations ---

--- a/src/termisu/error.cr
+++ b/src/termisu/error.cr
@@ -2,6 +2,10 @@
 class Termisu::Error < Exception
 end
 
+# Error raised when another live Termisu instance owns the process terminal.
+class Termisu::TerminalInUseError < Termisu::Error
+end
+
 # Error raised for terminal I/O operations.
 #
 # Wraps system-level I/O errors with additional context about

--- a/src/termisu/ffi/context.cr
+++ b/src/termisu/ffi/context.cr
@@ -1,21 +1,100 @@
 class Termisu::FFI::Context
   getter termisu : ::Termisu
 
-  @closed : Atomic(Bool)
+  # Bound the time an FFI poll waits before observing cross-thread shutdown.
+  # Crystal channels are scheduler-local in supported non-preview_mt builds,
+  # while atomics and OS sleeps work from arbitrary host threads.
+  POLL_CANCELLATION_INTERVAL = 1.millisecond
+
+  @closing = Atomic(Bool).new(false)
+  @closed = Atomic(Bool).new(false)
+  @in_flight = Atomic(Int32).new(0)
 
   def initialize(sync_updates : Bool)
-    @closed = Atomic(Bool).new(false)
+    @scheduler_thread = Thread.current
     @termisu = ::Termisu.new(sync_updates: sync_updates)
   end
 
-  def close : Nil
-    return unless @closed.compare_and_set(false, true)
+  # Runs one FFI operation while preventing close from crossing its lifetime.
+  # The second closing check closes the race between the first check and the
+  # counter increment: such a caller backs out without touching Termisu.
+  def with_operation(& : self -> T) : T? forall T
+    return nil if @closing.get
+
+    @in_flight.add(1)
+    if @closing.get
+      @in_flight.sub(1)
+      return nil
+    end
 
     begin
+      yield self
+    ensure
+      @in_flight.sub(1)
+    end
+  end
+
+  # Polls non-blockingly between short OS sleeps so close can cancel an
+  # indefinite (or very long) wait before draining operation leases. Avoiding
+  # scheduler waits is required because the C ABI may run on a foreign thread.
+  # The ownership lease remains held until close completes all cleanup below.
+  def poll_event(timeout_ms : Int32) : Event::Any?
+    return nil if @closing.get
+    return @termisu.try_poll_event if timeout_ms == 0
+
+    deadline = timeout_ms < 0 ? nil : monotonic_now + timeout_ms.milliseconds
+    loop do
+      return nil if @closing.get
+      if event = @termisu.try_poll_event
+        return event
+      end
+
+      wait = POLL_CANCELLATION_INTERVAL
+      if deadline
+        remaining = deadline - monotonic_now
+        return nil if remaining <= 0.seconds
+        wait = remaining if remaining < wait
+      end
+      Fiber.yield if Thread.current == @scheduler_thread
+      sleep_os_thread(wait)
+    end
+  end
+
+  private def sleep_os_thread(duration : Time::Span) : Nil
+    total_nanoseconds = duration.total_nanoseconds.to_i64
+    request = uninitialized LibC::Timespec
+    request.tv_sec = typeof(request.tv_sec).new(total_nanoseconds // 1_000_000_000)
+    request.tv_nsec = typeof(request.tv_nsec).new(total_nanoseconds % 1_000_000_000)
+
+    loop do
+      return if LibC.nanosleep(pointerof(request), out remaining) == 0
+      return unless Errno.value == Errno::EINTR
+      request = remaining
+    end
+  end
+
+  # Exposed for lifecycle coordination and focused concurrency assertions.
+  def operations_in_flight? : Bool
+    @in_flight.get > 0
+  end
+
+  def close : Nil
+    unless @closing.compare_and_set(false, true)[1]
+      until @closed.get
+        Fiber.yield if Thread.current == @scheduler_thread
+        Thread.yield
+      end
+      return
+    end
+
+    until @in_flight.get.zero?
+      Fiber.yield if Thread.current == @scheduler_thread
+      Thread.yield
+    end
+    begin
       @termisu.close
-    rescue ex
-      @closed.set(false)
-      raise ex
+    ensure
+      @closed.set(true)
     end
   end
 end

--- a/src/termisu/ffi/core.cr
+++ b/src/termisu/ffi/core.cr
@@ -2,22 +2,29 @@ module Termisu::FFI
   def self.create(sync_updates : Bool) : UInt64
     context = Context.new(sync_updates)
     Registry.insert(context)
+  rescue ex
+    context.try(&.close)
+    raise ex
   end
 
   def self.destroy(handle : UInt64) : Status
     context = Registry.fetch(handle)
     return invalid_handle_status unless context
 
-    context.close
-    Registry.delete(handle)
+    begin
+      context.close
+    ensure
+      Registry.delete(handle)
+    end
     Status::Ok
   end
 
   def self.close(handle : UInt64) : Status
-    with_context(handle) do |context|
-      context.close
-      Status::Ok
-    end
+    context = Registry.fetch(handle)
+    return invalid_handle_status unless context
+
+    context.close
+    Status::Ok
   end
 
   def self.size(handle : UInt64, out_size : ABI::Size*) : Status
@@ -225,11 +232,7 @@ module Termisu::FFI
     return invalid_argument_status("out_event is null") if out_event.null?
 
     with_context(handle) do |context|
-      event = if timeout_ms < 0
-                context.termisu.poll_event
-              else
-                context.termisu.poll_event(timeout_ms)
-              end
+      event = context.poll_event(timeout_ms)
 
       if event
         Conversions.write_abi_event(event, out_event)
@@ -272,7 +275,10 @@ module Termisu::FFI
   private def self.with_context(handle : UInt64, & : Context -> Status) : Status
     context = Registry.fetch(handle)
     return invalid_handle_status unless context
-    yield context
+
+    result = context.with_operation { |leased| yield leased }
+    return invalid_handle_status if result.nil?
+    result
   end
 
   private def self.with_context_u8(handle : UInt64, & : Context -> UInt8) : UInt8
@@ -281,7 +287,13 @@ module Termisu::FFI
       ErrorState.set("Invalid handle")
       return 0_u8
     end
-    yield context
+
+    result = context.with_operation { |leased| yield leased }
+    if result.nil?
+      ErrorState.set("Invalid handle")
+      return 0_u8
+    end
+    result
   end
 
   private def self.invalid_handle_status : Status

--- a/src/termisu/log.cr
+++ b/src/termisu/log.cr
@@ -18,9 +18,8 @@ class Termisu
   # ## Dispatch Modes
   #
   # **Async mode** (default): Uses `Log::DispatchMode::Async` for better performance.
-  # Logs are queued to a fiber and written asynchronously. Uses SafeFileIO
-  # wrapper to handle writes after file close, and Fiber.yield on close to
-  # allow pending logs to be processed.
+  # Logs are queued to a fiber and written asynchronously. The backend is
+  # drained and closed before its log file is released.
   #
   # **Sync mode**: Uses `Log::DispatchMode::Direct` for real-time logging.
   # Logs appear immediately in the file, ideal for debugging crashes.
@@ -86,6 +85,9 @@ class Termisu
   module Logging
     # Open log file handle (nil when logging disabled)
     class_property log_file : File? = nil
+
+    # Installed backend (nil when logging disabled or closed)
+    class_property backend : ::Log::IOBackend? = nil
 
     # Whether logging has been configured (prevents duplicate setup)
     class_property? configured : Bool = false
@@ -167,6 +169,7 @@ class Termisu
         # Async mode needs SafeFileIO wrapper to handle writes after file close
         io : IO = is_sync ? file : SafeFileIO.new(file)
         backend = ::Log::IOBackend.new(io: io, formatter: FORMATTER, dispatcher: dispatch_mode)
+        self.backend = backend
 
         ::Log.setup("*", level, backend)
 
@@ -179,19 +182,26 @@ class Termisu
       self.configured = true
     end
 
-    # Closes the log file and cleans up resources.
+    # Closes the logging backend and its file.
     #
-    # In async mode, yields to let the dispatch fiber process pending
-    # logs before closing. Called automatically by Termisu.close.
+    # Detaching the backend first prevents new entries while `Backend#close`
+    # drains its async dispatcher. The file must remain open until that drain
+    # completes. Called automatically by Termisu.close.
     def self.close
+      if retained_backend = backend
+        ::Log.setup { |_| } rescue nil
+        retained_backend.close rescue nil
+        self.backend = nil
+      end
+
       if file = log_file
-        if async_mode?
-          3.times { Fiber.yield }
-          file.flush rescue nil
-        end
+        file.flush rescue nil
         file.close rescue nil
         self.log_file = nil
       end
+
+      self.async_mode = false
+      self.configured = false
     end
 
     # Flushes any buffered log entries to disk.

--- a/src/termisu/terminal.cr
+++ b/src/termisu/terminal.cr
@@ -29,6 +29,7 @@ class Termisu::Terminal < Termisu::Renderer
   @enhanced_keyboard : Bool = false
   @bracketed_paste : Bool = false
   @sync_updates : Bool = true
+  @terminal_closed = Atomic(Bool).new(false)
   getter cursor : Cursor = Cursor.new
   getter title : String = ""
 
@@ -61,9 +62,16 @@ class Termisu::Terminal < Termisu::Renderer
     *,
     @sync_updates : Bool = true,
   )
+    @buffer = initial_buffer
+    Log.debug { "Terminal initialized: #{@buffer.width}x#{@buffer.height}, sync_updates: #{@sync_updates}" }
+  end
+
+  private def initial_buffer : Buffer
     width, height = size
-    @buffer = Buffer.new(width, height)
-    Log.debug { "Terminal initialized: #{width}x#{height}, sync_updates: #{@sync_updates}" }
+    Buffer.new(width, height)
+  rescue ex
+    @backend.close rescue nil
+    raise ex
   end
 
   # Enters alternate screen mode.
@@ -74,13 +82,21 @@ class Termisu::Terminal < Termisu::Renderer
   def enter_alternate_screen
     return if @alternate_screen
     Log.debug { "Entering alternate screen" }
-    write(@terminfo.enter_ca_seq)
-    write(@terminfo.clear_screen_seq)
-    write(@terminfo.enter_keypad_seq)
-    reset_render_state
-    apply_cursor_state
-    flush
+
+    # Record the transition before emitting anything so a partial write is
+    # always paired with a best-effort exit during rollback.
     @alternate_screen = true
+    begin
+      write(@terminfo.enter_ca_seq)
+      write(@terminfo.clear_screen_seq)
+      write(@terminfo.enter_keypad_seq)
+      reset_render_state
+      apply_cursor_state
+      flush
+    rescue ex
+      exit_alternate_screen rescue nil
+      raise ex
+    end
   end
 
   # Exits alternate screen mode.
@@ -91,13 +107,17 @@ class Termisu::Terminal < Termisu::Renderer
   def exit_alternate_screen
     return unless @alternate_screen
     Log.debug { "Exiting alternate screen" }
-    @cursor = Cursor.new visible: true
-    apply_cursor_state
-    write(@terminfo.exit_keypad_seq)
-    write(@terminfo.exit_ca_seq)
-    reset_render_state
-    flush
+
+    # Clear first so shutdown is exactly-once even when output fails. Continue
+    # through every restoration step and report the first error afterwards.
     @alternate_screen = false
+    @cursor = Cursor.new visible: true
+    error = capture_cleanup_error(nil) { apply_cursor_state }
+    error = capture_cleanup_error(error) { write(@terminfo.exit_keypad_seq) }
+    error = capture_cleanup_error(error) { write(@terminfo.exit_ca_seq) }
+    reset_render_state
+    error = capture_cleanup_error(error) { flush }
+    raise error if error
   end
 
   # Returns whether alternate screen mode is active.
@@ -650,13 +670,24 @@ class Termisu::Terminal < Termisu::Renderer
 
   # Closes the terminal and underlying backend.
   def close
+    return unless @terminal_closed.compare_and_set(false, true)[1]
+
     Log.debug { "Closing terminal" }
-    disable_mouse
-    disable_enhanced_keyboard
-    disable_bracketed_paste
-    exit_alternate_screen
-    disable_raw_mode
-    @backend.close
+    error = capture_cleanup_error(nil) { disable_mouse }
+    error = capture_cleanup_error(error) { disable_enhanced_keyboard }
+    error = capture_cleanup_error(error) { disable_bracketed_paste }
+    error = capture_cleanup_error(error) { exit_alternate_screen }
+    # Backend#close restores termios and closes descriptors even if restoration
+    # fails. Keep it last, but always reach it after escape-sequence failures.
+    error = capture_cleanup_error(error) { @backend.close }
+    raise error if error
+  end
+
+  private def capture_cleanup_error(error : Exception?, &) : Exception?
+    yield
+    error
+  rescue ex
+    error || ex
   end
 
   # --- Cell Buffer Operations ---
@@ -856,9 +887,9 @@ class Termisu::Terminal < Termisu::Renderer
   def disable_mouse
     return unless @mouse_enabled
     Log.debug { "Disabling mouse tracking" }
+    @mouse_enabled = false
     apply_mouse_state false
     flush
-    @mouse_enabled = false
   end
 
   # Returns whether mouse tracking is currently enabled.
@@ -901,9 +932,9 @@ class Termisu::Terminal < Termisu::Renderer
   def disable_enhanced_keyboard
     return unless @enhanced_keyboard
     Log.debug { "Disabling enhanced keyboard protocol" }
+    @enhanced_keyboard = false
     apply_enhanced_keyboard_state false
     flush
-    @enhanced_keyboard = false
   end
 
   # Returns whether enhanced keyboard protocol is enabled.
@@ -949,9 +980,9 @@ class Termisu::Terminal < Termisu::Renderer
   def disable_bracketed_paste
     return unless @bracketed_paste
     Log.debug { "Disabling bracketed paste" }
+    @bracketed_paste = false
     apply_bracketed_paste_state false
     flush
-    @bracketed_paste = false
   end
 
   # Returns whether bracketed paste mode is currently enabled.

--- a/src/termisu/terminal/backend.cr
+++ b/src/termisu/terminal/backend.cr
@@ -20,6 +20,7 @@ class Termisu::Terminal::Backend
   @tty : TTY
   @termios : Termios
   @raw_mode_enabled : Bool = false
+  @closed = Atomic(Bool).new(false)
 
   getter infd : Int32
   getter outfd : Int32
@@ -177,8 +178,13 @@ class Termisu::Terminal::Backend
 
   # Closes the terminal backend, disabling raw mode and closing TTY.
   def close
-    disable_raw_mode
-    @tty.close
+    return unless @closed.compare_and_set(false, true)[1]
+
+    begin
+      disable_raw_mode
+    ensure
+      @tty.close
+    end
   end
 end
 

--- a/src/termisu/terminal_ownership.cr
+++ b/src/termisu/terminal_ownership.cr
@@ -1,0 +1,32 @@
+# Process-global ownership guard for the controlling terminal.
+#
+# A process has one controlling terminal and Termisu also installs a global
+# SIGWINCH handler and logging backend. Letting two instances manage those
+# resources independently makes either instance's shutdown corrupt the other.
+class Termisu::TerminalOwnership
+  @@owned = Atomic(Bool).new(false)
+
+  @released = Atomic(Bool).new(false)
+
+  private def initialize
+  end
+
+  def self.acquire : self
+    acquired = @@owned.compare_and_set(false, true, :acquire, :relaxed)[1]
+    unless acquired
+      raise Termisu::TerminalInUseError.new(
+        "The process terminal is already controlled by another live Termisu instance"
+      )
+    end
+
+    new
+  end
+
+  # Releases this lease at most once. In particular, a repeated close on an old
+  # instance cannot release the lease subsequently acquired by a new instance.
+  def release : Nil
+    return unless @released.compare_and_set(false, true, :acquire, :relaxed)[1]
+
+    @@owned.set(false, :release)
+  end
+end

--- a/src/termisu/tty.cr
+++ b/src/termisu/tty.cr
@@ -13,7 +13,7 @@ class Termisu::TTY
   @outfd : Int32
   @infd : Int32
   @owns_input_fd : Bool
-  @closed : Bool = false
+  @closed = Atomic(Bool).new(false)
 
   {% begin %}
     {% bsd = flag?(:openbsd) || flag?(:freebsd) %}
@@ -35,9 +35,8 @@ class Termisu::TTY
 
   # Closes the TTY file descriptors.
   def close
-    return if @closed
+    return unless @closed.compare_and_set(false, true)[1]
 
-    @closed = true
     input_fd = @owns_input_fd ? @infd : -1
     @owns_input_fd = false
     @outfd = -1


### PR DESCRIPTION
## Summary
- enforce an atomic single-owner lease for process-global terminal state with constructor rollback and exactly-once release
- drain in-flight FFI calls before close/destroy can release ownership, rejecting calls after closing starts
- make alternate-screen and terminal/backend shutdown best-effort transactional while preserving the original cleanup error

## Testing
- `mise exec -- unbuffer crystal spec spec/termisu_spec.cr spec/termisu/ffi_spec.cr spec/termisu/ffi --no-color` (55 examples, 0 failures, 1 expected pending)
- `mise exec -- bin/hace format:check`
- `mise exec -- bin/hace ameba` (158 files, 0 failures)
- `mise exec -- bin/hace spec` (1280 examples, 0 failures, 1 expected pending)
- `mise exec -- bin/hace ffi:build`
- `mise exec -- bin/hace c:check`
- `mise exec -- bin/hace c:test`
- `mise exec -- bin/hace js:test` (48 tests passed)

## Compatibility
Only one live `Termisu`/FFI context may control the process terminal. FFI operations begun after a handle starts closing now return `InvalidHandle`; repeated close and subsequent destroy remain supported.
