### PR TITLE
fix: correct zero-valued flag checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ event.ctrl_q?
 event.ctrl_z?
 
 # Check for any modifier
-event.modifiers.none?            # No modifiers held
+event.modifiers == Termisu::Input::Modifier::None # No modifiers held
 event.modifiers.ctrl?            # Direct modifier check
 event.modifiers & Input::Modifier::Ctrl  # Bitwise check
 
@@ -470,6 +470,10 @@ event.key.to_char                # => Char? for printable keys
 ```
 
 ### Modifiers
+
+Compare modifiers directly with `Input::Modifier::None` to check whether none are set.
+The flags-generated `none?` predicate checks inclusion of the zero-valued `None` member,
+so it is not an emptiness check.
 
 ```crystal
 Input::Modifier::None

--- a/docs-web/content/guide/modifiers.md
+++ b/docs-web/content/guide/modifiers.md
@@ -6,6 +6,10 @@ weight = 120
 
 # Modifiers
 
+Compare modifiers directly with `Input::Modifier::None` to check whether none are set.
+The flags-generated `none?` predicate checks inclusion of the zero-valued `None` member,
+so it is not an emptiness check.
+
 ```crystal
 Input::Modifier::None
 Input::Modifier::Shift

--- a/spec/e2e/__snapshots__/showcase.snap.txt
+++ b/spec/e2e/__snapshots__/showcase.snap.txt
@@ -84,6 +84,12 @@ r9 c69-71 "Cyn" fg=ansi256(14) bg=default attr=None
 r9 c77-79 "Wht" fg=ansi256(15) bg=default attr=None
 r11 c18-21 "Text" fg=ansi8(3) bg=default attr=None
 r11 c23-33 "Attributes:" fg=ansi8(3) bg=default attr=None
+r12 c26-29 "Bold" fg=ansi8(7) bg=default attr=Bold
+r12 c32-40 "Underline" fg=ansi8(7) bg=default attr=Underline
+r12 c43-49 "Reverse" fg=ansi8(7) bg=default attr=Reverse
+r12 c52-54 "Dim" fg=ansi8(7) bg=default attr=Dim
+r12 c57-62 "Italic" fg=ansi8(7) bg=default attr=Cursive
+r12 c65-70 "Strike" fg=ansi8(7) bg=default attr=Strikethrough
 r14 c18-26 "Combined:" fg=ansi8(3) bg=default attr=None
 r14 c28-41 "Bold+Underline" fg=ansi8(2) bg=default attr=Bold|Underline
 r14 c45-54 "Dim+Italic" fg=ansi8(6) bg=default attr=Dim|Cursive

--- a/spec/termisu/attribute_spec.cr
+++ b/spec/termisu/attribute_spec.cr
@@ -45,6 +45,16 @@ describe Termisu::Attribute do
   end
 
   describe "flag combinations" do
+    it "distinguishes zero, single, and combined flag values from None" do
+      none = Termisu::Attribute::None
+      single = Termisu::Attribute::Bold
+      combined = Termisu::Attribute::Bold | Termisu::Attribute::Underline
+
+      (none == Termisu::Attribute::None).should be_true
+      (single == Termisu::Attribute::None).should be_false
+      (combined == Termisu::Attribute::None).should be_false
+    end
+
     it "can combine Bold and Underline" do
       attr = Termisu::Attribute::Bold | Termisu::Attribute::Underline
       attr.bold?.should be_true

--- a/spec/termisu/event/key_spec.cr
+++ b/spec/termisu/event/key_spec.cr
@@ -5,7 +5,7 @@ describe Termisu::Event::Key do
     it "creates a key event with default modifiers" do
       event = Termisu::Event::Key.new(Termisu::Input::Key::LowerA)
       event.key.should eq(Termisu::Input::Key::LowerA)
-      event.modifiers.none?.should be_true
+      event.modifiers.should eq(Termisu::Input::Modifier::None)
     end
 
     it "creates a key event with specified modifiers" do

--- a/spec/termisu/event/mouse_spec.cr
+++ b/spec/termisu/event/mouse_spec.cr
@@ -125,7 +125,7 @@ describe Termisu::Event::Mouse do
 
     it "creates a mouse event with default modifiers and no motion" do
       event = Termisu::Event::Mouse.new(1, 1, Termisu::Event::Mouse::Button::Left)
-      event.modifiers.none?.should be_true
+      event.modifiers.should eq(Termisu::Input::Modifier::None)
       event.motion?.should be_false
     end
 

--- a/spec/termisu/input/modifier_spec.cr
+++ b/spec/termisu/input/modifier_spec.cr
@@ -48,7 +48,7 @@ describe Termisu::Input::Modifier do
 
       it "decodes code 1 as None (base code)" do
         mods = Termisu::Input::Modifier.from_xterm_code(1)
-        mods.none?.should be_true
+        mods.should eq(Termisu::Input::Modifier::None)
       end
 
       it "decodes code 2 as Shift (1 + 1)" do
@@ -199,11 +199,14 @@ describe Termisu::Input::Modifier do
       (Termisu::Input::Modifier::Shift | Termisu::Input::Modifier::Meta).meta?.should be_true
     end
 
-    it "none? returns true only when no modifiers are set" do
-      Termisu::Input::Modifier::None.none?.should be_true
-      # Note: Crystal's @[Flags] enum none? checks if value == 0
-      # Individual flags like Shift have non-zero values, so none? returns true
-      # because it checks if NO flags are set, not if it's the None variant
+    it "distinguishes zero, single, and combined flag values from None" do
+      none = Termisu::Input::Modifier::None
+      single = Termisu::Input::Modifier::Shift
+      combined = Termisu::Input::Modifier::Shift | Termisu::Input::Modifier::Ctrl
+
+      (none == Termisu::Input::Modifier::None).should be_true
+      (single == Termisu::Input::Modifier::None).should be_false
+      (combined == Termisu::Input::Modifier::None).should be_false
     end
   end
 end

--- a/spec/termisu/input/parser_spec.cr
+++ b/spec/termisu/input/parser_spec.cr
@@ -100,7 +100,7 @@ describe Termisu::Input::Parser do
         event.should be_a(Termisu::Event::Key)
         if event.is_a?(Termisu::Event::Key)
           event.key.should eq(Termisu::Input::Key::LowerA)
-          event.modifiers.none?.should be_true
+          event.modifiers.should eq(Termisu::Input::Modifier::None)
         end
       end
 

--- a/spec/termisu/terminal/mode_spec.cr
+++ b/spec/termisu/terminal/mode_spec.cr
@@ -28,7 +28,7 @@ describe Termisu::Terminal::Mode do
       it "returns None (no flags set)" do
         mode = Termisu::Terminal::Mode.raw
         mode.should eq(Termisu::Terminal::Mode::None)
-        mode.none?.should be_true
+        (mode == Termisu::Terminal::Mode::None).should be_true
       end
 
       it "has no flags enabled" do
@@ -154,13 +154,19 @@ describe Termisu::Terminal::Mode do
       mode.extended?.should be_true
     end
 
-    it "can check for None" do
-      mode = Termisu::Terminal::Mode::None
-      mode.none?.should be_true
-      mode.canonical?.should be_false
-      mode.echo?.should be_false
-      mode.signals?.should be_false
-      mode.extended?.should be_false
+    it "distinguishes zero, single, and combined flag values from None" do
+      none = Termisu::Terminal::Mode::None
+      single = Termisu::Terminal::Mode::Signals
+      combined = Termisu::Terminal::Mode::Canonical | Termisu::Terminal::Mode::Echo
+
+      (none == Termisu::Terminal::Mode::None).should be_true
+      (single == Termisu::Terminal::Mode::None).should be_false
+      (combined == Termisu::Terminal::Mode::None).should be_false
+
+      none.canonical?.should be_false
+      none.echo?.should be_false
+      none.signals?.should be_false
+      none.extended?.should be_false
     end
 
     it "supports bitwise operations" do

--- a/spec/termisu/terminal_spec.cr
+++ b/spec/termisu/terminal_spec.cr
@@ -284,6 +284,29 @@ describe Termisu::Terminal do
     ensure
       terminal.try &.close
     end
+
+    it "invalidates after single and combined non-raw modes, but not raw mode" do
+      terminal = CaptureTerminal.new(sync_updates: false)
+      terminal.set_cell(0, 0, 'X')
+      terminal.render
+
+      modes = {
+        Termisu::Terminal::Mode::None                                    => false,
+        Termisu::Terminal::Mode::Signals                                 => true,
+        Termisu::Terminal::Mode::Echo | Termisu::Terminal::Mode::Signals => true,
+      }
+
+      modes.each do |mode, should_invalidate|
+        terminal.clear_captured
+        terminal.with_mode(mode, preserve_screen: true) { }
+        terminal.clear_captured
+        terminal.render
+
+        terminal.output.includes?("X").should eq(should_invalidate)
+      end
+    ensure
+      terminal.try &.close
+    end
   end
 
   describe "#with_cooked_mode" do

--- a/spec/termisu/testing/screen_spec.cr
+++ b/spec/termisu/testing/screen_spec.cr
@@ -122,6 +122,16 @@ describe Termisu::Testing::Screen do
     out.should contain(%(r0 c2 "C" fg=ansi8(2) bg=default attr=None))
   end
 
+  it "reports single and combined attributes without requiring a color" do
+    s = screen(10, 1)
+    s.feed("A\e[1mB\e[4mC")
+
+    out = s.to_styled_s
+    out.should contain(%(r0 c1 "B" fg=default bg=default attr=Bold))
+    out.should contain(%(r0 c2 "C" fg=default bg=default attr=Bold|Underline))
+    out.should_not contain(%(r0 c0 "A"))
+  end
+
   it "excludes masked regions from styled snapshots" do
     s = screen(20, 1)
     s.feed("\e[31mFrame 7")

--- a/spec/termisu_spec.cr
+++ b/spec/termisu_spec.cr
@@ -14,6 +14,43 @@ rescue
   false
 end
 
+# Test-only input source that records facade pause/resume handoffs without
+# starting a reader fiber.
+private class PausableInputSource < Termisu::Event::Source::Input
+  getter start_count : Int32 = 0
+  getter stop_count : Int32 = 0
+  @test_running : Bool = false
+
+  def start(_output : Channel(Termisu::Event::Any)) : Nil
+    @start_count += 1
+    @test_running = true
+  end
+
+  def stop : Nil
+    @stop_count += 1
+    @test_running = false
+  end
+
+  def running? : Bool
+    @test_running
+  end
+end
+
+# Build the public facade around controlled collaborators so mode coordination
+# can be tested independently of its normal initialization lifecycle.
+class Termisu
+  def initialize(
+    @terminal : Terminal,
+    @reader : Reader,
+    @input_parser : Input::Parser,
+    @input_source : Event::Source::Input,
+    @resize_source : Event::Source::Resize,
+    @event_loop : Event::Loop,
+  )
+    @timer_source = nil
+  end
+end
+
 describe Termisu do
   it "has a version number" do
     Termisu::VERSION.should_not be_nil
@@ -33,6 +70,77 @@ describe Termisu do
           Termisu.new
         end
       end
+    end
+  end
+
+  describe "#with_mode" do
+    it "pauses input for single and combined non-raw modes, but not raw mode" do
+      read_fd, write_fd = create_pipe
+      reader = Termisu::Reader.new(read_fd)
+      parser = Termisu::Input::Parser.new(reader)
+      input_source = PausableInputSource.new(reader, parser)
+      resize_source = Termisu::Event::Source::Resize.new(-> { {80, 24} })
+      event_loop = Termisu::Event::Loop.new
+      terminal = CaptureTerminal.new(sync_updates: false)
+      terminal.mode = Termisu::Terminal::Mode.raw
+      termisu = Termisu.new(terminal, reader, parser, input_source, resize_source, event_loop)
+      input_source.start(event_loop.output)
+
+      modes = {
+        Termisu::Terminal::Mode::None                                    => false,
+        Termisu::Terminal::Mode::Signals                                 => true,
+        Termisu::Terminal::Mode::Echo | Termisu::Terminal::Mode::Signals => true,
+      }
+
+      modes.each do |mode, should_pause|
+        starts_before = input_source.start_count
+        stops_before = input_source.stop_count
+
+        termisu.with_mode(mode, preserve_screen: true) do
+          input_source.running?.should eq(!should_pause)
+          input_source.stop_count.should eq(stops_before + (should_pause ? 1 : 0))
+        end
+
+        input_source.running?.should be_true
+        input_source.start_count.should eq(starts_before + (should_pause ? 1 : 0))
+      end
+    ensure
+      terminal.try &.close
+      LibC.close(read_fd) if read_fd
+      LibC.close(write_fd) if write_fd
+    end
+
+    it "keeps input paused until the outer nested non-raw mode exits" do
+      read_fd, write_fd = create_pipe
+      reader = Termisu::Reader.new(read_fd)
+      parser = Termisu::Input::Parser.new(reader)
+      input_source = PausableInputSource.new(reader, parser)
+      resize_source = Termisu::Event::Source::Resize.new(-> { {80, 24} })
+      event_loop = Termisu::Event::Loop.new
+      terminal = CaptureTerminal.new(sync_updates: false)
+      terminal.mode = Termisu::Terminal::Mode.raw
+      termisu = Termisu.new(terminal, reader, parser, input_source, resize_source, event_loop)
+      input_source.start(event_loop.output)
+
+      termisu.with_mode(Termisu::Terminal::Mode.cooked, preserve_screen: true) do
+        input_source.running?.should be_false
+
+        termisu.with_mode(Termisu::Terminal::Mode.password, preserve_screen: true) do
+          input_source.running?.should be_false
+        end
+
+        input_source.running?.should be_false
+        input_source.start_count.should eq(1)
+        input_source.stop_count.should eq(1)
+      end
+
+      input_source.running?.should be_true
+      input_source.start_count.should eq(2)
+      input_source.stop_count.should eq(1)
+    ensure
+      terminal.try &.close
+      LibC.close(read_fd) if read_fd
+      LibC.close(write_fd) if write_fd
     end
   end
 

--- a/src/termisu.cr
+++ b/src/termisu.cr
@@ -587,11 +587,14 @@ class Termisu
 
     # Any non-raw mode needs input processing paused to avoid conflicts
     # between our input reader and direct STDIN access
-    needs_pause = !mode.none?
+    needs_pause = mode != Terminal::Mode::None
+    owns_input_pause = needs_pause && @input_source.running?
     previous_mode = @terminal.current_mode
 
-    # Pause input processing to avoid conflict with shell/external program
-    pause_input_processing if needs_pause
+    # Pause input processing to avoid conflict with shell/external program.
+    # Only the scope that stopped a running source may restart it; nested
+    # non-raw scopes must leave their outer scope's pause in place.
+    pause_input_processing if owns_input_pause
 
     @terminal.with_mode(mode, preserve_screen) do
       emit_mode_change(mode, previous_mode)
@@ -601,7 +604,7 @@ class Termisu
     # Emit event for restoration (back to previous mode or raw default)
     restored_mode = @terminal.current_mode
     emit_mode_change(restored_mode, mode) if restored_mode
-    resume_input_processing if needs_pause
+    resume_input_processing if owns_input_pause
     Log.debug { "Termisu.with_mode: restored" }
   end
 

--- a/src/termisu/terminal.cr
+++ b/src/termisu/terminal.cr
@@ -555,7 +555,7 @@ class Termisu::Terminal < Termisu::Renderer
     apply_terminal_state
     # Always invalidate after non-raw modes - screen content is
     # unpredictable after puts/print/gets during the mode block
-    invalidate_buffer unless mode.none?
+    invalidate_buffer unless mode == Terminal::Mode::None
     # Reset cached style state so next render re-emits all escape sequences.
     # External programs during the mode block may have changed terminal
     # styling, making our cached fg/bg/attr assumptions stale.

--- a/src/termisu/testing/screen.cr
+++ b/src/termisu/testing/screen.cr
@@ -224,7 +224,7 @@ module Termisu::Testing
     private def styled?(cell : Cell) : Bool
       return false if cell.grapheme == " "
       cell.bg != Color.default ||
-        !cell.attr.none? ||
+        cell.attr != Attribute::None ||
         (cell.fg != Color.default && cell.fg != Color.white)
     end
 


### PR DESCRIPTION
## Summary
- replace vacuous generated `none?` checks for zero-valued flags with explicit `None` comparisons
- preserve input pause ownership across nested non-raw facade mode scopes
- cover zero, single, and combined flags, attribute-only snapshots, buffer invalidation, and mode handoff behavior

## Testing
- `mise exec -- unbuffer crystal spec spec/termisu_spec.cr`
- `mise exec -- unbuffer crystal spec spec/termisu/terminal/mode_spec.cr spec/termisu/terminal_spec.cr spec/termisu/testing/screen_spec.cr spec/termisu/input/modifier_spec.cr spec/termisu/attribute_spec.cr`
- `mise exec -- bin/hace format:check`
- `mise exec -- bin/hace ameba`
- `mise exec -- bin/hace spec`
- `mise exec -- bin/hace e2e`

## Compatibility
No public API changes. Legitimate named flag predicates remain unchanged; zero-valued `None` checks now use explicit equality.
