### PR TITLE
fix: coordinate raw input ownership

### DIFF
--- a/Hacefile.yml
+++ b/Hacefile.yml
@@ -375,6 +375,7 @@ tasks:
       crystal build examples/colors.cr -o bin/colors --release
       crystal build examples/keyboard_and_mouse.cr -o bin/kmd --release
       crystal build examples/animation.cr -o bin/animation --release
+      crystal build tests/fixtures/input_ownership.cr -o bin/input-ownership-fixture --release
   e2e:
     description: Build examples and run the Crystal-native E2E suite (spec/e2e)
     phony: true

--- a/examples/demo.cr
+++ b/examples/demo.cr
@@ -100,24 +100,27 @@ begin
     termisu.set_cell(idx, 14, char, fg: Termisu::Color::Yellow, attr: Termisu::Attribute::Bold)
   end
 
-  # Initial render - renders all cells
-  termisu.render
-
-  # Wait for input
-  if termisu.wait_for_input(5000)
-    if byte = termisu.read_byte
-      response = "You pressed: '#{byte.chr}' (byte: #{byte})"
-      response.each_char_with_index do |char, idx|
-        termisu.set_cell(idx, 15, char, fg: Termisu::Color::Green)
-      end
-      termisu.render # Only the changed cells are rendered (diff-based)
-    end
-  else
-    timeout_msg = "Timeout! No input received."
-    timeout_msg.each_char_with_index do |char, idx|
-      termisu.set_cell(idx, 15, char, fg: Termisu::Color::Red)
-    end
+  # Raw reads use an explicit lease so the event parser cannot consume the
+  # same bytes concurrently. Acquire it before displaying the prompt.
+  termisu.with_raw_input do
+    # Initial render - renders all cells
     termisu.render
+
+    if termisu.wait_for_input(5000)
+      if byte = termisu.read_byte
+        response = "You pressed: '#{byte.chr}' (byte: #{byte})"
+        response.each_char_with_index do |char, idx|
+          termisu.set_cell(idx, 15, char, fg: Termisu::Color::Green)
+        end
+        termisu.render # Only the changed cells are rendered (diff-based)
+      end
+    else
+      timeout_msg = "Timeout! No input received."
+      timeout_msg.each_char_with_index do |char, idx|
+        termisu.set_cell(idx, 15, char, fg: Termisu::Color::Red)
+      end
+      termisu.render
+    end
   end
 
   # Animated goodbye with cursor following the text

--- a/examples/showcase.cr
+++ b/examples/showcase.cr
@@ -286,50 +286,55 @@ begin
     termisu.set_cell(hint_x + idx, hint_y, char, fg: Termisu::Color.ansi256(245))
   end
 
-  # Initial render
-  termisu.render
-
   # --- Main Loop ---
   spinners = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']
 
-  loop do
-    # Wait for input with 100ms timeout for animation
-    if termisu.wait_for_input(100)
-      if byte = termisu.read_byte
-        # Quit on 'q'
-        break if byte == 'q'.ord || byte == 'Q'.ord
+  # Acquire raw ownership before displaying the prompt so early keystrokes
+  # cannot be consumed by the event parser.
+  termisu.with_raw_input do
+    # Initial render
+    termisu.render
 
-        # Display pressed key
-        50.times { |col| termisu.set_cell(margin + col, key_y, ' ') } # Clear line
+    loop do
+      # Wait for input with 100ms timeout for animation
+      if termisu.wait_for_input(100)
+        if byte = termisu.read_byte
+          # Quit on 'q'
+          break if byte == 'q'.ord || byte == 'Q'.ord
 
-        key_char = byte.chr
-        display = key_char.printable? ? "'#{key_char}'" : "(non-printable)"
-        msg = "Key: #{display}  byte=#{byte}  hex=0x#{byte.to_s(16).upcase.rjust(2, '0')}"
-        msg.each_char_with_index do |char, col|
-          termisu.set_cell(margin + col, key_y, char, fg: Termisu::Color.magenta, attr: Termisu::Attribute::Bold)
+          # Display pressed key
+          50.times { |col| termisu.set_cell(margin + col, key_y, ' ') } # Clear line
+
+          key_char = byte.chr
+          display = key_char.printable? ? "'#{key_char}'" : "(non-printable)"
+          msg = "Key: #{display}  byte=#{byte}  hex=0x#{byte.to_s(16).upcase.rjust(2, '0')}"
+          msg.each_char_with_index do |char, col|
+            termisu.set_cell(margin + col, key_y, char,
+              fg: Termisu::Color.magenta, attr: Termisu::Attribute::Bold)
+          end
         end
       end
+
+      # Update animation
+      frame += 1
+      spinner = spinners[frame % spinners.size]
+
+      # Clear and redraw status line
+      60.times { |col| termisu.set_cell(margin + col, status_y, ' ') }
+
+      status = "#{spinner} Running... Frame #{frame}"
+      status.each_char_with_index do |char, col|
+        termisu.set_cell(margin + col, status_y, char, fg: Termisu::Color.green)
+      end
+
+      # Color cycling dots
+      3.times do |dot|
+        color_idx = ((frame * 3) + (dot * 72)) % 216 + 16
+        termisu.set_cell(width - 4 + dot, status_y, '●', fg: Termisu::Color.ansi256(color_idx))
+      end
+
+      termisu.render
     end
-
-    # Update animation
-    frame += 1
-    spinner = spinners[frame % spinners.size]
-
-    # Clear and redraw status line
-    60.times { |col| termisu.set_cell(margin + col, status_y, ' ') }
-
-    status = "#{spinner} Running... Frame #{frame}"
-    status.each_char_with_index do |char, col|
-      termisu.set_cell(margin + col, status_y, char, fg: Termisu::Color.green)
-    end
-
-    # Color cycling dots
-    3.times do |dot|
-      color_idx = ((frame * 3) + (dot * 72)) % 216 + 16
-      termisu.set_cell(width - 4 + dot, status_y, '●', fg: Termisu::Color.ansi256(color_idx))
-    end
-
-    termisu.render
   end
 
   # Animated goodbye (from demo.cr)

--- a/examples/simple.cr
+++ b/examples/simple.cr
@@ -17,19 +17,22 @@ begin
   # Position and show cursor
   termisu.set_cursor(14, 1)
 
-  # Render only changed cells (diff-based)
-  termisu.render
+  # Raw reads use an explicit lease so the event parser cannot consume the
+  # same bytes concurrently. Acquire it before displaying the prompt.
+  termisu.with_raw_input do
+    # Render only changed cells (diff-based)
+    termisu.render
 
-  # Wait for input
-  if termisu.wait_for_input(5000)
-    byte = termisu.read_byte
-    if byte
-      msg = "You pressed: '#{byte.chr}' (byte: #{byte})"
-      msg.each_char_with_index do |char, idx|
-        termisu.set_cell(idx, 3, char, Termisu::Color.white, attr: attr)
-        termisu.set_cursor(idx + 1, 3)
-        termisu.render
-        sleep 0.01.seconds
+    if termisu.wait_for_input(5000)
+      byte = termisu.read_byte
+      if byte
+        msg = "You pressed: '#{byte.chr}' (byte: #{byte})"
+        msg.each_char_with_index do |char, idx|
+          termisu.set_cell(idx, 3, char, Termisu::Color.white, attr: attr)
+          termisu.set_cursor(idx + 1, 3)
+          termisu.render
+          sleep 0.01.seconds
+        end
       end
     end
   end

--- a/spec/e2e/pty_spec.cr
+++ b/spec/e2e/pty_spec.cr
@@ -4,6 +4,39 @@ require "./e2e_helper"
 # a controlling PTY and confirm we capture its rendered output. Lives under
 # spec/e2e (not the unit suite) because it needs a built example binary.
 describe Termisu::Testing::Pty do
+  it "hands facade input from raw reads back to event parsing without loss" do
+    requires_binary "bin/input-ownership-fixture"
+
+    Termisu::Testing.terminal(
+      "bin/input-ownership-fixture",
+      cols: 80,
+      rows: 11,
+      env: {"TERM" => "xterm-256color"},
+    ) do |term|
+      term.get_by_text("LEASE REQUIRED").should be_true
+      term.get_by_text("COOKED RAW OK").should be_true
+      term.get_by_text("RAW COOKED OK").should be_true
+      term.get_by_text("PROBE READY").should be_true
+
+      term.write("\e[200~")
+      term.get_by_text("PROBE ESC").should be_true
+      term.write("\e")
+      term.get_by_text("PROBE RETAINED").should be_true
+      term.write("[201~")
+      term.get_by_text("PROBE COMPLETE").should be_true
+      term.get_by_text("RAW READY").should be_true
+
+      term.write("\e[A")
+      term.get_by_text("RAW 1b5b41").should be_true
+      term.get_by_text("EVENT READY").should be_true
+
+      term.write("z")
+      term.get_by_text("EVENT z").should be_true
+      term.row(9).rstrip.should eq("EVENT READY")
+      term.row(10).rstrip.should eq("EVENT z")
+    end
+  end
+
   it "spawns a program on a controlling PTY and captures its output" do
     requires_binary "bin/simple"
 

--- a/spec/termisu/event/source/input_spec.cr
+++ b/spec/termisu/event/source/input_spec.cr
@@ -409,8 +409,14 @@ describe Termisu::Event::Source::Input do
         # First start/stop cycle
         source.start(channel)
         source.running?.should be_true
+        first_fiber = source.@fiber || fail "input fiber not started"
         source.stop
         source.running?.should be_false
+        200.times do
+          break if first_fiber.dead?
+          sleep 1.millisecond
+        end
+        first_fiber.dead?.should be_true
 
         # Second start should work with new channel
         channel2 = Channel(Termisu::Event::Any).new(10)
@@ -432,6 +438,142 @@ describe Termisu::Event::Source::Input do
         source.stop
         channel.close
         channel2.close
+      ensure
+        reader.try(&.close)
+        LibC.close(read_fd)
+        LibC.close(write_fd)
+      end
+    end
+
+    it "clears protocol de-duplication state before raw input takes ownership" do
+      read_fd, write_fd = create_pipe
+      begin
+        reader = Termisu::Reader.new(read_fd)
+        parser = Termisu::Input::Parser.new(reader)
+        source = Termisu::Event::Source::Input.new(reader, parser)
+        channel = Channel(Termisu::Event::Any).new(1)
+
+        source.start(channel)
+        protocol_event = "\e[120;1;120u".to_slice
+        LibC.write(write_fd, protocol_event, protocol_event.size)
+
+        select
+        when event = channel.receive
+          event.as(Termisu::Event::Key).char.should eq('x')
+        when timeout(100.milliseconds)
+          fail "Kitty protocol event was not delivered"
+        end
+
+        source.stop
+        source.prepare_raw_handoff.should be_true
+
+        LibC.write(write_fd, "x".to_unsafe, 1)
+        reader.read_byte(100).should eq('x'.ord.to_u8)
+
+        resumed_channel = Channel(Termisu::Event::Any).new(1)
+        source.start(resumed_channel)
+        LibC.write(write_fd, "x".to_unsafe, 1)
+
+        select
+        when event = resumed_channel.receive
+          key_event = event.as(Termisu::Event::Key)
+          key_event.key.should eq(Termisu::Input::Key::LowerX)
+          key_event.char.should eq('x')
+        when timeout(100.milliseconds)
+          fail "genuine key after raw handoff was not delivered"
+        end
+
+        source.stop
+        channel.close
+        resumed_channel.close
+      ensure
+        reader.try(&.close)
+        LibC.close(read_fd)
+        LibC.close(write_fd)
+      end
+    end
+
+    it "keeps an event blocked by backpressure for the restarted fiber" do
+      read_fd, write_fd = create_pipe
+      begin
+        reader = Termisu::Reader.new(read_fd)
+        parser = Termisu::Input::Parser.new(reader)
+        source = Termisu::Event::Source::Input.new(reader, parser)
+        blocked_channel = Channel(Termisu::Event::Any).new
+
+        source.start(blocked_channel)
+        LibC.write(write_fd, "x".to_unsafe, 1)
+        sleep 20.milliseconds # let the parser reach the blocked channel send
+
+        fiber = source.@fiber || fail "input fiber not started"
+        source.stop
+        source.running?.should be_false
+        source.prepare_raw_handoff.should be_false
+        200.times do
+          break if fiber.dead?
+          sleep 1.millisecond
+        end
+        fiber.dead?.should be_true
+
+        resumed_channel = Channel(Termisu::Event::Any).new(1)
+        source.start(resumed_channel)
+
+        select
+        when event = resumed_channel.receive
+          event.as(Termisu::Event::Key).char.should eq('x')
+        when timeout(100.milliseconds)
+          fail "parsed input was lost while handing off ownership"
+        end
+
+        source.stop
+        source.prepare_raw_handoff.should be_true
+        blocked_channel.close
+        resumed_channel.close
+      ensure
+        reader.try(&.close)
+        LibC.close(read_fd)
+        LibC.close(write_fd)
+      end
+    end
+
+    it "rejects a raw handoff while a paste-end probe retains bytes" do
+      read_fd, write_fd = create_pipe
+      begin
+        reader = Termisu::Reader.new(read_fd)
+        parser = Termisu::Input::Parser.new(reader)
+        source = Termisu::Event::Source::Input.new(reader, parser)
+        channel = Channel(Termisu::Event::Any).new(2)
+
+        source.start(channel)
+        LibC.write(write_fd, "\e[200~\e".to_unsafe, 7)
+
+        select
+        when event = channel.receive
+          event.as(Termisu::Event::Key).key.should eq(Termisu::Input::Key::PasteStart)
+        when timeout(100.milliseconds)
+          fail "paste start was not parsed"
+        end
+        sleep 20.milliseconds # let the parser retain the marker's lone ESC
+
+        source.stop
+        source.prepare_raw_handoff.should be_false
+
+        LibC.write(write_fd, "[201~X".to_unsafe, 6)
+        retained = parser.poll_event(100)
+        retained.as(Termisu::Event::Key).key.should eq(Termisu::Input::Key::PasteEnd)
+        source.prepare_raw_handoff.should be_true
+
+        source.start(channel)
+        select
+        when event = channel.receive
+          event.as(Termisu::Event::Key).char.should eq('X')
+        when timeout(100.milliseconds)
+          fail "input after the retained probe was not parsed"
+        end
+
+        source.stop
+        source.prepare_raw_handoff.should be_true
+        channel.close
       ensure
         reader.try(&.close)
         LibC.close(read_fd)

--- a/spec/termisu_spec.cr
+++ b/spec/termisu_spec.cr
@@ -36,6 +36,49 @@ private class PausableInputSource < Termisu::Event::Source::Input
   end
 end
 
+# Forces close to run after the facade has decided to restart input but before
+# the source records that restart. The production ownership lock must make the
+# close fiber wait until start returns, so Event::Loop#stop wins last.
+private class CloseDuringRestartInputSource < PausableInputSource
+  @close_during_start : Termisu?
+  @close_done = Channel(Exception?).new(1)
+
+  def close_during_next_start(termisu : Termisu) : Nil
+    @close_during_start = termisu
+  end
+
+  def start(output : Channel(Termisu::Event::Any)) : Nil
+    if termisu = @close_during_start
+      @close_during_start = nil
+      close_started = Channel(Nil).new
+      spawn do
+        close_started.send(nil)
+        error = nil.as(Exception?)
+        begin
+          termisu.close
+        rescue ex
+          error = ex
+        ensure
+          @close_done.send(error)
+        end
+      end
+
+      # Let close either acquire the ownership lock (the regression) or block
+      # behind this in-progress restart (the fixed behavior).
+      close_started.receive
+      Fiber.yield
+    end
+
+    super(output)
+  end
+
+  def wait_for_close : Nil
+    if error = @close_done.receive
+      raise error
+    end
+  end
+end
+
 private class FailingStopEventLoop < Termisu::Event::Loop
   getter stop_count : Int32 = 0
 
@@ -117,6 +160,10 @@ class Termisu
     @ownership = TerminalOwnership.acquire
     @closed = Atomic(Bool).new(false)
     @timer_source = nil
+    @input_ownership_lock = Mutex.new
+    @raw_input_owner = nil
+    @raw_input_depth = 0
+    @input_pause_depth = 0
   end
 end
 
@@ -219,6 +266,30 @@ describe Termisu do
   end
 
   describe "#close" do
+    it "does not restart input when close begins during raw lease release" do
+      read_fd, write_fd = create_pipe
+      reader = Termisu::Reader.new(read_fd)
+      parser = Termisu::Input::Parser.new(reader)
+      input_source = CloseDuringRestartInputSource.new(reader, parser)
+      resize_source = Termisu::Event::Source::Resize.new(-> { {80, 24} })
+      event_loop = Termisu::Event::Loop.new
+      terminal = CaptureTerminal.new(sync_updates: false)
+      termisu = Termisu.new(terminal, reader, parser, input_source, resize_source, event_loop)
+      event_loop.add_source(input_source).start
+
+      input_source.close_during_next_start(termisu)
+      termisu.with_raw_input { }
+      input_source.wait_for_close
+
+      event_loop.running?.should be_false
+      event_loop.output.closed?.should be_true
+      input_source.running?.should be_false
+    ensure
+      termisu.try &.close
+      LibC.close(read_fd) if read_fd
+      LibC.close(write_fd) if write_fd
+    end
+
     it "preserves the first failure while completing cleanup and releasing ownership" do
       read_fd, write_fd = create_pipe
       reader = Termisu::Reader.new(read_fd)
@@ -331,12 +402,99 @@ describe Termisu do
 
         input_source.running?.should be_false
         input_source.start_count.should eq(1)
-        input_source.stop_count.should eq(1)
+        input_source.stop_count.should eq(2)
       end
 
       input_source.running?.should be_true
       input_source.start_count.should eq(2)
-      input_source.stop_count.should eq(1)
+      input_source.stop_count.should eq(2)
+    ensure
+      termisu.try &.close
+      LibC.close(read_fd) if read_fd
+      LibC.close(write_fd) if write_fd
+    end
+
+    it "preserves buffered raw input when an overlapping mode exits" do
+      read_fd, write_fd = create_pipe
+      reader = Termisu::Reader.new(read_fd)
+      parser = Termisu::Input::Parser.new(reader)
+      input_source = PausableInputSource.new(reader, parser)
+      resize_source = Termisu::Event::Source::Resize.new(-> { {80, 24} })
+      event_loop = Termisu::Event::Loop.new
+      terminal = CaptureTerminal.new(sync_updates: false)
+      terminal.mode = Termisu::Terminal::Mode.raw
+      termisu = Termisu.new(terminal, reader, parser, input_source, resize_source, event_loop)
+      input_source.start(event_loop.output)
+
+      mode_entered = Channel(Nil).new
+      release_mode = Channel(Nil).new
+      mode_exited = Channel(Nil).new
+      spawn do
+        termisu.with_cooked_mode(preserve_screen: true) do
+          mode_entered.send(nil)
+          release_mode.receive
+        end
+      ensure
+        mode_exited.send(nil)
+      end
+
+      mode_entered.receive
+      termisu.with_raw_input do
+        LibC.write(write_fd, "AB".to_unsafe, 2).should eq(2)
+        termisu.peek_byte.should eq('A'.ord.to_u8)
+
+        release_mode.send(nil)
+        mode_exited.receive
+
+        termisu.input_available?.should be_true
+        termisu.read_bytes(2).should eq("AB".to_slice)
+      end
+    ensure
+      termisu.try &.close
+      LibC.close(read_fd) if read_fd
+      LibC.close(write_fd) if write_fd
+    end
+
+    it "keeps input paused when a mode starts during a raw input lease" do
+      read_fd, write_fd = create_pipe
+      reader = Termisu::Reader.new(read_fd)
+      parser = Termisu::Input::Parser.new(reader)
+      input_source = PausableInputSource.new(reader, parser)
+      resize_source = Termisu::Event::Source::Resize.new(-> { {80, 24} })
+      event_loop = Termisu::Event::Loop.new
+      terminal = CaptureTerminal.new(sync_updates: false)
+      terminal.mode = Termisu::Terminal::Mode.raw
+      termisu = Termisu.new(terminal, reader, parser, input_source, resize_source, event_loop)
+      input_source.start(event_loop.output)
+
+      mode_entered = Channel(Nil).new
+      release_mode = Channel(Nil).new
+      mode_exited = Channel(Nil).new
+
+      termisu.with_raw_input do
+        spawn do
+          termisu.with_cooked_mode(preserve_screen: true) do
+            mode_entered.send(nil)
+            release_mode.receive
+          end
+        ensure
+          mode_exited.send(nil)
+        end
+
+        mode_entered.receive
+        input_source.running?.should be_false
+        input_source.stop_count.should eq(2)
+      end
+
+      input_source.running?.should be_false
+      input_source.start_count.should eq(1)
+
+      release_mode.send(nil)
+      mode_exited.receive
+
+      input_source.running?.should be_true
+      input_source.start_count.should eq(2)
+      input_source.stop_count.should eq(2)
     ensure
       termisu.try &.close
       LibC.close(read_fd) if read_fd

--- a/src/termisu.cr
+++ b/src/termisu.cr
@@ -32,6 +32,10 @@ class Termisu
   @resize_source : Event::Source::Resize
   @event_loop : Event::Loop
   @timer_source : Event::Source::Timer | Event::Source::SystemTimer | Nil
+  @input_ownership_lock : Mutex
+  @raw_input_owner : Fiber?
+  @raw_input_depth : Int32
+  @input_pause_depth : Int32
 
   # Initializes Termisu with all required components.
   #
@@ -50,6 +54,10 @@ class Termisu
   def initialize(*, sync_updates : Bool = true)
     @ownership = TerminalOwnership.acquire
     @closed = Atomic(Bool).new(false)
+    @input_ownership_lock = Mutex.new
+    @raw_input_owner = nil
+    @raw_input_depth = 0
+    @input_pause_depth = 0
 
     resources = begin
       initialize_resources(sync_updates)
@@ -157,7 +165,10 @@ class Termisu
   # The event loop is stopped first to ensure fibers that might be using
   # the reader are terminated before the reader is closed.
   def close
-    return unless @closed.compare_and_set(false, true)[1]
+    won_close = @input_ownership_lock.synchronize do
+      @closed.compare_and_set(false, true)[1]
+    end
+    return unless won_close
 
     lifecycle_log { Log.info { "Closing Termisu" } }
 
@@ -277,19 +288,119 @@ class Termisu
 
   # --- Input Operations ---
 
-  delegate read_byte, # Reads single byte, returns UInt8?
-    read_bytes,       # Reads count bytes, returns Bytes?
-    peek_byte,        # Peeks next byte without consuming, returns UInt8?
-    to: @reader
+  # Temporarily gives the calling fiber exclusive access to raw terminal input.
+  #
+  # Termisu normally owns input through its event parser. Raw reads must happen
+  # inside this block so the parser can be stopped and fully quiesced first.
+  # Event parsing resumes when the outermost lease ends, including when the
+  # block raises.
+  #
+  # ```
+  # termisu.with_raw_input do
+  #   if termisu.wait_for_input(1000)
+  #     byte = termisu.read_byte
+  #   end
+  # end
+  # ```
+  def with_raw_input(&)
+    fiber = acquire_raw_input
+    begin
+      yield
+    ensure
+      release_raw_input(fiber)
+    end
+  end
 
-  # Checks if input data is available.
+  private def acquire_raw_input : Fiber
+    fiber = Fiber.current
+
+    @input_ownership_lock.synchronize do
+      if owner = @raw_input_owner
+        unless owner.same?(fiber)
+          raise InputOwnershipError.new("raw input is already leased by another fiber")
+        end
+        @raw_input_depth += 1
+      else
+        @input_source.stop
+        unless @input_source.prepare_raw_handoff
+          start_input_processing_if_unpaused
+          raise InputOwnershipError.new(
+            "raw input cannot be leased while the event parser retains input; " \
+            "finish the pending event and retry",
+          )
+        end
+
+        @raw_input_owner = fiber
+        @raw_input_depth = 1
+      end
+    end
+
+    fiber
+  end
+
+  # Reads a single raw byte. Must be called inside `with_raw_input`.
+  def read_byte : UInt8?
+    ensure_raw_input_owner("read_byte")
+    @reader.read_byte
+  end
+
+  # Reads exactly *count* raw bytes. Must be called inside `with_raw_input`.
+  def read_bytes(count : Int32) : Bytes?
+    ensure_raw_input_owner("read_bytes")
+    @reader.read_bytes(count)
+  end
+
+  # Peeks at the next raw byte. Must be called inside `with_raw_input`.
+  def peek_byte : UInt8?
+    ensure_raw_input_owner("peek_byte")
+    @reader.peek_byte
+  end
+
+  # Checks if raw input data is available. Must be called inside
+  # `with_raw_input`.
   def input_available? : Bool
+    ensure_raw_input_owner("input_available?")
     @reader.available?
   end
 
-  # Waits for input data with a timeout in milliseconds.
+  # Waits for raw input data with a timeout in milliseconds. Must be called
+  # inside `with_raw_input`.
   def wait_for_input(timeout_ms : Int32) : Bool
+    ensure_raw_input_owner("wait_for_input")
     @reader.wait_for_data(timeout_ms)
+  end
+
+  private def ensure_raw_input_owner(operation : String) : Nil
+    owns_input = @input_ownership_lock.synchronize do
+      @raw_input_owner.try(&.same?(Fiber.current)) || false
+    end
+    return if owns_input
+
+    raise InputOwnershipError.new(
+      "#{operation} requires a raw input lease; call it inside Termisu#with_raw_input",
+    )
+  end
+
+  private def release_raw_input(fiber : Fiber) : Nil
+    @input_ownership_lock.synchronize do
+      return unless @raw_input_owner.try(&.same?(fiber))
+
+      @raw_input_depth -= 1
+      return unless @raw_input_depth == 0
+
+      @raw_input_owner = nil
+      start_input_processing_if_unpaused
+    end
+  end
+
+  # Starts the parser only when every input-pause owner has released it.
+  # Must be called while holding `@input_ownership_lock`.
+  private def start_input_processing_if_unpaused : Nil
+    return unless @input_pause_depth == 0
+    return unless @raw_input_owner.nil?
+    return if @closed.get
+
+    @input_source.start(@event_loop.output)
   end
 
   # --- Event-Based Input API ---
@@ -677,15 +788,15 @@ class Termisu
   def with_mode(mode : Terminal::Mode, preserve_screen : Bool = false, &)
     Log.debug { "Termisu.with_mode: #{mode}, preserve_screen: #{preserve_screen}" }
 
-    # Any non-raw mode needs input processing paused to avoid conflicts
-    # between our input reader and direct STDIN access
-    needs_pause = mode != Terminal::Mode::None
-    owns_input_pause = needs_pause && @input_source.running?
+    # Terminal::Mode.raw uses the zero-valued None member, so every other mode
+    # needs input processing paused to avoid conflicts between our input reader
+    # and direct STDIN access. Every non-raw scope participates in pause-depth
+    # accounting so overlapping raw leases cannot restart input prematurely.
+    owns_input_pause = mode != Terminal::Mode::None
     previous_mode = @terminal.current_mode
 
     # Pause input processing to avoid conflict with shell/external program.
-    # Only the scope that stopped a running source may restart it; nested
-    # non-raw scopes must leave their outer scope's pause in place.
+    # Nested and overlapping non-raw scopes each own one pause-depth entry.
     pause_input_processing if owns_input_pause
 
     @terminal.with_mode(mode, preserve_screen) do
@@ -795,22 +906,29 @@ class Termisu
 
   # Pauses input processing for mode transitions.
   #
-  # Stops the input source and clears any pending input to avoid
-  # conflicts when switching to user-interactive modes.
+  # Stops the input source and clears any pending event input to avoid conflicts
+  # when switching to user-interactive modes. Buffered input is preserved if a
+  # raw lease acquired ownership while mode scopes overlapped across fibers.
   private def pause_input_processing
     Log.debug { "Pausing input processing" }
-    @input_source.stop
-    @reader.clear_buffer
+    @input_ownership_lock.synchronize do
+      @input_source.stop
+      @input_pause_depth += 1
+      @reader.clear_buffer if @raw_input_owner.nil?
+    end
   end
 
   # Resumes input processing after mode transitions.
   #
-  # Clears any stale input and restarts the input source to
-  # continue receiving events.
+  # Clears stale event input and restarts the input source only after every mode
+  # pause and raw lease has ended. An active raw owner's buffer is left intact.
   private def resume_input_processing
     Log.debug { "Resuming input processing" }
-    @reader.clear_buffer
-    @input_source.start(@event_loop.output)
+    @input_ownership_lock.synchronize do
+      @reader.clear_buffer if @raw_input_owner.nil?
+      @input_pause_depth -= 1 if @input_pause_depth > 0
+      start_input_processing_if_unpaused
+    end
   end
 
   # Emits a mode change event to the event loop.

--- a/src/termisu/error.cr
+++ b/src/termisu/error.cr
@@ -6,6 +6,11 @@ end
 class Termisu::TerminalInUseError < Termisu::Error
 end
 
+# Error raised when raw and event-based input APIs are mixed without an
+# explicit ownership handoff.
+class Termisu::InputOwnershipError < Termisu::Error
+end
+
 # Error raised for terminal I/O operations.
 #
 # Wraps system-level I/O errors with additional context about

--- a/src/termisu/event/source/input.cr
+++ b/src/termisu/event/source/input.cr
@@ -52,8 +52,11 @@ class Termisu::Event::Source::Input < Termisu::Event::Source
   @reader : Termisu::Reader
   @parser : Termisu::Input::Parser
   @running : Atomic(Bool)
-  @output : Channel(Event::Any)?
+  @lifecycle_lock : Mutex
+  @stop_signal : Channel(Nil)?
+  @done : Channel(Nil)?
   @fiber : Fiber?
+  @pending_event : Event::Any?
 
   # Creates a new input source.
   #
@@ -61,6 +64,7 @@ class Termisu::Event::Source::Input < Termisu::Event::Source
   # - `parser` - Parser instance for escape sequence parsing
   def initialize(@reader : Termisu::Reader, @parser : Termisu::Input::Parser)
     @running = Atomic(Bool).new(false)
+    @lifecycle_lock = Mutex.new
   end
 
   # Starts polling for input events and sending them to the output channel.
@@ -68,27 +72,57 @@ class Termisu::Event::Source::Input < Termisu::Event::Source
   # Spawns a fiber that drains available input events without blocking
   # and sends them to the channel.
   #
-  # Prevents double-start with `compare_and_set`.
+  # Serializes lifecycle changes so a previous polling fiber is fully stopped
+  # before another can start.
   def start(output : Channel(Event::Any)) : Nil
-    return unless @running.compare_and_set(false, true)
+    @lifecycle_lock.synchronize do
+      return if @running.get
 
-    @output = output
+      stop_signal = Channel(Nil).new
+      done = Channel(Nil).new
+      @stop_signal = stop_signal
+      @done = done
+      @running.set(true)
 
-    @fiber = spawn(name: "termisu-input") do
-      run_loop
+      @fiber = spawn(name: "termisu-input") do
+        run_loop(output, stop_signal)
+      ensure
+        @running.set(false)
+        done.close
+      end
+
+      lifecycle_log { Log.debug { "Input source started" } }
     end
-
-    lifecycle_log { Log.debug { "Input source started" } }
   end
 
   # Stops polling for input events.
   #
-  # Sets the running flag to false, causing the fiber to exit
-  # on its next iteration. Uses compare_and_set for idempotent
-  # stop operations.
+  # Signals the polling fiber and waits for it to finish. When this method
+  # returns, the parser no longer touches the reader, so ownership can be
+  # handed to a raw-input caller without splitting an input sequence.
   def stop : Nil
-    return unless @running.compare_and_set(true, false)
-    lifecycle_log { Log.debug { "Input source stopped" } }
+    @lifecycle_lock.synchronize do
+      fiber = @fiber
+      return unless fiber
+      return if fiber.dead?
+
+      @running.set(false)
+      @stop_signal.try { |signal| signal.close unless signal.closed? }
+      @done.try(&.receive?)
+      lifecycle_log { Log.debug { "Input source stopped" } }
+    end
+  end
+
+  # Prepares the stopped source to hand its reader to a raw-input consumer.
+  #
+  # Callers must stop the source first. A parsed event blocked on backpressure
+  # and bytes retained by an in-progress parser probe both remain event-owned;
+  # handing the reader to a raw consumer in either state would reorder or split
+  # the input stream.
+  def prepare_raw_handoff : Bool
+    @lifecycle_lock.synchronize do
+      !@running.get && @pending_event.nil? && @parser.prepare_raw_handoff
+    end
   end
 
   # Returns true if the input source is currently running.
@@ -102,19 +136,23 @@ class Termisu::Event::Source::Input < Termisu::Event::Source
   end
 
   # Main input loop - runs in a spawned fiber.
-  private def run_loop : Nil
-    output = @output
-    return unless output
-
+  private def run_loop(output : Channel(Event::Any), stop_signal : Channel(Nil)) : Nil
     while @running.get
       emitted = false
       drained = 0
 
       while @running.get && drained < MAX_DRAIN_PER_CYCLE
-        event = @parser.poll_event(0)
+        event = @pending_event || @parser.poll_event(0)
         break unless event
 
-        output.send(event)
+        unless send_event(output, stop_signal, event)
+          # The parser already consumed this complete event. Keep it for the
+          # next run instead of losing it when a full output channel is paused.
+          @pending_event = event
+          return
+        end
+
+        @pending_event = nil
         emitted = true
         drained += 1
       end
@@ -130,5 +168,18 @@ class Termisu::Event::Source::Input < Termisu::Event::Source
   rescue Channel::ClosedError
     # Channel closed during shutdown - exit gracefully
     Log.debug { "Input channel closed, exiting" }
+  end
+
+  private def send_event(
+    output : Channel(Event::Any),
+    stop_signal : Channel(Nil),
+    event : Event::Any,
+  ) : Bool
+    select
+    when output.send(event)
+      true
+    when stop_signal.receive?
+      false
+    end
   end
 end

--- a/src/termisu/input/parser.cr
+++ b/src/termisu/input/parser.cr
@@ -169,6 +169,18 @@ class Termisu::Input::Parser
   def initialize(@reader : Reader)
   end
 
+  # Prepares to move ownership to an unparsed raw-input consumer.
+  #
+  # An open paste is parser state even when its push-back queue is momentarily
+  # empty, so raw access must wait until the matching PasteEnd restores a clean
+  # boundary. Once that boundary is clean, the raw consumer owns the next byte;
+  # discard the protocol echo guard so it cannot affect parsing after handback.
+  def prepare_raw_handoff : Bool
+    ready = @pending.empty? && !@in_paste && @paste_deadline.nil?
+    @dup_guard = nil if ready
+    ready
+  end
+
   # Reads a complete UTF-8 character (1-4 bytes) starting from the given lead byte.
   # Consumes the additional continuation bytes from the reader.
   # Returns nil if incomplete, invalid, or not UTF-8 text.

--- a/tests/fixtures/input_ownership.cr
+++ b/tests/fixtures/input_ownership.cr
@@ -1,0 +1,96 @@
+require "../../src/termisu"
+
+private def show(termisu : Termisu, message : String, row : Int32) : Nil
+  message.each_char_with_index do |char, column|
+    termisu.set_cell(column, row, char)
+  end
+  termisu.render
+end
+
+private def wait_for_key(
+  termisu : Termisu,
+  expected : Termisu::Input::Key,
+  timeout : Time::Span = 2.seconds,
+) : Bool
+  deadline = monotonic_now + timeout
+  while (remaining = deadline - monotonic_now) > Time::Span.zero
+    event = termisu.poll_event(remaining)
+    return false unless event
+    return true if event.as?(Termisu::Event::Key).try(&.key) == expected
+  end
+  false
+end
+
+termisu = Termisu.new(sync_updates: false)
+
+begin
+  begin
+    termisu.read_byte
+  rescue Termisu::InputOwnershipError
+    show(termisu, "LEASE REQUIRED", 0)
+  end
+
+  cooked_states = [] of Bool
+  termisu.with_cooked_mode(preserve_screen: true) do
+    cooked_states << !termisu.@input_source.running?
+    termisu.with_raw_input do
+      cooked_states << !termisu.@input_source.running?
+    end
+    cooked_states << !termisu.@input_source.running?
+  end
+  cooked_states << termisu.@input_source.running?
+  cooked_nested = cooked_states.all?
+  show(termisu, "COOKED RAW #{cooked_nested ? "OK" : "BAD"}", 1)
+
+  raw_nested = false
+  termisu.with_raw_input do
+    outer_stopped = !termisu.@input_source.running?
+    termisu.with_cooked_mode(preserve_screen: true) do
+      raw_nested = outer_stopped && !termisu.@input_source.running?
+    end
+    raw_nested &&= !termisu.@input_source.running?
+  end
+  raw_nested &&= termisu.@input_source.running?
+  show(termisu, "RAW COOKED #{raw_nested ? "OK" : "BAD"}", 2)
+
+  show(termisu, "PROBE READY", 3)
+  if wait_for_key(termisu, Termisu::Input::Key::PasteStart)
+    show(termisu, "PROBE ESC", 4)
+    sleep 100.milliseconds
+
+    begin
+      termisu.with_raw_input { }
+    rescue Termisu::InputOwnershipError
+      show(termisu, "PROBE RETAINED", 5)
+    end
+
+    # Complete the event-owned probe under explicit source quiescence. The
+    # source normally polls non-blockingly; this bounded poll makes the PTY
+    # fixture deterministic without changing parser deadline behavior.
+    termisu.@input_source.stop
+    retained = termisu.@input_parser.poll_event(2_000)
+    termisu.@input_source.start(termisu.@event_loop.output)
+    if retained.as?(Termisu::Event::Key).try(&.key) == Termisu::Input::Key::PasteEnd
+      show(termisu, "PROBE COMPLETE", 6)
+    end
+  end
+
+  termisu.with_raw_input do
+    show(termisu, "RAW READY", 7)
+    if termisu.wait_for_input(2_000)
+      if bytes = termisu.read_bytes(3)
+        show(termisu, "RAW #{bytes.hexstring}", 8)
+      end
+    end
+  end
+
+  show(termisu, "EVENT READY", 9)
+  if event = termisu.poll_event(2.seconds)
+    if key = event.as?(Termisu::Event::Key)
+      show(termisu, "EVENT #{key.char}", 10)
+    end
+  end
+  sleep 100.milliseconds
+ensure
+  termisu.close
+end


### PR DESCRIPTION
## Summary
- add fiber-scoped raw input leases that synchronously quiesce event parsing and prevent duplicate input fibers
- preserve backpressured events and reject handoff while the parser retains bytes or in-progress paste state
- coordinate nested raw leases with cooked-mode/suspend pauses and cover the facade handoff through a PTY

## Testing
- `unbuffer mise exec -- crystal spec spec/termisu_spec.cr spec/termisu/reader_spec.cr spec/termisu/event/source/input_spec.cr spec/termisu/input`
- `mise exec -- crystal spec spec/termisu/event/source/input_spec.cr`
- `mise exec -- bin/hace format:check`
- `mise exec -- bin/hace ameba`
- `mise exec -- bin/hace spec`
- `mise exec -- bin/hace e2e`

## Compatibility
Raw `read_byte`, `read_bytes`, `peek_byte`, `input_available?`, and `wait_for_input` calls now require `with_raw_input`. A lease raises `InputOwnershipError` while the event parser retains an event or an open bracketed-paste probe; callers should let event parsing finish and retry. The mode pause check uses the flags value directly as a minimal compatibility hook because `Flags#none?` does not identify the zero/raw mode.