### PR TITLE
fix: preserve render state on failure

### DIFF
--- a/spec/termisu/buffer_spec.cr
+++ b/spec/termisu/buffer_spec.cr
@@ -1,5 +1,66 @@
 require "../spec_helper"
 
+private class RenderFaultRenderer < MockRenderer
+  enum Phase
+    Move
+    Sgr
+    Write
+    Flush
+  end
+
+  property fail_phase : Phase?
+  getter? failed : Bool = false
+
+  def initialize(@fail_phase : Phase?)
+  end
+
+  def move_cursor(x : Int32, y : Int32)
+    fail_once(Phase::Move)
+    super
+  end
+
+  def apply_sgr(
+    fg : Termisu::Color,
+    bg : Termisu::Color,
+    attr : Termisu::Attribute,
+    old_fg : Termisu::Color?,
+    old_bg : Termisu::Color?,
+    old_attr : Termisu::Attribute,
+  ) : Nil
+    fail_once(Phase::Sgr)
+    super
+  end
+
+  def write(data : String, columns_advanced = 0)
+    fail_once(Phase::Write)
+    super
+  end
+
+  def flush
+    fail_once(Phase::Flush)
+    super
+  end
+
+  private def fail_once(phase : Phase) : Nil
+    return if @fail_phase != phase || @failed
+
+    @failed = true
+    raise "injected #{phase} failure"
+  end
+end
+
+private class CachedRenderFaultRenderer < CaptureRenderer
+  property? fail_next_move : Bool = false
+
+  def move_cursor(x : Int32, y : Int32)
+    if @fail_next_move
+      @fail_next_move = false
+      raise "injected cached move failure"
+    end
+    super
+  end
+end
+
 describe Termisu::Buffer do
   describe ".new" do
     it "creates a buffer with specified dimensions" do
@@ -292,6 +353,65 @@ describe Termisu::Buffer do
       renderer.write_calls.should contain("A")
       renderer.write_calls.should contain("BC")
     end
+
+    RenderFaultRenderer::Phase.each do |phase|
+      it "fully retries the frame after a #{phase.to_s.downcase} failure" do
+        renderer = RenderFaultRenderer.new(phase)
+        buffer = Termisu::Buffer.new(4, 1)
+        buffer.set_cell(0, 0, 'A', fg: Termisu::Color.red)
+        buffer.set_cell(2, 0, 'B', fg: Termisu::Color.blue)
+
+        expect_raises(Exception, "injected #{phase} failure") do
+          buffer.render_to(renderer)
+        end
+
+        renderer.failed?.should be_true
+        renderer.clear
+        buffer.render_to(renderer)
+
+        renderer.write_calls.sum(&.size).should eq(4)
+        renderer.write_calls.join.should contain("A")
+        renderer.write_calls.join.should contain("B")
+        renderer.fg_calls.should contain(Termisu::Color.red)
+      end
+    end
+
+    it "clears stale cached attributes when retrying an unstyled frame" do
+      renderer = CachedRenderFaultRenderer.new
+      buffer = Termisu::Buffer.new(1, 1)
+      buffer.set_cell(0, 0, 'A', attr: Termisu::Attribute::Bold)
+      buffer.render_to(renderer)
+
+      buffer.set_cell(0, 0, 'B', attr: Termisu::Attribute::None)
+      renderer.fail_next_move = true
+      expect_raises(Exception, "injected cached move failure") do
+        buffer.render_to(renderer)
+      end
+
+      renderer.clear_writes
+      buffer.render_to(renderer)
+
+      renderer.writes.should contain("\e[0m")
+      renderer.writes.should contain("B")
+    end
+
+    it "retries a wide cell and its continuation atomically after a write failure" do
+      renderer = RenderFaultRenderer.new(RenderFaultRenderer::Phase::Write)
+      buffer = Termisu::Buffer.new(4, 1)
+      buffer.set_cell(0, 0, '中', fg: Termisu::Color.red)
+      buffer.set_cell(2, 0, 'A')
+
+      expect_raises(Exception, "injected Write failure") do
+        buffer.render_to(renderer)
+      end
+
+      renderer.clear
+      buffer.render_to(renderer)
+
+      renderer.write_calls.join.should contain("中")
+      renderer.write_calls.join.should contain("A")
+      renderer.move_calls.should contain({0, 0})
+    end
   end
 
   describe "#sync_to (full redraw)" do
@@ -328,6 +448,22 @@ describe Termisu::Buffer do
       # All 5 cells should be in a single batched write
       renderer.write_calls.size.should eq(1)
       renderer.write_calls[0].size.should eq(5)
+    end
+
+    it "leaves a failed full redraw retryable as a complete frame" do
+      renderer = RenderFaultRenderer.new(RenderFaultRenderer::Phase::Write)
+      buffer = Termisu::Buffer.new(3, 1)
+      buffer.set_cell(1, 0, 'X', fg: Termisu::Color.red)
+
+      expect_raises(Exception, "injected Write failure") do
+        buffer.sync_to(renderer)
+      end
+
+      renderer.clear
+      buffer.render_to(renderer)
+
+      renderer.write_calls.sum(&.size).should eq(3)
+      renderer.write_calls.join.should contain("X")
     end
   end
 

--- a/spec/termisu/render_state_spec.cr
+++ b/spec/termisu/render_state_spec.cr
@@ -2,11 +2,12 @@ require "../spec_helper"
 
 describe Termisu::RenderState do
   describe ".new" do
-    it "initializes with nil/unknown state" do
+    it "initializes with unknown colors and known default attributes" do
       state = Termisu::RenderState.new
       state.fg.should be_nil
       state.bg.should be_nil
       state.attr.should eq(Termisu::Attribute::None)
+      state.attr_known?.should be_true
     end
   end
 
@@ -22,6 +23,7 @@ describe Termisu::RenderState do
       state.fg.should be_nil
       state.bg.should be_nil
       state.attr.should eq(Termisu::Attribute::None)
+      state.attr_known?.should be_false
     end
   end
 
@@ -35,6 +37,17 @@ describe Termisu::RenderState do
       changed.should be_true
       renderer.fg_calls.should eq([Termisu::Color.green])
       renderer.bg_calls.should eq([Termisu::Color.blue])
+    end
+
+    it "clears unknown physical attributes before applying a reset style" do
+      renderer = MockRenderer.new
+      state = Termisu::RenderState.new
+      state.reset
+
+      state.apply_style(renderer, Termisu::Color.white, Termisu::Color.default, Termisu::Attribute::None)
+
+      renderer.reset_count.should eq(1)
+      state.attr_known?.should be_true
     end
 
     it "skips emission when style unchanged" do

--- a/spec/termisu/terminal/sync_update_spec.cr
+++ b/spec/termisu/terminal/sync_update_spec.cr
@@ -18,6 +18,94 @@ private class RaisingCaptureTerminal < CaptureTerminal
   end
 end
 
+private class PrimaryAndCleanupFaultTerminal < CaptureTerminal
+  enum CleanupPhase
+    EsuWrite
+    Flush
+  end
+
+  property cleanup_phase : CleanupPhase?
+  getter? cleanup_failed : Bool = false
+
+  def size : {Int32, Int32}
+    {3, 1}
+  end
+
+  def move_cursor(x : Int32, y : Int32)
+    raise "primary render failure"
+  end
+
+  def write(data : String, columns_advanced = 0)
+    if data == Termisu::Terminal::ESU && @cleanup_phase == CleanupPhase::EsuWrite
+      @cleanup_failed = true
+      raise "cleanup ESU failure"
+    end
+    @writes << data
+  end
+
+  def flush
+    if @cleanup_phase == CleanupPhase::Flush
+      @cleanup_failed = true
+      raise "cleanup flush failure"
+    end
+    super
+  end
+end
+
+private class SyncFaultTerminal < CaptureTerminal
+  enum Phase
+    Begin
+    Move
+    Sgr
+    Write
+    End
+    Flush
+  end
+
+  property fail_phase : Phase?
+  getter? failed : Bool = false
+
+  def size : {Int32, Int32}
+    {3, 1}
+  end
+
+  def move_cursor(x : Int32, y : Int32)
+    fail_once(Phase::Move)
+    super
+  end
+
+  def write(data : String, columns_advanced = 0)
+    if data == Termisu::Terminal::BSU
+      fail_once(Phase::Begin)
+    elsif data == Termisu::Terminal::ESU
+      fail_once(Phase::End)
+    end
+    @writes << data
+  end
+
+  def write(data : Bytes, columns_advanced = 0)
+    text = String.new(data)
+    if text.starts_with?('\e') && text.ends_with?('m')
+      fail_once(Phase::Sgr)
+    else
+      fail_once(Phase::Write)
+    end
+    @writes << text
+  end
+
+  def flush
+    fail_once(Phase::Flush)
+    super
+  end
+
+  private def fail_once(phase : Phase) : Nil
+    return if @fail_phase != phase || @failed
+
+    @failed = true
+    raise "injected #{phase} failure"
+  end
+end
+
 describe "Synchronized Update Emission" do
   describe "#render" do
     it "emits BSU before content and ESU after when sync_updates enabled" do
@@ -127,6 +215,53 @@ describe "Synchronized Update Emission" do
       terminal.captured_flush_count.should eq(1)
     ensure
       terminal.try &.close
+    end
+  end
+
+  describe "transaction retries" do
+    SyncFaultTerminal::Phase.each do |phase|
+      it "fully retries an unstyled frame after a synchronized-update #{phase.to_s.downcase} failure" do
+        terminal = SyncFaultTerminal.new(sync_updates: true)
+        terminal.set_cell(0, 0, 'X', attr: Termisu::Attribute::Bold)
+        terminal.render
+
+        terminal.clear_captured
+        terminal.set_cell(0, 0, 'Y', attr: Termisu::Attribute::None)
+        terminal.fail_phase = phase
+        expect_raises(Exception, "injected #{phase} failure") do
+          terminal.render
+        end
+
+        terminal.failed?.should be_true
+        terminal.clear_captured
+        terminal.render
+
+        content_writes = terminal.writes.reject(&.starts_with?('\e'))
+        content_writes.join.should eq("Y  ")
+        terminal.output.should contain(Termisu::Terminal::BSU)
+        terminal.output.should contain(Termisu::Terminal::ESU)
+        terminal.output.should contain("\e[m")
+        terminal.captured_flush_count.should eq(1)
+      ensure
+        terminal.try &.close
+      end
+    end
+  end
+
+  describe "compound transaction failures" do
+    PrimaryAndCleanupFaultTerminal::CleanupPhase.each do |cleanup_phase|
+      it "preserves the rendering error when #{cleanup_phase.to_s.underscore} cleanup also fails" do
+        terminal = PrimaryAndCleanupFaultTerminal.new(sync_updates: true)
+        terminal.set_cell(0, 0, 'X')
+        terminal.cleanup_phase = cleanup_phase
+
+        expect_raises(Exception, "primary render failure") do
+          terminal.render
+        end
+        terminal.cleanup_failed?.should be_true
+      ensure
+        terminal.try &.close
+      end
     end
   end
 

--- a/spec/termisu/terminal_caching_spec.cr
+++ b/spec/termisu/terminal_caching_spec.cr
@@ -1,5 +1,13 @@
 require "../spec_helper"
 
+private class CustomResetTerminfo < Termisu::Terminfo
+  RESET_SEQUENCE = "<reset-attributes>"
+
+  def reset_attrs_seq : String
+    RESET_SEQUENCE
+  end
+end
+
 describe "Terminal State Caching" do
   describe "foreground color caching" do
     it "writes escape sequence on first call" do
@@ -229,6 +237,40 @@ describe "Terminal State Caching" do
       terminal.writes.should contain("\e[44m")
       terminal.writes.should contain("\e[1m")
       terminal.writes.should contain("\e[?25h")
+    end
+  end
+
+  describe "direct style recovery after #reset_render_state" do
+    styles = [
+      {name: "foreground", sequence: "\e[31m", apply: ->(terminal : CaptureTerminal) { terminal.foreground = Termisu::Color.red; nil }},
+      {name: "background", sequence: "\e[44m", apply: ->(terminal : CaptureTerminal) { terminal.background = Termisu::Color.blue; nil }},
+      {name: "bold", sequence: "\e[1m", apply: ->(terminal : CaptureTerminal) { terminal.enable_bold; nil }},
+      {name: "underline", sequence: "\e[4m", apply: ->(terminal : CaptureTerminal) { terminal.enable_underline; nil }},
+      {name: "blink", sequence: "\e[5m", apply: ->(terminal : CaptureTerminal) { terminal.enable_blink; nil }},
+      {name: "reverse", sequence: "\e[7m", apply: ->(terminal : CaptureTerminal) { terminal.enable_reverse; nil }},
+      {name: "dim", sequence: "\e[2m", apply: ->(terminal : CaptureTerminal) { terminal.enable_dim; nil }},
+      {name: "cursive", sequence: "\e[3m", apply: ->(terminal : CaptureTerminal) { terminal.enable_cursive; nil }},
+      {name: "hidden", sequence: "\e[8m", apply: ->(terminal : CaptureTerminal) { terminal.enable_hidden; nil }},
+      {name: "strikethrough", sequence: "\e[9m", apply: ->(terminal : CaptureTerminal) { terminal.enable_strikethrough; nil }},
+    ]
+
+    styles.each do |style|
+      it "resets before applying #{style[:name]} and then caches it" do
+        terminal = CaptureTerminal.new(
+          sync_updates: false,
+          terminfo: CustomResetTerminfo.new
+        )
+        terminal.reset_render_state
+
+        style[:apply].call(terminal)
+        terminal.writes.should eq([CustomResetTerminfo::RESET_SEQUENCE, style[:sequence]])
+
+        terminal.clear_captured
+        style[:apply].call(terminal)
+        terminal.writes.should be_empty
+      ensure
+        terminal.try &.close
+      end
     end
   end
 

--- a/src/termisu/buffer.cr
+++ b/src/termisu/buffer.cr
@@ -265,6 +265,14 @@ class Termisu::Buffer
     end
 
     renderer.flush if auto_flush
+  rescue error
+    # A renderer can fail after accepting only part of a cursor, style, or
+    # character write. Its resulting screen and cursor state are unknowable,
+    # so retain no diff or style assumptions and make the whole frame
+    # retryable. Front keys are also staged per batch below, but a final flush
+    # failure must invalidate batches whose writes had already returned.
+    invalidate
+    raise error
   end
 
   # Forces a full redraw of all cells to the renderer, ignoring the diff.
@@ -286,6 +294,9 @@ class Termisu::Buffer
     reset_dirty_rows
 
     renderer.flush if auto_flush
+  rescue error
+    invalidate
+    raise error
   end
 
   # Resizes the buffer to new dimensions.
@@ -537,10 +548,7 @@ class Termisu::Buffer
   private def skip_row_cell?(back_key : UInt128, idx : Int32, diff_only : Bool) : Bool
     return true if diff_only && back_key == @front_keys.unsafe_fetch(idx)
 
-    return false unless Cell.key_continuation?(back_key)
-
-    @front_keys.unsafe_put(idx, back_key)
-    true
+    Cell.key_continuation?(back_key)
   end
 
   private def render_row_batch(
@@ -564,7 +572,6 @@ class Termisu::Buffer
       break if diff_only && back_key == @front_keys.unsafe_fetch(idx)
 
       if Cell.key_continuation?(back_key)
-        @front_keys.unsafe_put(idx, back_key)
         col += 1
         next
       end
@@ -580,13 +587,25 @@ class Termisu::Buffer
         @batch_buffer << @graphemes.unsafe_fetch(idx)
       end
       columns_advanced += Cell.key_width(back_key)
-      @front_keys.unsafe_put(idx, back_key)
       col += 1
     end
 
     render_batch(renderer, batch_start, row, @batch_buffer.to_slice,
       Cell.key_fg(first_key), Cell.key_bg(first_key), Cell.key_attr(first_key), columns_advanced)
+    commit_front_batch(row_start, batch_start, col)
     col
+  end
+
+  # Commits a batch only after its cursor movement, style transition, and
+  # character write have all returned successfully. Continuation keys are
+  # committed with their leading glyph so wide-cell occupancy remains atomic.
+  private def commit_front_batch(row_start : Int32, batch_start : Int32, batch_end : Int32) : Nil
+    col = batch_start
+    while col < batch_end
+      idx = row_start + col
+      @front_keys.unsafe_put(idx, @back_keys.unsafe_fetch(idx))
+      col += 1
+    end
   end
 
   # Renders a batch of characters with the same styling.

--- a/src/termisu/render_state.cr
+++ b/src/termisu/render_state.cr
@@ -24,16 +24,20 @@ struct Termisu::RenderState
   # Current background color (nil = unknown/reset)
   property bg : Color?
 
-  # Current text attributes
+  # Current text attributes. `attr_known?` distinguishes a known default
+  # from an invalidated terminal whose active attributes are unknown.
   property attr : Attribute
+  getter? attr_known : Bool
 
   def initialize
     @fg, @bg, @attr = default_state
+    @attr_known = true
   end
 
   # Resets state to unknown (forces next render to emit all sequences).
   def reset
     @fg, @bg, @attr = default_state
+    @attr_known = false
   end
 
   # Applies style to renderer, only emitting changes.
@@ -50,12 +54,21 @@ struct Termisu::RenderState
     bg : Color,
     attr : Attribute,
   ) : Bool
-    return false if attr == @attr && fg == @fg && bg == @bg
+    return false if @attr_known && attr == @attr && fg == @fg && bg == @bg
 
-    renderer.apply_sgr(fg, bg, attr, @fg, @bg, @attr)
+    # Attribute::None is a valid known state, not an unknown-state sentinel.
+    # After invalidation, clear every potentially active physical attribute
+    # before applying the target style. The reset also invalidates colors.
+    if @attr_known
+      renderer.apply_sgr(fg, bg, attr, @fg, @bg, @attr)
+    else
+      renderer.reset_attributes
+      renderer.apply_sgr(fg, bg, attr, nil, nil, Attribute::None)
+    end
     @fg = fg
     @bg = bg
     @attr = attr
+    @attr_known = true
     true
   end
 

--- a/src/termisu/terminal.cr
+++ b/src/termisu/terminal.cr
@@ -37,6 +37,7 @@ class Termisu::Terminal < Termisu::Renderer
   @cached_fg : Color?
   @cached_bg : Color?
   @cached_attr : Attribute = Attribute::None
+  @cached_attr_known : Bool = true
 
   # Cached terminal size to avoid a TIOCGWINSZ ioctl per write/move_cursor.
   # Refreshed by resize() and invalidated after mode switches.
@@ -131,6 +132,7 @@ class Termisu::Terminal < Termisu::Renderer
     @cached_fg = nil
     @cached_bg = nil
     @cached_attr = Attribute::None
+    @cached_attr_known = false
   end
 
   # Precomputed SGR color sequences, indexed by color index.
@@ -158,6 +160,7 @@ class Termisu::Terminal < Termisu::Renderer
   # Caches the color to avoid redundant escape sequences when called
   # repeatedly with the same color.
   def foreground=(color : Color)
+    ensure_style_state
     return if @cached_fg == color
     @cached_fg = color
 
@@ -180,6 +183,7 @@ class Termisu::Terminal < Termisu::Renderer
   # Caches the color to avoid redundant escape sequences when called
   # repeatedly with the same color.
   def background=(color : Color)
+    ensure_style_state
     return if @cached_bg == color
     @cached_bg = color
 
@@ -232,6 +236,11 @@ class Termisu::Terminal < Termisu::Renderer
     old_bg : Color?,
     old_attr : Attribute,
   ) : Nil
+    # `Attribute::None` cannot represent an unknown physical state. A failed
+    # frame marks this cache unknown, so establish a real default before any
+    # selective transition. This also invalidates both cached colors.
+    ensure_style_state
+
     # The combined emitter hardcodes ECMA-48 SGR parameters; when the loaded
     # attribute capabilities are non-standard, defer to the granular
     # terminfo-driven decomposition (mirrors the cup_is_standard? guard).
@@ -256,6 +265,7 @@ class Termisu::Terminal < Termisu::Renderer
     write(buf.to_slice)
 
     @cached_attr = attr
+    @cached_attr_known = true
     @cached_fg = fg
     @cached_bg = bg
   end
@@ -318,6 +328,11 @@ class Termisu::Terminal < Termisu::Renderer
     end
   end
 
+  # Establishes a known terminal style before consulting any style cache.
+  private def ensure_style_state : Nil
+    reset_attributes unless @cached_attr_known
+  end
+
   # Resets all attributes to default.
   #
   # Also clears cached color/attribute state since reset affects all styling.
@@ -326,12 +341,14 @@ class Termisu::Terminal < Termisu::Renderer
     @cached_fg = nil
     @cached_bg = nil
     @cached_attr = Attribute::None
+    @cached_attr_known = true
   end
 
   # Enables bold text.
   #
   # Caches attribute state to avoid redundant escape sequences.
   def enable_bold
+    ensure_style_state
     return if @cached_attr.bold?
     @cached_attr |= Attribute::Bold
     write(@terminfo.bold_seq)
@@ -341,6 +358,7 @@ class Termisu::Terminal < Termisu::Renderer
   #
   # Caches attribute state to avoid redundant escape sequences.
   def enable_underline
+    ensure_style_state
     return if @cached_attr.underline?
     @cached_attr |= Attribute::Underline
     write(@terminfo.underline_seq)
@@ -350,6 +368,7 @@ class Termisu::Terminal < Termisu::Renderer
   #
   # Caches attribute state to avoid redundant escape sequences.
   def enable_blink
+    ensure_style_state
     return if @cached_attr.blink?
     @cached_attr |= Attribute::Blink
     write(@terminfo.blink_seq)
@@ -359,6 +378,7 @@ class Termisu::Terminal < Termisu::Renderer
   #
   # Caches attribute state to avoid redundant escape sequences.
   def enable_reverse
+    ensure_style_state
     return if @cached_attr.reverse?
     @cached_attr |= Attribute::Reverse
     write(@terminfo.reverse_seq)
@@ -368,6 +388,7 @@ class Termisu::Terminal < Termisu::Renderer
   #
   # Caches attribute state to avoid redundant escape sequences.
   def enable_dim
+    ensure_style_state
     return if @cached_attr.dim?
     @cached_attr |= Attribute::Dim
     write(@terminfo.dim_seq)
@@ -377,6 +398,7 @@ class Termisu::Terminal < Termisu::Renderer
   #
   # Caches attribute state to avoid redundant escape sequences.
   def enable_cursive
+    ensure_style_state
     return if @cached_attr.cursive?
     @cached_attr |= Attribute::Cursive
     write(@terminfo.italic_seq)
@@ -386,6 +408,7 @@ class Termisu::Terminal < Termisu::Renderer
   #
   # Caches attribute state to avoid redundant escape sequences.
   def enable_hidden
+    ensure_style_state
     return if @cached_attr.hidden?
     @cached_attr |= Attribute::Hidden
     write(@terminfo.hidden_seq)
@@ -395,6 +418,7 @@ class Termisu::Terminal < Termisu::Renderer
   #
   # Caches attribute state to avoid redundant escape sequences.
   def enable_strikethrough
+    ensure_style_state
     return if @cached_attr.strikethrough?
     @cached_attr |= Attribute::Strikethrough
     write(@terminfo.strikethrough_seq)
@@ -673,13 +697,8 @@ class Termisu::Terminal < Termisu::Renderer
   # When sync_updates is enabled, wraps the render in DEC mode 2026 sequences
   # (BSU/ESU) to prevent screen tearing during rapid updates.
   def render
-    begin_sync_update
-    begin
-      with_ephemeral_cursor do
-        @buffer.render_to(self, auto_flush: !@sync_updates)
-      end
-    ensure
-      end_sync_update
+    render_transaction do
+      @buffer.render_to(self, auto_flush: !@sync_updates)
     end
   end
 
@@ -690,14 +709,39 @@ class Termisu::Terminal < Termisu::Renderer
   # When sync_updates is enabled, wraps the sync in DEC mode 2026 sequences
   # (BSU/ESU) to prevent screen tearing during the full redraw.
   def sync
-    begin_sync_update
-    begin
-      with_ephemeral_cursor do
-        @buffer.sync_to(self, auto_flush: !@sync_updates)
-      end
-    ensure
-      end_sync_update
+    render_transaction do
+      @buffer.sync_to(self, auto_flush: !@sync_updates)
     end
+  end
+
+  # Keeps Buffer and Terminal caches provisional until every operation around
+  # a frame, including synchronized-update framing and its flush, succeeds.
+  # Buffer handles failures from its direct renderer calls; this outer guard
+  # also covers BSU/ESU and restores cache truth for Terminal's renderer state.
+  private def render_transaction(&)
+    primary_error : Exception? = nil
+
+    begin
+      begin_sync_update
+      with_ephemeral_cursor { yield }
+    rescue error
+      primary_error = error
+    ensure
+      # BSU writes can fail after partial output, so attempt ESU even when
+      # beginning the synchronized update raises. If rendering already failed,
+      # preserve that primary error when cleanup fails too.
+      begin
+        end_sync_update
+      rescue exception
+        raise exception unless primary_error
+      end
+    end
+
+    raise primary_error if primary_error
+  rescue error
+    @buffer.invalidate
+    reset_render_state
+    raise error
   end
 
   # Emits BSU (Begin Synchronized Update) sequence if sync_updates is enabled.

--- a/src/termisu/terminal/cursor.cr
+++ b/src/termisu/terminal/cursor.cr
@@ -17,16 +17,24 @@ class Termisu::Terminal
   end
 
   private def apply_cursor_state
-    x, y = @cursor.x, @cursor.y
-    @cursor.x, @cursor.y = -1, -1
-    move_cursor(x, y)
+    desired = @cursor
+    begin
+      x, y = desired.x, desired.y
+      @cursor.x, @cursor.y = -1, -1
+      move_cursor(x, y)
 
-    if @cursor.visible?
-      @cursor.visible = false
-      show_cursor
-    else
-      @cursor.visible = true
-      hide_cursor
+      if desired.visible?
+        @cursor.visible = false
+        show_cursor
+      else
+        @cursor.visible = true
+        hide_cursor
+      end
+    rescue error
+      # Preserve the requested cursor state if any of the forced emissions
+      # fails. Rendering will force the complete state again on its next try.
+      @cursor = desired
+      raise error
     end
   end
 
@@ -129,8 +137,8 @@ class Termisu::Terminal
   private def with_ephemeral_cursor(visible : Bool = false, &)
     cursor_backup = @cursor
     @cursor = Cursor.new visible
-    apply_cursor_state
     begin
+      apply_cursor_state
       yield
     ensure
       @cursor = cursor_backup


### PR DESCRIPTION
## Summary
- commit front-buffer batches only after cursor, style, and content writes succeed
- invalidate complete frames and terminal cursor/style caches after render, synchronized-update, or flush failures
- track unknown attribute state explicitly and reset physical attributes before retrying an unstyled or subset-styled frame
- add fault-injection coverage for begin, cursor move, SGR, content write, end, flush, full redraw, and wide-cell retries

## Testing
- `mise exec -- unbuffer crystal spec spec/termisu/buffer_spec.cr spec/termisu/render_state_spec.cr spec/termisu/terminal/sync_update_spec.cr spec/termisu/terminal_caching_spec.cr` (138 examples)
- `mise exec -- bin/hace format:check`
- `mise exec -- bin/hace ameba` (157 files)
- `mise exec -- bin/hace spec` (1288 examples, 0 failures, 1 pending)
- `mise exec -- bin/hace e2e` (81 examples)
- `git diff --check`

## Compatibility
No public API signatures change. A retry after uncertain output can emit one additional terminal attribute reset to re-establish physical style state.
