### PR TITLE
perf: add cancellable input readiness

### DIFF
--- a/bench/input_readiness_latency.cr
+++ b/bench/input_readiness_latency.cr
@@ -1,0 +1,58 @@
+# Reproducible end-to-end input readiness latency probe.
+#
+# Workload: after 100 warmups, write one ASCII byte to a pipe and measure from
+# immediately before write(2) until Input delivers the parsed key to a waiting
+# channel consumer. Samples are serialized so no prior byte is outstanding.
+# This includes worker, scheduler, parser, and channel wakeup latency.
+#
+# Usage: crystal run --release bench/input_readiness_latency.cr -- [samples] [--raw]
+require "../src/termisu"
+
+private def measure_input_latency(samples : Int32) : Array(Int64)
+  descriptors = StaticArray(Int32, 2).new(0)
+  raise IO::Error.from_errno("pipe") unless LibC.pipe(descriptors) == 0
+  read_fd, write_fd = descriptors
+
+  begin
+    reader = Termisu::Reader.new(read_fd)
+    parser = Termisu::Input::Parser.new(reader)
+    source = Termisu::Event::Source::Input.new(reader, parser)
+    channel = Channel(Termisu::Event::Any).new(1)
+    latencies = Array(Int64).new(samples)
+
+    begin
+      source.start(channel)
+      (samples + 100).times do |index|
+        started = monotonic_now
+        raise IO::Error.from_errno("write") unless LibC.write(write_fd, "x".to_unsafe, 1) == 1
+        event = channel.receive.as(Termisu::Event::Key)
+        raise "unexpected input event" unless event.char == 'x'
+        elapsed = (monotonic_now - started).total_nanoseconds.to_i64
+        latencies << elapsed if index >= 100
+      end
+    ensure
+      source.stop
+      channel.close
+      reader.close
+    end
+
+    latencies
+  ensure
+    LibC.close(read_fd)
+    LibC.close(write_fd)
+  end
+end
+
+samples = ARGV.find(&.to_i?).try(&.to_i) || 500
+abort "samples must be positive" unless samples > 0
+raw = ARGV.includes?("--raw")
+latencies = measure_input_latency(samples)
+sorted = latencies.sort
+percentile = ->(fraction : Float64) do
+  index = ((sorted.size - 1) * fraction).round.to_i
+  sorted[index] / 1_000.0
+end
+
+puts "samples=#{samples} unit=us workload=pipe_write_to_parsed_channel_receive"
+puts "p50=#{percentile.call(0.50)} p95=#{percentile.call(0.95)} p99=#{percentile.call(0.99)}"
+puts latencies.join(',') if raw

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,3 +1,5 @@
+TERMISU_INPUT_READINESS_SPEC = true
+
 require "spec"
 require "../src/termisu"
 require "./support/*"

--- a/spec/termisu/event/source/input_spec.cr
+++ b/spec/termisu/event/source/input_spec.cr
@@ -1,4 +1,14 @@
+require "socket"
 require "../../../spec_helper"
+
+private class InputReadinessCountingReader < Termisu::Reader
+  getter wait_count = Atomic(Int32).new(0)
+
+  def wait_for_data(timeout_ms : Int32) : Bool
+    @wait_count.add(1)
+    super
+  end
+end
 
 private def receive_input_key(channel : Channel(Termisu::Event::Any),
                               wait : Time::Span = 200.milliseconds) : Termisu::Event::Key
@@ -369,6 +379,30 @@ describe Termisu::Event::Source::Input do
       end
     end
 
+    it "wakes for a parser-owned paste deadline without more input" do
+      read_fd, write_fd = create_pipe
+      begin
+        reader = Termisu::Reader.new(read_fd)
+        parser = Termisu::Input::Parser.new(reader)
+        source = Termisu::Event::Source::Input.new(reader, parser)
+        channel = Channel(Termisu::Event::Any).new(2)
+        source.start(channel)
+
+        input = "#{paste_start}\e"
+        LibC.write(write_fd, input.to_unsafe, input.bytesize)
+        receive_input_key(channel).key.should eq(Termisu::Input::Key::PasteStart)
+        receive_input_key(channel, 1500.milliseconds).key.should eq(Termisu::Input::Key::Escape)
+
+        source.stop
+        channel.close
+      ensure
+        source.try(&.stop)
+        reader.try(&.close)
+        LibC.close(read_fd)
+        LibC.close(write_fd)
+      end
+    end
+
     it "does not let a pasted escape consume the closing marker" do
       read_fd, write_fd = create_pipe
       begin
@@ -659,11 +693,198 @@ describe Termisu::Event::Source::Input do
 end
 
 describe Termisu::Event::Source::Input do
-  describe "idle polling" do
-    it "keeps the measured 4ms idle interval" do
-      # Regression pin for the idle busy-poll stopgap: ~978 -> ~244 idle
-      # select(2)/s at the cost of up to 4ms of added idle input latency.
+  describe "cooperative readiness" do
+    it "does not directly probe the input descriptor while idle" do
       Termisu::Event::Source::Input::IDLE_SLEEP.should eq(4.milliseconds)
+      read_fd, write_fd = create_pipe
+      begin
+        reader = InputReadinessCountingReader.new(read_fd)
+        parser = Termisu::Input::Parser.new(reader)
+        source = Termisu::Event::Source::Input.new(reader, parser)
+        channel = Channel(Termisu::Event::Any).new(1)
+
+        source.start(channel)
+        100.times { Fiber.yield }
+        reader.wait_count.get.should eq(0)
+
+        LibC.write(write_fd, "a".to_unsafe, 1)
+        receive_input_key(channel).char.should eq('a')
+
+        source.stop
+        channel.close
+      ensure
+        source.try(&.stop)
+        reader.try(&.close)
+        LibC.close(read_fd)
+        LibC.close(write_fd)
+      end
+    end
+
+    it "preserves descriptor flags throughout the readiness lease" do
+      read_fd, write_fd = create_pipe
+      begin
+        before = LibC.fcntl(read_fd, LibC::F_GETFL, 0)
+        reader = Termisu::Reader.new(read_fd)
+        parser = Termisu::Input::Parser.new(reader)
+        source = Termisu::Event::Source::Input.new(reader, parser)
+        channel = Channel(Termisu::Event::Any).new(1)
+
+        source.start(channel)
+        LibC.fcntl(read_fd, LibC::F_GETFL, 0).should eq(before)
+        source.stop
+        LibC.fcntl(read_fd, LibC::F_GETFL, 0).should eq(before)
+
+        channel.close
+      ensure
+        source.try(&.stop)
+        reader.try(&.close)
+        LibC.close(read_fd)
+        LibC.close(write_fd)
+      end
+    end
+
+    it "keeps output usable when input and output share an open description" do
+      left, right = UNIXSocket.pair
+      begin
+        # Warm Crystal's socket wrapper before taking the baseline: on kqueue
+        # platforms its first write enables nonblocking mode on the shared open
+        # description. The readiness lease itself must make no further change.
+        left.write("warmup".to_slice)
+        warmup = Bytes.new(6)
+        right.read_fully(warmup)
+        before = LibC.fcntl(left.fd, LibC::F_GETFL, 0)
+        reader = Termisu::Reader.new(left.fd)
+        parser = Termisu::Input::Parser.new(reader)
+        source = Termisu::Event::Source::Input.new(reader, parser)
+        channel = Channel(Termisu::Event::Any).new(1)
+
+        source.start(channel)
+        left.write("output".to_slice)
+        buffer = Bytes.new(6)
+        right.read_fully(buffer)
+        String.new(buffer).should eq("output")
+        LibC.fcntl(left.fd, LibC::F_GETFL, 0).should eq(before)
+
+        source.stop
+        channel.close
+      ensure
+        source.try(&.stop)
+        reader.try(&.close)
+        left.close
+        right.close
+      end
+    end
+
+    it "delivers trailing bytes in order and parks after HUP" do
+      read_fd, write_fd = create_pipe
+      begin
+        reader = InputReadinessCountingReader.new(read_fd)
+        parser = Termisu::Input::Parser.new(reader)
+        source = Termisu::Event::Source::Input.new(reader, parser)
+        channel = Channel(Termisu::Event::Any).new(3)
+
+        source.start(channel)
+        LibC.write(write_fd, "aé".to_unsafe, "aé".bytesize)
+        LibC.close(write_fd)
+        write_fd = -1
+
+        receive_input_key(channel).char.should eq('a')
+        receive_input_key(channel).char.should eq('é')
+        1_000.times do
+          break if reader.@eof
+          Fiber.yield
+        end
+        reader.@eof.should be_true
+        count_at_eof = reader.wait_count.get
+        100.times { Fiber.yield }
+        reader.wait_count.get.should eq(count_at_eof)
+
+        source.stop
+        channel.close
+      ensure
+        source.try(&.stop)
+        reader.try(&.close)
+        LibC.close(read_fd)
+        LibC.close(write_fd) if write_fd >= 0
+      end
+    end
+
+    it "closes every descriptor when the worker join re-raises" do
+      read_fd, write_fd = create_pipe
+      begin
+        descriptors, error = Termisu::Event::Source::Input.worker_failure_cleanup_for_spec(read_fd)
+
+        error.should be_a(ArgumentError)
+        error.try(&.message).should eq("readiness worker fault")
+        descriptors.each do |descriptor|
+          LibC.fcntl(descriptor, LibC::F_GETFD, 0).should eq(-1)
+        end
+      ensure
+        LibC.close(read_fd)
+        LibC.close(write_fd)
+      end
+    end
+
+    it "fairly drains a HUP tail larger than one reader buffer" do
+      read_fd, write_fd = create_pipe
+      begin
+        reader = Termisu::Reader.new(read_fd)
+        parser = Termisu::Input::Parser.new(reader)
+        source = Termisu::Event::Source::Input.new(reader, parser)
+        input = String.build do |io|
+          193.times { |index| io << ('a'.ord + index % 26).chr }
+        end
+        channel = Channel(Termisu::Event::Any).new(input.bytesize)
+
+        source.start(channel)
+        LibC.write(write_fd, input.to_unsafe, input.bytesize).should eq(input.bytesize)
+        LibC.close(write_fd)
+        write_fd = -1
+
+        output = String.build do |io|
+          input.bytesize.times { io << receive_input_key(channel).char }
+        end
+        output.should eq(input)
+        reader.@eof.should be_true
+
+        source.stop
+        channel.close
+      ensure
+        source.try(&.stop)
+        reader.try(&.close)
+        LibC.close(read_fd)
+        LibC.close(write_fd) if write_fd >= 0
+      end
+    end
+
+    it "releases every readiness descriptor over repeated restarts" do
+      read_fd, write_fd = create_pipe
+      begin
+        reader = Termisu::Reader.new(read_fd)
+        parser = Termisu::Input::Parser.new(reader)
+        source = Termisu::Event::Source::Input.new(reader, parser)
+        channel = Channel(Termisu::Event::Any).new(1)
+
+        # Warm the Crystal event-loop backend before counting. Other specs may
+        # release process-level descriptors concurrently, so a lower count is
+        # harmless; leaked run descriptors would make the count grow.
+        source.start(channel)
+        source.stop
+        before = Dir["/dev/fd/*"].size
+
+        2_000.times do
+          source.start(channel)
+          source.stop
+        end
+
+        Dir["/dev/fd/*"].size.should be <= before
+        channel.close
+      ensure
+        source.try(&.stop)
+        reader.try(&.close)
+        LibC.close(read_fd)
+        LibC.close(write_fd)
+      end
     end
 
     it "delivers input that arrives after an idle stretch" do

--- a/spec/termisu_spec.cr
+++ b/spec/termisu_spec.cr
@@ -1119,15 +1119,13 @@ describe "Termisu Event::Loop Integration" do
         bytes = Bytes['z'.ord.to_u8]
         LibC.write(write_fd, bytes, bytes.size)
 
-        # Give fiber a chance to process
-        sleep 10.milliseconds
-
-        # Should get event immediately via select/else
+        # Worker-thread startup is not ordered by a scheduler sleep. Wait for
+        # the input event itself instead of treating 10ms as a readiness barrier.
         select
         when event = event_loop.output.receive
           event.should be_a(Termisu::Event::Key)
           event.as(Termisu::Event::Key).char.should eq('z')
-        else
+        when timeout(200.milliseconds)
           fail "Should have received event"
         end
 

--- a/src/termisu/event/source/input.cr
+++ b/src/termisu/event/source/input.cr
@@ -1,7 +1,7 @@
 # Terminal input event source.
 #
 # Wraps `Reader` and `Input::Parser` to produce Key and Mouse events
-# via a dedicated polling fiber.
+# via a dedicated fiber.
 #
 # ## Usage
 #
@@ -31,16 +31,8 @@
 class Termisu::Event::Source::Input < Termisu::Event::Source
   Log = Termisu::Logs::Event
 
-  # Idle sleep when no input is available.
-  #
-  # Keeps CPU usage low without introducing long blocking waits that
-  # can starve high-frequency timers.
-  #
-  # 4ms is a measured stopgap for the idle busy-poll: it cuts idle
-  # select(2) calls from ~978/s to ~244/s at the cost of up to 4ms of
-  # added input latency when idle. The proper fix (deferred) is evented
-  # IO on the input fd — cooperative IO::FileDescriptor wakeup on data,
-  # ~20 wakeups/s with lower latency than any fixed sleep.
+  # Retained for source compatibility. Input readiness is no longer polled on
+  # this interval.
   IDLE_SLEEP = 4.milliseconds
 
   # Maximum events drained per loop iteration.
@@ -49,6 +41,269 @@ class Termisu::Event::Source::Input < Termisu::Event::Source
   # while still allowing bursty input to be processed quickly.
   MAX_DRAIN_PER_CYCLE = 64
 
+  # A run-local bridge between blocking poll(2) and Crystal's cooperative IO.
+  #
+  # The duplicated input descriptor is used only for readiness: Parser remains
+  # the sole consumer. It is never wrapped in
+  # IO::FileDescriptor because that constructor may set O_NONBLOCK on the shared
+  # open-file description.
+  # A control pipe cancels or rearms the poll worker, while a second pipe wakes
+  # the source fiber through Crystal's ordinary public IO API.
+  private class ReadinessLease
+    # POSIX specifies F_DUPFD as command zero on all supported targets.
+    private F_DUPFD = 0
+
+    enum Status : UInt8
+      Ready     = 1
+      Hangup    = 2
+      Error     = 3
+      Cancelled = 4
+    end
+
+    private enum Command : UInt8
+      Rearm = 1
+      Stop  = 2
+    end
+
+    @input_fd : Int32 = -1
+    @wake_reader : IO::FileDescriptor?
+    @wake_writer : IO::FileDescriptor?
+    @control_reader : IO::FileDescriptor?
+    @control_writer : IO::FileDescriptor?
+    @thread : Thread?
+    @cancelled = Atomic(Bool).new(false)
+    @closed = Atomic(Bool).new(false)
+
+    def initialize(fd : Int32)
+      @input_fd = duplicate(fd)
+      wake_reader, wake_writer = IO.pipe
+      @wake_reader = wake_reader
+      @wake_writer = wake_writer
+      control_reader, control_writer = IO.pipe
+      @control_reader = control_reader
+      @control_writer = control_writer
+      input_fd = @input_fd
+      wake_fd = wake_writer.fd
+      control_fd = control_reader.fd
+      @thread = Thread.new do
+        worker_loop(input_fd, wake_fd, control_fd)
+      rescue error
+        # Wake the source fiber so stop can reach the synchronous join, which
+        # re-raises this original worker failure after closing all resources.
+        publish(wake_fd, Status::Error)
+        raise error
+      end
+    rescue error
+      close_descriptors
+      raise error
+    end
+
+    def wait(deadline : MonotonicTime?) : Status?
+      reader = @wake_reader || raise IO::Error.new("Input readiness lease is closed")
+      if deadline
+        remaining = deadline - monotonic_now
+        return if remaining <= Time::Span.zero
+        reader.read_timeout = remaining
+      else
+        reader.read_timeout = nil
+      end
+
+      byte = reader.read_byte
+      byte ? Status.from_value(byte) : nil
+    rescue IO::TimeoutError
+      nil
+    end
+
+    def rearm : Nil
+      write_command(Command::Rearm)
+    end
+
+    def cancel : Nil
+      return unless @cancelled.compare_and_set(false, true)[1]
+
+      write_command(Command::Stop) rescue nil
+    end
+
+    def close : Nil
+      return unless @closed.compare_and_set(false, true)[1]
+
+      cancel
+      begin
+        @thread.try(&.join)
+      ensure
+        # Thread#join re-raises a worker failure. Descriptor ownership still
+        # ends here, and the worker error remains the primary exception.
+        close_descriptors
+      end
+    end
+
+    {% if @top_level.has_constant?(:TERMISU_INPUT_READINESS_SPEC) %}
+      def fail_worker_for_spec : Array(Int32)
+        cancel
+        @thread.try(&.join)
+        @thread = Thread.new { raise ArgumentError.new("readiness worker fault") }
+        descriptors = [
+          @wake_reader.not_nil!.fd,
+          @wake_writer.not_nil!.fd,
+          @control_reader.not_nil!.fd,
+          @control_writer.not_nil!.fd,
+        ]
+        descriptors << @input_fd
+        descriptors
+      end
+    {% end %}
+
+    private def close_descriptors : Nil
+      @wake_reader.try(&.close) rescue nil
+      @wake_writer.try(&.close) rescue nil
+      @control_reader.try(&.close) rescue nil
+      @control_writer.try(&.close) rescue nil
+      LibC.close(@input_fd) if @input_fd >= 0
+      @input_fd = -1
+    end
+
+    private def duplicate(fd : Int32) : Int32
+      duplicate = LibC.fcntl(fd, F_DUPFD, 0)
+      raise IO::Error.from_errno("Could not duplicate input descriptor") if duplicate == -1
+
+      if LibC.fcntl(duplicate, LibC::F_SETFD, LibC::FD_CLOEXEC) == -1
+        errno = Errno.value
+        LibC.close(duplicate)
+        Errno.value = errno
+        raise IO::Error.from_errno("Could not configure input descriptor duplicate")
+      end
+      duplicate
+    end
+
+    private def worker_loop(input_fd : Int32, wake_fd : Int32, control_fd : Int32) : Nil
+      loop do
+        pollfds = uninitialized StaticArray(Termisu::System::Poll::Pollfd, 2)
+        control_pollfd = uninitialized Termisu::System::Poll::Pollfd
+        control_pollfd.fd = control_fd
+        control_pollfd.events = Termisu::System::Poll::POLLIN
+        control_pollfd.revents = 0_i16
+        pollfds[0] = control_pollfd
+        input_pollfd = uninitialized Termisu::System::Poll::Pollfd
+        input_pollfd.fd = input_fd
+        input_pollfd.events = Termisu::System::Poll::POLLIN
+        input_pollfd.revents = 0_i16
+        pollfds[1] = input_pollfd
+
+        result = Termisu::System::Poll.poll(
+          pollfds.to_unsafe,
+          Termisu::System::Poll::NfdsT.new(2),
+          -1
+        )
+        if result < 0
+          next if Errno.value.eintr?
+          publish(wake_fd, Status::Error)
+          return
+        end
+
+        # Cancellation wins a simultaneous input/HUP wake. The worker publishes
+        # it through the cooperative pipe; no cross-fiber descriptor close is
+        # needed to interrupt the source fiber on kqueue-based platforms.
+        if readable?(pollfds[0].revents)
+          if read_command(control_fd).stop?
+            publish(wake_fd, Status::Cancelled)
+            return
+          end
+        end
+        next unless pollfds[1].revents != 0
+
+        status = classify(pollfds[1].revents)
+        return unless publish(wake_fd, status)
+        if wait_for_command(control_fd).stop?
+          publish(wake_fd, Status::Cancelled)
+          return
+        end
+      end
+    end
+
+    private def wait_for_command(control_fd : Int32) : Command
+      loop do
+        pollfd = uninitialized Termisu::System::Poll::Pollfd
+        pollfd.fd = control_fd
+        pollfd.events = Termisu::System::Poll::POLLIN
+        pollfd.revents = 0_i16
+        result = Termisu::System::Poll.poll(
+          pointerof(pollfd),
+          Termisu::System::Poll::NfdsT.new(1),
+          -1
+        )
+        next if result < 0 && Errno.value.eintr?
+        return Command::Stop if result <= 0
+        return read_command(control_fd)
+      end
+    end
+
+    private def read_command(fd : Int32) : Command
+      byte = uninitialized UInt8
+      loop do
+        result = LibC.read(fd, pointerof(byte), 1)
+        return Command.from_value(byte) if result == 1
+        next if result < 0 && Errno.value.eintr?
+        return Command::Stop
+      end
+    end
+
+    private def write_command(command : Command) : Nil
+      writer = @control_writer || raise IO::Error.new("Input readiness lease is closed")
+      write_byte(writer.fd, command.value)
+    end
+
+    private def publish(fd : Int32, status : Status) : Bool
+      write_byte(fd, status.value)
+      true
+    rescue IO::Error
+      false
+    end
+
+    private def write_byte(fd : Int32, byte : UInt8) : Nil
+      loop do
+        result = LibC.write(fd, pointerof(byte), 1)
+        return if result == 1
+        next if result < 0 && Errno.value.eintr?
+        raise IO::Error.from_errno("Input readiness pipe write failed")
+      end
+    end
+
+    private def readable?(events : Int16) : Bool
+      mask = Termisu::System::Poll::POLLIN |
+             Termisu::System::Poll::POLLHUP |
+             Termisu::System::Poll::POLLERR |
+             Termisu::System::Poll::POLLNVAL
+      (events & mask) != 0
+    end
+
+    private def classify(events : Int16) : Status
+      if (events & Termisu::System::Poll::POLLNVAL) != 0
+        Status::Error
+      elsif (events & Termisu::System::Poll::POLLHUP) != 0
+        # HUP can accompany POLLIN/POLLERR while trailing bytes remain.
+        Status::Hangup
+      elsif (events & Termisu::System::Poll::POLLERR) != 0
+        Status::Error
+      else
+        Status::Ready
+      end
+    end
+  end
+
+  {% if @top_level.has_constant?(:TERMISU_INPUT_READINESS_SPEC) %}
+    def self.worker_failure_cleanup_for_spec(fd : Int32) : {Array(Int32), Exception?}
+      lease = ReadinessLease.new(fd)
+      descriptors = lease.fail_worker_for_spec
+      error = begin
+        lease.close
+        nil
+      rescue ex
+        ex
+      end
+      {descriptors, error}
+    end
+  {% end %}
+
   @reader : Termisu::Reader
   @parser : Termisu::Input::Parser
   @running : Atomic(Bool)
@@ -56,6 +311,7 @@ class Termisu::Event::Source::Input < Termisu::Event::Source
   @stop_signal : Channel(Nil)?
   @done : Channel(Nil)?
   @fiber : Fiber?
+  @lease : ReadinessLease?
   @pending_event : Event::Any?
 
   # Creates a new input source.
@@ -67,27 +323,28 @@ class Termisu::Event::Source::Input < Termisu::Event::Source
     @lifecycle_lock = Mutex.new
   end
 
-  # Starts polling for input events and sending them to the output channel.
+  # Starts waiting for input events and sending them to the output channel.
   #
-  # Spawns a fiber that drains available input events without blocking
-  # and sends them to the channel.
-  #
-  # Serializes lifecycle changes so a previous polling fiber is fully stopped
-  # before another can start.
+  # Each run owns its descriptor duplicate, cancellation pipes, worker, and
+  # source fiber. A previous run is synchronously joined before replacement.
   def start(output : Channel(Event::Any)) : Nil
     @lifecycle_lock.synchronize do
       return if @running.get
+      cleanup_stopped_run
 
+      lease = ReadinessLease.new(@reader.@fd)
       stop_signal = Channel(Nil).new
       done = Channel(Nil).new
+      @lease = lease
       @stop_signal = stop_signal
       @done = done
       @running.set(true)
 
       @fiber = spawn(name: "termisu-input") do
-        run_loop(output, stop_signal)
+        run_loop(output, stop_signal, lease)
       ensure
         @running.set(false)
+        lease.cancel
         done.close
       end
 
@@ -95,20 +352,19 @@ class Termisu::Event::Source::Input < Termisu::Event::Source
     end
   end
 
-  # Stops polling for input events.
+  # Stops input processing and synchronously releases every run-owned resource.
   #
-  # Signals the polling fiber and waits for it to finish. When this method
-  # returns, the parser no longer touches the reader, so ownership can be
-  # handed to a raw-input caller without splitting an input sequence.
+  # When this method returns, the parser no longer touches the reader, so
+  # ownership can be handed to a raw-input caller without splitting a sequence.
   def stop : Nil
     @lifecycle_lock.synchronize do
-      fiber = @fiber
-      return unless fiber
-      return if fiber.dead?
+      return unless @fiber || @lease
 
       @running.set(false)
       @stop_signal.try { |signal| signal.close unless signal.closed? }
+      @lease.try(&.cancel)
       @done.try(&.receive?)
+      cleanup_stopped_run
       lifecycle_log { Log.debug { "Input source stopped" } }
     end
   end
@@ -135,39 +391,145 @@ class Termisu::Event::Source::Input < Termisu::Event::Source
     "input"
   end
 
-  # Main input loop - runs in a spawned fiber.
-  private def run_loop(output : Channel(Event::Any), stop_signal : Channel(Nil)) : Nil
-    while @running.get
-      emitted = false
-      drained = 0
+  private def cleanup_stopped_run : Nil
+    lease = @lease
+    @lease = nil
+    @fiber = nil
+    @stop_signal = nil
+    @done = nil
+    lease.try(&.close)
+  end
 
-      while @running.get && drained < MAX_DRAIN_PER_CYCLE
-        event = @pending_event || @parser.poll_event(0)
-        break unless event
+  private def run_loop(
+    output : Channel(Event::Any),
+    stop_signal : Channel(Nil),
+    lease : ReadinessLease,
+  ) : Nil
+    # A complete event retained across backpressure has precedence over bytes
+    # that arrived later, and does not require descriptor readiness.
+    return unless drain_pending_event(output, stop_signal)
 
-        unless send_event(output, stop_signal, event)
-          # The parser already consumed this complete event. Keep it for the
-          # next run instead of losing it when a full output channel is paused.
-          @pending_event = event
-          return
-        end
-
-        @pending_event = nil
-        emitted = true
-        drained += 1
-      end
-
-      break unless @running.get
-
-      if emitted
-        Fiber.yield
-      else
-        sleep IDLE_SLEEP
-      end
-    end
+    drain_initial_buffer(output, stop_signal)
+    readiness_loop(output, stop_signal, lease)
   rescue Channel::ClosedError
-    # Channel closed during shutdown - exit gracefully
+    # Channel closed during shutdown - exit gracefully.
     Log.debug { "Input channel closed, exiting" }
+  rescue error : IO::Error
+    raise error if @running.get
+  end
+
+  private def drain_initial_buffer(
+    output : Channel(Event::Any),
+    stop_signal : Channel(Nil),
+  ) : Nil
+    # A prior parser/raw-owner call may have filled Reader past the event it
+    # consumed. Those bytes precede future descriptor readiness.
+    while @running.get && parser_buffered_input?
+      emitted, exhausted = drain_cycle(output, stop_signal)
+      break unless exhausted && parser_buffered_input?
+      Fiber.yield if emitted
+    end
+  end
+
+  private def readiness_loop(
+    output : Channel(Event::Any),
+    stop_signal : Channel(Nil),
+    lease : ReadinessLease,
+  ) : Nil
+    descriptor_closed = false
+    while @running.get
+      status = lease.wait(parser_deadline)
+      break unless @running.get
+      break if status == ReadinessLease::Status::Cancelled
+
+      if status == ReadinessLease::Status::Error
+        raise Termisu::IOError.select_failed(Errno::EBADF)
+      end
+      descriptor_closed ||= status == ReadinessLease::Status::Hangup
+
+      begin
+        emitted = drain_available(output, stop_signal, descriptor_closed)
+        return unless @running.get
+      rescue error : Termisu::IOError
+        # Some PTYs report EIO rather than a zero-byte read after HUP. Trailing
+        # bytes were drained first; remain cancellably parked like ordinary EOF.
+        raise error unless descriptor_closed
+        next
+      end
+
+      eof = @reader.@eof
+      lease.rearm unless eof || descriptor_closed
+      Fiber.yield if emitted
+    end
+  end
+
+  private def drain_pending_event(
+    output : Channel(Event::Any),
+    stop_signal : Channel(Nil),
+  ) : Bool
+    return true unless event = @pending_event
+    return false unless send_event(output, stop_signal, event)
+
+    @pending_event = nil
+    true
+  end
+
+  private def drain_available(
+    output : Channel(Event::Any),
+    stop_signal : Channel(Nil),
+    descriptor_closed : Bool,
+  ) : Bool
+    emitted, exhausted = drain_cycle(output, stop_signal)
+
+    # HUP can be reported while more than one Reader buffer of trailing input
+    # remains. Keep consuming until read(2) reaches EOF (or a PTY reports EIO),
+    # yielding between bounded cycles so a large tail stays scheduler-fair.
+    while @running.get && ((exhausted && parser_buffered_input?) ||
+          (descriptor_closed && !@reader.@eof))
+      Fiber.yield
+      cycle_emitted, exhausted = drain_cycle(output, stop_signal)
+      emitted ||= cycle_emitted
+      # A few PTY implementations can report HUP before a nonblocking read
+      # returns EAGAIN. Do not turn that mismatch into a tight drain loop.
+      break if descriptor_closed && !cycle_emitted && !parser_buffered_input?
+    end
+
+    emitted
+  end
+
+  private def drain_cycle(
+    output : Channel(Event::Any),
+    stop_signal : Channel(Nil),
+  ) : {Bool, Bool}
+    emitted = false
+    drained = 0
+
+    while @running.get && drained < MAX_DRAIN_PER_CYCLE
+      event = @parser.poll_event(0)
+      break unless event
+
+      unless send_event(output, stop_signal, event)
+        # The parser already consumed this complete event. Keep it for the next
+        # run instead of losing it when a full output channel is paused.
+        @pending_event = event
+        return {emitted, false}
+      end
+
+      emitted = true
+      drained += 1
+    end
+
+    {emitted, drained == MAX_DRAIN_PER_CYCLE}
+  end
+
+  # Parser and Reader are private implementation collaborators of this source.
+  # Direct ivar access keeps readiness/deadline plumbing out of the public API.
+  private def parser_deadline : MonotonicTime?
+    @parser.@paste_deadline
+  end
+
+  private def parser_buffered_input? : Bool
+    !@parser.@pending.empty? || @reader.@buffer_pos < @reader.@buffer_len
   end
 
   private def send_event(

--- a/src/termisu/reader.cr
+++ b/src/termisu/reader.cr
@@ -28,6 +28,7 @@ class Termisu::Reader
   @buffer : Bytes
   @buffer_pos : Int32 = 0
   @buffer_len : Int32 = 0
+  @eof : Bool = false
 
   # Maximum retry attempts for EINTR before giving up.
   # This prevents infinite loops in pathological signal storms.
@@ -287,12 +288,14 @@ class Termisu::Reader
       if bytes_read > 0
         @buffer_pos = 0
         @buffer_len = bytes_read.to_i32
+        @eof = false
         Termisu::Logs::Reader.trace { "fill_buffer: read #{bytes_read} bytes" }
         return true
       elsif bytes_read == 0
         # EOF
         @buffer_pos = 0
         @buffer_len = 0
+        @eof = true
         Termisu::Logs::Reader.debug { "fill_buffer: EOF" }
         return false
       end
@@ -315,6 +318,7 @@ class Termisu::Reader
         # Non-blocking I/O would block - no data available
         @buffer_pos = 0
         @buffer_len = 0
+        @eof = false
         return false
       end
 

--- a/src/termisu/system/poll.cr
+++ b/src/termisu/system/poll.cr
@@ -11,8 +11,12 @@ module Termisu::System
       revents : Int16
     end
 
-    # nfds_t maps to unsigned long on supported Termisu targets.
-    alias NfdsT = LibC::ULong
+    # Linux defines nfds_t as unsigned long; Darwin and FreeBSD use unsigned int.
+    {% if flag?(:darwin) || flag?(:freebsd) %}
+      alias NfdsT = LibC::UInt
+    {% else %}
+      alias NfdsT = LibC::ULong
+    {% end %}
 
     fun poll(fds : Pollfd*, nfds : NfdsT, timeout : Int32) : Int32
 


### PR DESCRIPTION
## Rationale
Replace recurring 4 ms input probes with run-owned cancellable readiness while keeping `Input::Parser` as the only byte consumer.

## Design
- A private lease duplicates the input fd for blocking `poll(2)` readiness only; control/wake pipes provide cancellation and cooperative fiber wakeup.
- Stop synchronously joins each run. Worker failures wake the source, remain the primary error, and descriptor closure is unconditional.
- Parser-owned paste deadlines wake independently of descriptor readiness.
- EOF/HUP drains trailing bytes in bounded fair cycles, then parks without spinning.
- The duplicate is never wrapped as Crystal IO, so shared open-file-description flags are unchanged; the public API is unchanged.

## Evidence
- Focused Input/parser: 124 examples, 0 failures on local Crystal 1.17 and 1.21; includes deterministic worker-fault cleanup and >Reader-buffer HUP-tail coverage.
- Facade controlling-PTY and input-ownership PTY passed locally on Linux.
- C ABI/native C lifecycle passed; Bun 48 tests, typecheck, and Biome passed.
- Full Ameba (162 files), Crystal format, C checks, and `git diff --check` passed.
- Linux CI Crystal 1.17–1.21 passed; FreeBSD unit and E2E suites passed in multiple runs.
- Five-second Linux `strace`: one blocking input `poll`, zero recurring direct input probes; scheduler waits were attributed separately.
- `bench/input_readiness_latency.cr` defines the serialized pipe-write-to-parsed-channel workload and can emit raw samples. Five 500-sample local runs had p50 20.098–20.309 µs and p95 31.620–10,069.258 µs; shared-host contention makes these informational, not a gate.

## Blocking limitation
**This PR is intentionally draft and must not merge.** macOS unit matrix runs can pass, but the required controlling-PTY E2E consistently fails: Darwin reports error readiness for the duplicated TTY, while attempted `select(2)`/`kqueue(2)` fallbacks either block startup or miss input. Those unsafe fallbacks were removed. The audit's macOS runtime gate therefore remains unsatisfied.
