### PR TITLE
perf: repair benchmark harness

### DIFF
--- a/bench/bench_runner.cr
+++ b/bench/bench_runner.cr
@@ -2,84 +2,232 @@ require "benchmark"
 require "../src/termisu"
 require "../src/termisu/time_compat"
 
-# Concurrent benchmark runner infrastructure
-#
-# Features:
-# - Runs benchmark suites concurrently using Crystal fibers
-# - Captures benchmark results for flexible rendering
-# - Lightweight measurement without external dependencies
-
 module Termisu::Bench
-  # Result from a single benchmark
+  # Measurement settings. A sample times one batch, never each operation.
+  record BenchConfig, samples : Int32, sample_time : Time::Span do
+    MIN_SAMPLES = 5
+
+    def initialize(@samples : Int32 = 8, @sample_time : Time::Span = 50.milliseconds)
+      raise ArgumentError.new("samples must be at least #{MIN_SAMPLES}") if @samples < MIN_SAMPLES
+      raise ArgumentError.new("sample time must be positive") unless @sample_time > Time::Span.zero
+    end
+
+    def self.from_env : self
+      samples = ENV.fetch("TERMISU_BENCH_SAMPLES", "8").to_i
+      sample_ms = ENV.fetch("TERMISU_BENCH_SAMPLE_MS", "50").to_f
+      new(samples, sample_ms.milliseconds)
+    end
+  end
+
+  # Work performed by a sample, separate from GC allocation accounting.
+  record BenchMetrics,
+    mutations : UInt64,
+    emitted_bytes : UInt64,
+    string_writes : UInt64,
+    byte_writes : UInt64,
+    callback_calls : UInt64,
+    flushes : UInt64 do
+    def self.empty : self
+      new(0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64)
+    end
+
+    def +(other : self) : self
+      self.class.new(
+        mutations + other.mutations,
+        emitted_bytes + other.emitted_bytes,
+        string_writes + other.string_writes,
+        byte_writes + other.byte_writes,
+        callback_calls + other.callback_calls,
+        flushes + other.flushes
+      )
+    end
+  end
+
+  # One raw batch measurement. Allocation bytes come from Benchmark.memory.
+  record BenchSample,
+    iterations : Int32,
+    elapsed : Time::Span,
+    allocated_bytes : Int64,
+    metrics : BenchMetrics do
+    def iterations_per_second : Float64
+      iterations.to_f64 / elapsed.total_seconds
+    end
+
+    def bytes_per_operation : Float64
+      allocated_bytes.to_f64 / iterations
+    end
+  end
+
+  # Result from one benchmark job, including its complete raw distribution.
   record BenchResult,
     name : String,
     iterations_per_second : Float64,
     mean_time : Time::Span,
     std_dev_percent : Float64,
-    bytes_per_op : Int64
+    bytes_per_op : Float64,
+    samples : Array(BenchSample),
+    metrics : BenchMetrics
 
-  # A group of related benchmarks
+  # A group of related benchmarks.
   record BenchGroup,
     name : String,
     results : Array(BenchResult)
 
-  # Suite containing multiple groups
+  # Suite containing multiple groups.
   record BenchSuite,
     name : String,
     groups : Array(BenchGroup)
 
-  # Captures benchmark measurements
+  # Observable destination for pure benchmark results. This prevents a result
+  # from becoming dead work without allocating in zero-allocation controls.
+  module BenchSink
+    extend self
+
+    @@value = 0_u64
+
+    def consume(value : Bytes) : Nil
+      identity = value.to_unsafe.address.to_u64 ^ value.size.to_u64
+      @@value &+= identity
+    end
+
+    def consume(value : Reference) : Nil
+      @@value &+= value.object_id.to_u64
+    end
+
+    def consume(value) : Nil
+      @@value &+= value.hash.to_u64
+    end
+
+    def value : UInt64
+      @@value
+    end
+  end
+
+  # Captures repeated batch measurements in report order.
   class BenchCapture
     getter results : Array(BenchResult) = [] of BenchResult
 
-    def report(name : String, &block)
-      # Warmup
-      100.times { block.call }
+    def initialize(@config : BenchConfig = BenchConfig.from_env)
+    end
 
-      # Measure
-      iterations = 0
-      measure_start = monotonic_now
-      while (monotonic_now - measure_start) < 100.milliseconds
-        block.call
-        iterations += 1
+    def report(
+      name : String,
+      before_sample : (-> Nil)? = nil,
+      sample_metrics : (-> BenchMetrics)? = nil,
+      validate_sample : (BenchSample -> Nil)? = nil,
+      mutations_per_iteration : Bool = false,
+      &block : -> T
+    ) forall T
+      action = -> { BenchSink.consume(block.call) }
+      iterations = calibrate(action)
+      samples = Array(BenchSample).new(@config.samples)
+
+      @config.samples.times do
+        before_sample.try(&.call)
+        GC.collect
+
+        elapsed = Time::Span.zero
+        allocated_bytes = Benchmark.memory do
+          elapsed = Time.measure { iterations.times { action.call } }
+        end
+        metrics = sample_metrics.try(&.call) || BenchMetrics.empty
+
+        if mutations_per_iteration && metrics.mutations != iterations.to_u64
+          raise "#{name}: expected #{iterations} mutations, observed #{metrics.mutations}"
+        end
+
+        sample = BenchSample.new(iterations, elapsed, allocated_bytes, metrics)
+        validate_sample.try(&.call(sample))
+        samples << sample
       end
-      elapsed = monotonic_now - measure_start
 
-      ips = iterations.to_f64 / elapsed.total_seconds
-      mean = elapsed / iterations
+      @results << summarize(name, samples)
+    end
 
-      @results << BenchResult.new(
-        name: name,
-        iterations_per_second: ips,
-        mean_time: mean,
-        std_dev_percent: 0.0, # Simplified - would need multiple runs
-        bytes_per_op: 0_i64
+    # Calibrate with exponentially larger batches. Clock reads occur around a
+    # batch only; the measured operation itself never samples the clock.
+    private def calibrate(action : -> Nil) : Int32
+      iterations = 1
+
+      loop do
+        elapsed = Time.measure { iterations.times { action.call } }
+        return iterations if elapsed >= @config.sample_time
+        return iterations if iterations > Int32::MAX // 2
+
+        iterations *= 2
+      end
+    end
+
+    private def summarize(name : String, samples : Array(BenchSample)) : BenchResult
+      rates = samples.map(&.iterations_per_second)
+      mean_rate = rates.sum / rates.size
+      variance = rates.sum { |rate| (rate - mean_rate) ** 2 } / rates.size
+      deviation = mean_rate.zero? ? 0.0 : Math.sqrt(variance) * 100.0 / mean_rate
+      total_iterations = samples.sum(0_i64, &.iterations.to_i64)
+      total_elapsed = samples.sum(Time::Span.zero, &.elapsed)
+      allocated_bytes = samples.sum(0_i64, &.allocated_bytes)
+      metrics = samples.reduce(BenchMetrics.empty) { |sum, sample| sum + sample.metrics }
+
+      BenchResult.new(
+        name,
+        mean_rate,
+        total_elapsed / total_iterations,
+        deviation,
+        allocated_bytes.to_f64 / total_iterations,
+        samples,
+        metrics
       )
     end
   end
 
-  # Concurrent benchmark runner utility
+  # Compatibility utility for future yielding/I/O suites. Suites may overlap,
+  # while returned results always retain registration order. CPU benchmarks do
+  # not use this runner because fibers cannot make those measurements parallel.
   class ConcurrentRunner
-    @suites : Array(BenchSuite) = [] of BenchSuite
-    @channel : Channel(BenchSuite)
+    alias Outcome = BenchSuite | Exception
 
-    def initialize
-      @channel = Channel(BenchSuite).new
-    end
+    @channel = Channel(NamedTuple(index: Int32, outcome: Outcome)).new
+    @completed = {} of Int32 => Outcome
+    @next_index = 0
+    @next_result_index = 0
 
-    def add_suite(name : String, &block : -> Array(BenchGroup))
+    def add_suite(name : String, &block : -> Array(BenchGroup)) : Nil
+      index = @next_index
+      @next_index += 1
+
       spawn do
-        groups = block.call
-        @channel.send(BenchSuite.new(name, groups))
+        outcome = begin
+          BenchSuite.new(name, block.call)
+        rescue error
+          error
+        end
+        @channel.send({index: index, outcome: outcome})
       end
     end
 
+    # Consume exactly count suites in registration order. A later suite may
+    # finish first; retain it until an earlier partial run_all call consumes
+    # the preceding registrations.
     def run_all(count : Int32) : Array(BenchSuite)
-      results = [] of BenchSuite
-      count.times do
-        results << @channel.receive
+      available = @next_index - @next_result_index
+      unless count >= 0 && count <= available
+        raise ArgumentError.new("count must be between 0 and #{available}")
       end
-      results
+
+      last_index = @next_result_index + count
+      until (@next_result_index...last_index).all? { |index| @completed.has_key?(index) }
+        result = @channel.receive
+        @completed[result[:index]] = result[:outcome]
+      end
+
+      outcomes = Array(Outcome).new(count) do |offset|
+        @completed.delete(@next_result_index + offset) || raise "concurrent suite result missing"
+      end
+      @next_result_index = last_index
+      outcomes.map do |outcome|
+        raise outcome if outcome.is_a?(Exception)
+        outcome
+      end
     end
   end
 end

--- a/bench/run.cr
+++ b/bench/run.cr
@@ -1,4 +1,4 @@
-# Disable logging during benchmarks for clean output
+# Disable logging during benchmarks for clean output.
 ENV["TERMISU_LOG_LEVEL"] = "none"
 
 require "log"
@@ -10,17 +10,15 @@ require "./suites/buffer_suite"
 require "./suites/color_suite"
 require "./suites/parser_suite"
 
-# Benchmark runner using Crystal fibers
-#
-# Usage: crystal run bench/run.cr
-#        crystal run bench/run.cr --release
-
+# Usage:
+#   crystal run bench/run.cr --release
+# For process-level distributions, invoke the release binary at least five
+# times and set TERMISU_BENCH_RUN and TERMISU_BENCH_AFFINITY to describe the
+# externally controlled run/affinity environment.
 module Termisu::Bench
-  # ANSI color codes for styled output
   module ANSIColors
     RESET        = "\e[0m"
     BOLD         = "\e[1m"
-    RED          = "\e[31m"
     GREEN        = "\e[32m"
     YELLOW       = "\e[33m"
     BLUE         = "\e[34m"
@@ -30,46 +28,76 @@ module Termisu::Bench
     BRIGHT_GREEN = "\e[92m"
   end
 
-  # Text-based benchmark renderer with ANSI colors
+  # Truth controls for Benchmark.memory. These stay in normal benchmark output
+  # so a runtime/toolchain that cannot distinguish them fails loudly.
+  module AllocationControlSuite
+    extend self
+
+    def run(config : BenchConfig = BenchConfig.from_env) : Array(BenchGroup)
+      capture = BenchCapture.new(config)
+      state = 0_u64
+
+      capture.report("zero-allocation control") do
+        state &+= 1
+        state &* 17_u64
+      end
+
+      capture.report("allocating control") do
+        state &+= 1
+        "x" * (32 + (state & 1).to_i)
+      end
+
+      zero = capture.results[0]
+      allocating = capture.results[1]
+      unless zero.samples.all?(&.allocated_bytes.zero?)
+        raise "zero-allocation control allocated #{zero.bytes_per_op} B/op"
+      end
+      unless allocating.samples.all? { |sample| sample.allocated_bytes > 0 }
+        raise "allocating control reported a zero-allocation sample"
+      end
+
+      [BenchGroup.new("Allocation Controls", capture.results)]
+    end
+  end
+
   class TextRenderer
     include ANSIColors
 
-    def render_header(title : String)
+    def render_header(title : String, config : BenchConfig) : Nil
       puts "#{CYAN}#{BOLD}╔#{"═" * 62}╗#{RESET}"
       puts "#{CYAN}#{BOLD}║#{title.center(62)}║#{RESET}"
       puts "#{CYAN}#{BOLD}╠#{"═" * 62}╣#{RESET}"
-      puts "#{CYAN}║#{RESET} Crystal: #{Crystal::VERSION.ljust(52)}#{CYAN}║#{RESET}"
-      puts "#{CYAN}║#{RESET} LLVM:    #{Crystal::LLVM_VERSION.ljust(52)}#{CYAN}║#{RESET}"
-      puts "#{CYAN}║#{RESET} Time:    #{Time.local.to_s.ljust(52)}#{CYAN}║#{RESET}"
+      header_field("Crystal", Crystal::VERSION)
+      header_field("LLVM", Crystal::LLVM_VERSION)
+      header_field("Build", BUILD_MODE)
+      header_field("Process", Process.pid.to_s)
+      header_field("Run", ENV.fetch("TERMISU_BENCH_RUN", "unspecified"))
+      header_field("Affinity", ENV.fetch("TERMISU_BENCH_AFFINITY", "externally unspecified"))
+      header_field("Environment", ENV.fetch("TERMISU_BENCH_ENVIRONMENT", "externally unspecified"))
+      header_field("Samples", config.samples.to_s)
+      header_field("Batch target", "#{config.sample_time.total_milliseconds} ms")
+      header_field("Time", Time.local.to_s)
       puts "#{CYAN}#{BOLD}╚#{"═" * 62}╝#{RESET}"
       puts
     end
 
-    def render_suite_start(suite_name : String)
+    def render_suite_start(suite_name : String) : Nil
       puts "#{MAGENTA}Running:#{RESET} #{BOLD}#{suite_name}#{RESET}"
     end
 
-    def render_group(group : BenchGroup)
+    def render_group(group : BenchGroup) : Nil
       puts
-      separator = "─" * (50 - group.name.size)
+      separator = "─" * Math.max(1, 50 - group.name.size)
       puts "#{BLUE}─── #{CYAN}#{BOLD}#{group.name}#{RESET} #{BLUE}#{separator}#{RESET}"
       puts
 
-      # Find fastest for comparison
       fastest = group.results.max_by(&.iterations_per_second)
-
-      group.results.each do |result|
-        render_result(result, fastest.iterations_per_second)
-      end
+      group.results.each { |result| render_result(result, fastest.iterations_per_second) }
     end
 
-    def render_result(result : BenchResult, fastest_ips : Float64)
-      name = result.name.size > 25 ? result.name[0, 22] + "..." : result.name
-      ips_str = format_ips(result.iterations_per_second)
-      time_str = format_time(result.mean_time)
-
+    def render_result(result : BenchResult, fastest_ips : Float64) : Nil
+      name = result.name.size > 30 ? result.name[0, 27] + "..." : result.name
       color = result.iterations_per_second >= fastest_ips * 0.95 ? BRIGHT_GREEN : GREEN
-
       comparison = if result.iterations_per_second < fastest_ips * 0.99
                      ratio = fastest_ips / result.iterations_per_second
                      "#{YELLOW}#{ratio.round(2)}× slower#{RESET}"
@@ -77,28 +105,43 @@ module Termisu::Bench
                      "#{BRIGHT_GREEN}#{BOLD}fastest#{RESET}"
                    end
 
-      line = "  #{WHITE}#{name.ljust(26)}#{RESET} "
-      line += "#{color}#{BOLD}#{ips_str.rjust(12)}#{RESET} "
-      line += "(#{time_str.rjust(10)}) #{comparison}"
-      puts line
+      puts "  #{WHITE}#{name.ljust(31)}#{RESET} " +
+           "#{color}#{BOLD}#{format_ips(result.iterations_per_second).rjust(12)}#{RESET} " +
+           "(#{format_time(result.mean_time).rjust(10)}) " +
+           "±#{result.std_dev_percent.round(2)}% " +
+           "#{format_bytes(result.bytes_per_op)} B/op #{comparison}"
+
+      unless result.metrics == BenchMetrics.empty
+        puts "    totals: #{format_metrics(result.metrics)}"
+      end
+
+      result.samples.each_with_index do |sample, index|
+        puts "    raw[#{(index + 1).to_s.rjust(2, '0')}]: " +
+             "iterations=#{sample.iterations} " +
+             "elapsed_ns=#{sample.elapsed.total_nanoseconds.to_i64} " +
+             "ips=#{sample.iterations_per_second.round(3)} " +
+             "allocated_bytes=#{sample.allocated_bytes} " +
+             format_metrics(sample.metrics)
+      end
     end
 
-    def render_suite_complete(suite : BenchSuite)
+    def render_suite_complete(suite : BenchSuite) : Nil
       puts
       total_benchmarks = suite.groups.sum(&.results.size)
       msg = "#{BRIGHT_GREEN}#{BOLD}✓ #{suite.name} Complete#{RESET}"
       puts "#{msg} - #{suite.groups.size} groups, #{total_benchmarks} benchmarks"
     end
 
-    def render_gc_stats
+    def render_gc_stats : Nil
       puts
       puts "#{CYAN}#{BOLD}GC Statistics:#{RESET}"
       stats = GC.stats
-      puts "  Heap size:  #{GREEN}#{stats.heap_size / 1024} KB#{RESET}"
-      puts "  Free bytes: #{GREEN}#{stats.free_bytes / 1024} KB#{RESET}"
+      puts "  Heap size:       #{GREEN}#{stats.heap_size / 1024} KB#{RESET}"
+      puts "  Free bytes:      #{GREEN}#{stats.free_bytes / 1024} KB#{RESET}"
+      puts "  Total allocated: #{GREEN}#{stats.total_bytes} B#{RESET}"
     end
 
-    def render_summary(suites : Array(BenchSuite))
+    def render_summary(suites : Array(BenchSuite)) : Nil
       total_groups = suites.sum(&.groups.size)
       total_benchmarks = suites.sum { |suite| suite.groups.sum(&.results.size) }
 
@@ -106,13 +149,21 @@ module Termisu::Bench
       puts "#{CYAN}#{BOLD}╔#{"═" * 40}╗#{RESET}"
       puts "#{CYAN}#{BOLD}║#{RESET}     BENCHMARK SUMMARY                  #{CYAN}#{BOLD}║#{RESET}"
       puts "#{CYAN}#{BOLD}╠#{"═" * 40}╣#{RESET}"
-      suites_str = suites.size.to_s.ljust(26)
-      puts "#{CYAN}║#{RESET}  Suites:     #{GREEN}#{suites_str}#{RESET}#{CYAN}║#{RESET}"
-      groups_str = total_groups.to_s.ljust(26)
-      puts "#{CYAN}║#{RESET}  Groups:     #{GREEN}#{groups_str}#{RESET}#{CYAN}║#{RESET}"
-      benchmarks_str = total_benchmarks.to_s.ljust(26)
-      puts "#{CYAN}║#{RESET}  Benchmarks: #{GREEN}#{benchmarks_str}#{RESET}#{CYAN}║#{RESET}"
+      summary_field("Suites", suites.size)
+      summary_field("Groups", total_groups)
+      summary_field("Benchmarks", total_benchmarks)
       puts "#{CYAN}#{BOLD}╚#{"═" * 40}╝#{RESET}"
+    end
+
+    private def header_field(name : String, value : String) : Nil
+      text = "#{name}:".ljust(12) + value
+      text = text[0, 60] if text.size > 60
+      puts "#{CYAN}║#{RESET} #{text.ljust(61)}#{CYAN}║#{RESET}"
+    end
+
+    private def summary_field(name : String, value) : Nil
+      value_string = value.to_s.ljust(26)
+      puts "#{CYAN}║#{RESET}  #{name.ljust(11)}#{GREEN}#{value_string}#{RESET}#{CYAN}║#{RESET}"
     end
 
     private def format_ips(ips : Float64) : String
@@ -124,7 +175,7 @@ module Termisu::Bench
       when .>= 1_000
         "#{(ips / 1_000).round(2)}K"
       else
-        "#{ips.round(2)}"
+        ips.round(2).to_s
       end
     end
 
@@ -141,60 +192,51 @@ module Termisu::Bench
         "#{nanos.round(2)}ns"
       end
     end
+
+    private def format_bytes(bytes : Float64) : String
+      bytes == bytes.round ? bytes.round.to_i64.to_s : bytes.round(2).to_s
+    end
+
+    private def format_metrics(metrics : BenchMetrics) : String
+      "mutations=#{metrics.mutations} " +
+        "emitted_bytes=#{metrics.emitted_bytes} " +
+        "string_writes=#{metrics.string_writes} " +
+        "byte_writes=#{metrics.byte_writes} " +
+        "callbacks=#{metrics.callback_calls} " +
+        "flushes=#{metrics.flushes}"
+    end
   end
 
-  def self.run
+  BUILD_MODE = {% if flag?(:release) %} "release" {% else %} "debug" {% end %}
+
+  def self.run : Nil
+    config = BenchConfig.from_env
     renderer = TextRenderer.new
+    renderer.render_header("TERMISU BENCHMARK SUITE", config)
 
-    renderer.render_header("TERMISU BENCHMARK SUITE")
-
-    # Channel for collecting results from concurrent suites
-    channel = Channel(NamedTuple(name: String, groups: Array(BenchGroup))).new
-
-    # Number of suites to run
-    suite_count = 3
-
-    # Spawn all benchmark suites concurrently using Crystal fibers
-    spawn(name: "buffer_suite") do
-      groups = BufferSuite.run
-      channel.send({name: "Buffer", groups: groups})
-    end
-
-    spawn(name: "color_suite") do
-      groups = ColorSuite.run
-      channel.send({name: "Color", groups: groups})
-    end
-
-    spawn(name: "parser_suite") do
-      groups = ParserSuite.run
-      channel.send({name: "Parser", groups: groups})
-    end
-
-    # Collect results as they complete
+    # Deliberately serial: registration, execution, and rendering have one
+    # stable order, and each suite factory is called exactly once.
     suites = [] of BenchSuite
-    completed = 0
+    run_suite(suites, renderer, "Harness") { AllocationControlSuite.run(config) }
+    run_suite(suites, renderer, "Buffer") { BufferSuite.run(config) }
+    run_suite(suites, renderer, "Color") { ColorSuite.run(config) }
+    run_suite(suites, renderer, "Parser") { ParserSuite.run(config) }
 
-    suite_count.times do
-      result = channel.receive
-      completed += 1
-
-      suite = BenchSuite.new(result[:name], result[:groups])
-      suites << suite
-
-      # Update progress
-      renderer.render_suite_start(result[:name])
-
-      # Render the completed suite's groups
-      result[:groups].each do |group|
-        renderer.render_group(group)
-      end
-
-      renderer.render_suite_complete(suite)
-    end
-
-    # Final stats
     renderer.render_gc_stats
     renderer.render_summary(suites)
+  end
+
+  private def self.run_suite(
+    suites : Array(BenchSuite),
+    renderer : TextRenderer,
+    name : String,
+    &block : -> Array(BenchGroup)
+  ) : Nil
+    renderer.render_suite_start(name)
+    suite = BenchSuite.new(name, block.call)
+    suites << suite
+    suite.groups.each { |group| renderer.render_group(group) }
+    renderer.render_suite_complete(suite)
   end
 end
 

--- a/bench/suites/buffer_suite.cr
+++ b/bench/suites/buffer_suite.cr
@@ -1,170 +1,478 @@
 require "../bench_runner"
 
 module Termisu::Bench
-  # Mock renderer for benchmarking flush operations
+  # Renderer sink that follows the same Bytes path as Terminal and records I/O
+  # independently from allocations measured by the runner.
   class NullRenderer < Renderer
-    def write(data : String, columns_advanced = 0); end
+    getter emitted_bytes = 0_u64
+    getter string_writes = 0_u64
+    getter byte_writes = 0_u64
+    getter callback_calls = 0_u64
+    getter flushes = 0_u64
 
-    def move_cursor(x : Int32, y : Int32); end
+    @expected_byte : UInt8? = nil
 
-    def foreground=(color : Color); end
+    def write(data : String, columns_advanced = 0) : Nil
+      validate_payload(data.to_slice)
+      @string_writes += 1
+      @emitted_bytes += data.bytesize.to_u64
+    end
 
-    def background=(color : Color); end
+    def write(data : Bytes, columns_advanced = 0) : Nil
+      validate_payload(data)
+      @byte_writes += 1
+      @emitted_bytes += data.size.to_u64
+    end
 
-    def flush; end
+    def move_cursor(x : Int32, y : Int32) : Nil
+      count_callback
+    end
 
-    def reset_attributes; end
+    def foreground=(color : Color) : Nil
+      count_callback
+    end
 
-    def enable_bold; end
+    def background=(color : Color) : Nil
+      count_callback
+    end
 
-    def enable_underline; end
+    def flush : Nil
+      @flushes += 1
+    end
 
-    def enable_blink; end
+    def reset_attributes : Nil
+      count_callback
+    end
 
-    def enable_reverse; end
+    def enable_bold : Nil
+      count_callback
+    end
 
-    def enable_dim; end
+    def enable_underline : Nil
+      count_callback
+    end
 
-    def enable_cursive; end
+    def enable_blink : Nil
+      count_callback
+    end
 
-    def enable_hidden; end
+    def enable_reverse : Nil
+      count_callback
+    end
 
-    def enable_strikethrough; end
+    def enable_dim : Nil
+      count_callback
+    end
 
-    def show_cursor; end
+    def enable_cursive : Nil
+      count_callback
+    end
 
-    def hide_cursor; end
+    def enable_hidden : Nil
+      count_callback
+    end
+
+    def enable_strikethrough : Nil
+      count_callback
+    end
+
+    def show_cursor : Nil
+      count_callback
+    end
+
+    def hide_cursor : Nil
+      count_callback
+    end
 
     def size : {Int32, Int32}
       {80, 24}
     end
 
     def close; end
+
+    def expect_uniform_payload(byte : UInt8?) : Nil
+      @expected_byte = byte
+    end
+
+    def reset_metrics : Nil
+      @emitted_bytes = 0_u64
+      @string_writes = 0_u64
+      @byte_writes = 0_u64
+      @callback_calls = 0_u64
+      @flushes = 0_u64
+    end
+
+    def metrics(mutations = 0_u64) : BenchMetrics
+      BenchMetrics.new(
+        mutations,
+        @emitted_bytes,
+        @string_writes,
+        @byte_writes,
+        @callback_calls,
+        @flushes
+      )
+    end
+
+    private def validate_payload(data : Bytes) : Nil
+      return unless expected = @expected_byte
+      raise "renderer emitted an unexpected payload" unless data.all? { |byte| byte == expected }
+    end
+
+    private def count_callback : Nil
+      @callback_calls += 1
+    end
+  end
+
+  # Counts only transitions proved from the fixture's observable state. It is
+  # reset outside each measured sample; failed state checks abort the run.
+  class MutationProbe
+    getter count = 0_u64
+
+    def reset : Nil
+      @count = 0_u64
+    end
+
+    def observe_cell_change(
+      buffer : Buffer,
+      x : Int32,
+      y : Int32,
+      before : Cell,
+      expected : Cell,
+    ) : UInt64
+      after = cell_at(buffer, x, y)
+      raise "cell mutation did not produce the expected state" unless before != after && after == expected
+      mark
+    end
+
+    def observe_frame_change(
+      buffer : Buffer,
+      before_first : Cell,
+      before_last : Cell,
+      expected : Cell,
+      last_x : Int32,
+      last_y : Int32,
+    ) : UInt64
+      after_first = cell_at(buffer, 0, 0)
+      after_last = cell_at(buffer, last_x, last_y)
+      changed = before_first != after_first && before_last != after_last
+      raise "frame mutation did not produce the expected boundary cells" unless changed &&
+                                                                                after_first == expected &&
+                                                                                after_last == expected
+      mark
+    end
+
+    def observe_fill_and_clear(
+      buffer : Buffer,
+      before_first : Cell,
+      before_last : Cell,
+      filled_first : Cell,
+      filled_last : Cell,
+      expected_filled : Cell,
+    ) : UInt64
+      after_first = cell_at(buffer, 0, 0)
+      after_last = cell_at(buffer, buffer.width - 1, buffer.height - 1)
+      valid = before_first.default_state? && before_last.default_state? &&
+              filled_first == expected_filled && filled_last == expected_filled &&
+              after_first.default_state? && after_last.default_state?
+      raise "refill + clear did not complete both state transitions" unless valid
+      mark
+    end
+
+    def observe_resize(
+      buffer : Buffer,
+      before_width : Int32,
+      before_height : Int32,
+      expected_width : Int32,
+      expected_height : Int32,
+    ) : UInt64
+      changed = before_width != buffer.width || before_height != buffer.height
+      expected = buffer.width == expected_width && buffer.height == expected_height
+      raise "resize did not produce the expected dimensions" unless changed && expected
+      mark
+    end
+
+    def metrics(renderer : NullRenderer? = nil) : BenchMetrics
+      renderer ? renderer.metrics(@count) : BenchMetrics.new(@count, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64)
+    end
+
+    private def cell_at(buffer : Buffer, x : Int32, y : Int32) : Cell
+      buffer.get_cell(x, y) || raise "benchmark cell coordinates are out of bounds"
+    end
+
+    private def mark : UInt64
+      @count += 1
+    end
   end
 
   module BufferSuite
     extend self
 
-    def run : Array(BenchGroup)
+    def run(config : BenchConfig = BenchConfig.from_env) : Array(BenchGroup)
       groups = [] of BenchGroup
 
-      # Shared resources
-      small_buffer = Buffer.new(80, 24)
-      medium_buffer = Buffer.new(120, 40)
-      large_buffer = Buffer.new(200, 60)
-      renderer = NullRenderer.new
-
-      groups << run_cell_operations(small_buffer, large_buffer)
-      groups << run_clear_operations(small_buffer, medium_buffer, large_buffer)
-      groups << run_fill_operations(small_buffer, medium_buffer)
-      groups << run_render_operations(small_buffer, renderer)
-      groups << run_sync_operations(small_buffer, medium_buffer, large_buffer, renderer)
-      groups << run_resize_operations
+      groups << run_cell_operations(config)
+      groups << run_clear_operations(config)
+      groups << run_fill_operations(config)
+      groups << run_render_operations(config)
+      groups << run_sync_operations(config)
+      groups << run_resize_operations(config)
 
       groups
     end
 
-    private def run_cell_operations(small : Buffer, large : Buffer) : BenchGroup
-      capture = BenchCapture.new
+    private def run_cell_operations(config : BenchConfig) : BenchGroup
+      capture = BenchCapture.new(config)
 
-      capture.report("set_cell (small)") do
-        small.set_cell(rand(80), rand(24), 'A')
-      end
+      add_cell_job(capture, "set_cell (small)", Buffer.new(80, 24), 40, 12)
+      add_cell_job(capture, "set_cell (large)", Buffer.new(200, 60), 100, 30)
 
-      capture.report("set_cell (large)") do
-        large.set_cell(rand(200), rand(60), 'A')
-      end
-
-      capture.report("set_cell with attrs") do
-        small.set_cell(
-          rand(80), rand(24), 'X',
-          fg: Color.green,
-          bg: Color.black,
-          attr: Attribute::Bold
-        )
+      buffer = Buffer.new(80, 24)
+      probe = MutationProbe.new
+      alternate = false
+      expected_x = Cell.new("X", fg: Color.green, bg: Color.black, attr: Attribute::Bold)
+      expected_y = Cell.new("Y", fg: Color.cyan, bg: Color.black, attr: Attribute::Underline)
+      capture.report(
+        "set_cell with attrs",
+        before_sample: -> { probe.reset },
+        sample_metrics: -> { probe.metrics },
+        mutations_per_iteration: true
+      ) do
+        alternate = !alternate
+        before = cell_at(buffer, 40, 12)
+        expected = alternate ? expected_x : expected_y
+        buffer.set_cell(40, 12, expected.grapheme, expected.fg, expected.bg, expected.attr)
+        probe.observe_cell_change(buffer, 40, 12, before, expected)
       end
 
       BenchGroup.new("Cell Set Operations", capture.results)
     end
 
-    private def run_clear_operations(small : Buffer, medium : Buffer, large : Buffer) : BenchGroup
-      capture = BenchCapture.new
+    private def add_cell_job(capture : BenchCapture, name : String, buffer : Buffer, x : Int32, y : Int32) : Nil
+      probe = MutationProbe.new
+      alternate = false
+      expected_a = Cell.new("A")
+      expected_b = Cell.new("B")
+      capture.report(
+        name,
+        before_sample: -> { probe.reset },
+        sample_metrics: -> { probe.metrics },
+        mutations_per_iteration: true
+      ) do
+        alternate = !alternate
+        before = cell_at(buffer, x, y)
+        expected = alternate ? expected_a : expected_b
+        buffer.set_cell(x, y, expected.grapheme)
+        probe.observe_cell_change(buffer, x, y, before, expected)
+      end
+    end
 
-      capture.report("clear (small)") { small.clear }
-      capture.report("clear (medium)") { medium.clear }
-      capture.report("clear (large)") { large.clear }
+    private def run_clear_operations(config : BenchConfig) : BenchGroup
+      capture = BenchCapture.new(config)
+
+      add_clear_job(capture, "refill + clear (small)", Buffer.new(80, 24))
+      add_clear_job(capture, "refill + clear (medium)", Buffer.new(120, 40))
+      add_clear_job(capture, "refill + clear (large)", Buffer.new(200, 60))
 
       BenchGroup.new("Buffer Clear", capture.results)
     end
 
-    private def run_fill_operations(small : Buffer, medium : Buffer) : BenchGroup
-      capture = BenchCapture.new
-
-      capture.report("fill small (80x24)") do
-        24.times do |row|
-          80.times do |col|
-            small.set_cell(col, row, '#')
-          end
+    private def add_clear_job(capture : BenchCapture, name : String, buffer : Buffer) : Nil
+      probe = MutationProbe.new
+      alternate = false
+      expected_a = Cell.new("A")
+      expected_b = Cell.new("B")
+      capture.report(
+        name,
+        before_sample: -> { probe.reset },
+        sample_metrics: -> { probe.metrics },
+        mutations_per_iteration: true
+      ) do
+        alternate = !alternate
+        expected = alternate ? expected_a : expected_b
+        before_first = cell_at(buffer, 0, 0)
+        before_last = cell_at(buffer, buffer.width - 1, buffer.height - 1)
+        buffer.height.times do |row|
+          buffer.width.times { |column| buffer.set_cell(column, row, expected.grapheme) }
         end
+        filled_first = cell_at(buffer, 0, 0)
+        filled_last = cell_at(buffer, buffer.width - 1, buffer.height - 1)
+        buffer.clear
+        probe.observe_fill_and_clear(buffer, before_first, before_last, filled_first, filled_last, expected)
       end
+    end
 
-      capture.report("fill medium (120x40)") do
-        40.times do |row|
-          120.times do |col|
-            medium.set_cell(col, row, '#')
-          end
-        end
-      end
+    private def run_fill_operations(config : BenchConfig) : BenchGroup
+      capture = BenchCapture.new(config)
+
+      add_fill_job(capture, "fill small A/B (80x24)", Buffer.new(80, 24))
+      add_fill_job(capture, "fill medium A/B (120x40)", Buffer.new(120, 40))
 
       BenchGroup.new("Full Screen Fill", capture.results)
     end
 
-    private def run_render_operations(buffer : Buffer, renderer : Renderer) : BenchGroup
-      capture = BenchCapture.new
+    private def add_fill_job(capture : BenchCapture, name : String, buffer : Buffer) : Nil
+      probe = MutationProbe.new
+      alternate = false
+      expected_a = Cell.new("A")
+      expected_b = Cell.new("B")
+      last_x = buffer.width - 1
+      last_y = buffer.height - 1
+      capture.report(
+        name,
+        before_sample: -> { probe.reset },
+        sample_metrics: -> { probe.metrics },
+        mutations_per_iteration: true
+      ) do
+        alternate = !alternate
+        expected = alternate ? expected_a : expected_b
+        before_first = cell_at(buffer, 0, 0)
+        before_last = cell_at(buffer, last_x, last_y)
+        buffer.height.times do |row|
+          buffer.width.times { |column| buffer.set_cell(column, row, expected.grapheme) }
+        end
+        probe.observe_frame_change(buffer, before_first, before_last, expected, last_x, last_y)
+      end
+    end
 
-      capture.report("render_to (no changes)") do
-        buffer.render_to(renderer)
+    private def run_render_operations(config : BenchConfig) : BenchGroup
+      capture = BenchCapture.new(config)
+      renderer = NullRenderer.new
+
+      clean = Buffer.new(80, 24)
+      add_renderer_job(capture, "render_to (no changes)", renderer, emitted_bytes_per_iteration: 0_u64) do
+        clean.render_to(renderer)
       end
 
-      capture.report("render_to (1 cell changed)") do
-        buffer.set_cell(40, 12, ((rand(26) + 65).to_u8).unsafe_chr)
-        buffer.render_to(renderer)
+      one_cell = Buffer.new(80, 24)
+      probe = MutationProbe.new
+      alternate = false
+      expected_a = Cell.new("A")
+      expected_b = Cell.new("B")
+      add_renderer_job(capture, "render_to (1 cell A/B)", renderer, probe, emitted_bytes_per_iteration: 1_u64) do
+        alternate = !alternate
+        expected = alternate ? expected_a : expected_b
+        renderer.expect_uniform_payload(expected.grapheme.byte_at(0))
+        before = cell_at(one_cell, 40, 12)
+        one_cell.set_cell(40, 12, expected.grapheme)
+        probe.observe_cell_change(one_cell, 40, 12, before, expected)
+        one_cell.render_to(renderer)
       end
 
-      capture.report("render_to (10% changed)") do
-        192.times { buffer.set_cell(rand(80), rand(24), 'X') }
-        buffer.render_to(renderer)
+      changed = Buffer.new(80, 24)
+      probe = MutationProbe.new
+      alternate = false
+      expected_x = Cell.new("X")
+      expected_y = Cell.new("Y")
+      add_renderer_job(capture, "render_to (10% A/B)", renderer, probe, emitted_bytes_per_iteration: 192_u64) do
+        alternate = !alternate
+        expected = alternate ? expected_x : expected_y
+        renderer.expect_uniform_payload(expected.grapheme.byte_at(0))
+        before_first = cell_at(changed, 0, 0)
+        before_last = cell_at(changed, 31, 2)
+        192.times do |index|
+          changed.set_cell(index % 80, index // 80, expected.grapheme)
+        end
+        probe.observe_frame_change(changed, before_first, before_last, expected, 31, 2)
+        changed.render_to(renderer)
       end
 
       BenchGroup.new("Render Operations (Diff-Based)", capture.results)
     end
 
-    private def run_sync_operations(small : Buffer, medium : Buffer, large : Buffer, renderer : Renderer) : BenchGroup
-      capture = BenchCapture.new
+    private def add_renderer_job(
+      capture : BenchCapture,
+      name : String,
+      renderer : NullRenderer,
+      probe : MutationProbe? = nil,
+      emitted_bytes_per_iteration : UInt64? = nil,
+      &block
+    ) : Nil
+      validate_sample = ->(sample : BenchSample) {
+        metrics = sample.metrics
+        expected_bytes = emitted_bytes_per_iteration.try { |bytes| bytes * sample.iterations.to_u64 }
+        raise "#{name}: unexpected emitted byte count" if expected_bytes && metrics.emitted_bytes != expected_bytes
+        raise "#{name}: String write bypassed Bytes path" unless metrics.string_writes.zero?
+        raise "#{name}: expected one flush per iteration" unless metrics.flushes == sample.iterations.to_u64
+        if metrics.emitted_bytes > 0 && metrics.byte_writes.zero?
+          raise "#{name}: emitted payload without a Bytes write"
+        end
+      }
 
-      capture.report("sync (small)") { small.sync_to(renderer) }
-      capture.report("sync (medium)") { medium.sync_to(renderer) }
-      capture.report("sync (large)") { large.sync_to(renderer) }
+      capture.report(
+        name,
+        before_sample: -> {
+          renderer.reset_metrics
+          probe.try(&.reset)
+        },
+        sample_metrics: -> { probe ? probe.metrics(renderer) : renderer.metrics },
+        validate_sample: validate_sample,
+        mutations_per_iteration: !probe.nil?
+      ) do
+        block.call
+      end
+    end
+
+    private def run_sync_operations(config : BenchConfig) : BenchGroup
+      capture = BenchCapture.new(config)
+      renderer = NullRenderer.new
+      renderer.expect_uniform_payload(' '.ord.to_u8)
+      small = Buffer.new(80, 24)
+      medium = Buffer.new(120, 40)
+      large = Buffer.new(200, 60)
+
+      add_renderer_job(capture, "sync (small)", renderer, emitted_bytes_per_iteration: 80_u64 * 24) do
+        small.sync_to(renderer)
+      end
+      add_renderer_job(capture, "sync (medium)", renderer, emitted_bytes_per_iteration: 120_u64 * 40) do
+        medium.sync_to(renderer)
+      end
+      add_renderer_job(capture, "sync (large)", renderer, emitted_bytes_per_iteration: 200_u64 * 60) do
+        large.sync_to(renderer)
+      end
 
       BenchGroup.new("Sync Operations (Full Redraw)", capture.results)
     end
 
-    private def run_resize_operations : BenchGroup
-      capture = BenchCapture.new
+    private def cell_at(buffer : Buffer, x : Int32, y : Int32) : Cell
+      buffer.get_cell(x, y) || raise "benchmark cell coordinates are out of bounds"
+    end
 
-      capture.report("resize grow") do
-        buf = Buffer.new(80, 24)
-        buf.resize(120, 40)
+    private def run_resize_operations(config : BenchConfig) : BenchGroup
+      capture = BenchCapture.new(config)
+      buffer = Buffer.new(80, 24)
+      probe = MutationProbe.new
+      large = false
+
+      capture.report(
+        "resize alternating 80x24 / 120x40",
+        before_sample: -> { probe.reset },
+        sample_metrics: -> { probe.metrics },
+        mutations_per_iteration: true
+      ) do
+        before_width = buffer.width
+        before_height = buffer.height
+        large = !large
+        expected_width, expected_height = large ? {120, 40} : {80, 24}
+        buffer.resize(expected_width, expected_height)
+        probe.observe_resize(buffer, before_width, before_height, expected_width, expected_height)
       end
 
-      capture.report("resize shrink") do
-        buf = Buffer.new(120, 40)
-        buf.resize(80, 24)
+      probe = MutationProbe.new
+      capture.report(
+        "construct + resize grow",
+        before_sample: -> { probe.reset },
+        sample_metrics: -> { probe.metrics },
+        mutations_per_iteration: true
+      ) do
+        fresh = Buffer.new(80, 24)
+        fresh.resize(120, 40)
+        probe.observe_resize(fresh, 80, 24, 120, 40)
       end
 
-      capture.report("resize same (no-op)") do
-        buf = Buffer.new(80, 24)
-        buf.resize(80, 24)
+      capture.report("resize same (no-op control)") do
+        fresh = Buffer.new(80, 24)
+        fresh.resize(80, 24)
+        raise "same-size resize changed dimensions" unless fresh.width == 80 && fresh.height == 24
       end
 
       BenchGroup.new("Resize Operations", capture.results)

--- a/bench/suites/color_suite.cr
+++ b/bench/suites/color_suite.cr
@@ -4,20 +4,20 @@ module Termisu::Bench
   module ColorSuite
     extend self
 
-    def run : Array(BenchGroup)
+    def run(config : BenchConfig = BenchConfig.from_env) : Array(BenchGroup)
       groups = [] of BenchGroup
 
-      groups << run_creation_benchmarks
-      groups << run_conversion_benchmarks
-      groups << run_palette_benchmarks
-      groups << run_equality_benchmarks
-      groups << run_escape_sequence_benchmarks
+      groups << run_creation_benchmarks(config)
+      groups << run_conversion_benchmarks(config)
+      groups << run_palette_benchmarks(config)
+      groups << run_equality_benchmarks(config)
+      groups << run_escape_sequence_benchmarks(config)
 
       groups
     end
 
-    private def run_creation_benchmarks : BenchGroup
-      capture = BenchCapture.new
+    private def run_creation_benchmarks(config : BenchConfig) : BenchGroup
+      capture = BenchCapture.new(config)
 
       capture.report("Color.default") { Color.default }
       capture.report("Color.black") { Color.black }
@@ -27,8 +27,8 @@ module Termisu::Bench
       BenchGroup.new("Color Creation", capture.results)
     end
 
-    private def run_conversion_benchmarks : BenchGroup
-      capture = BenchCapture.new
+    private def run_conversion_benchmarks(config : BenchConfig) : BenchGroup
+      capture = BenchCapture.new(config)
 
       capture.report("rgb_to_ansi256") do
         Color::Conversions.rgb_to_ansi256(128_u8, 64_u8, 200_u8)
@@ -45,8 +45,9 @@ module Termisu::Bench
       BenchGroup.new("Color Conversions", capture.results)
     end
 
-    private def run_palette_benchmarks : BenchGroup
-      capture = BenchCapture.new
+    private def run_palette_benchmarks(config : BenchConfig) : BenchGroup
+      capture = BenchCapture.new(config)
+      index = 0_u8
 
       capture.report("basic_color(:red)") do
         Color::Palette.basic_color(:red)
@@ -56,20 +57,20 @@ module Termisu::Bench
         Color::Palette.grayscale_color(12)
       end
 
-      capture.report("grayscale range check") do
-        idx = rand(256).to_u8
-        idx >= 232 && idx <= 255
+      capture.report("grayscale range check", before_sample: -> { index = 0_u8; nil }) do
+        index &+= 1
+        index >= 232 && index <= 255
       end
 
       BenchGroup.new("Palette Lookups", capture.results)
     end
 
-    private def run_equality_benchmarks : BenchGroup
+    private def run_equality_benchmarks(config : BenchConfig) : BenchGroup
       color1 = Color.rgb(100_u8, 150_u8, 200_u8)
       color2 = Color.rgb(100_u8, 150_u8, 200_u8)
       color3 = Color.rgb(200_u8, 150_u8, 100_u8)
 
-      capture = BenchCapture.new
+      capture = BenchCapture.new(config)
 
       capture.report("color == (equal)") { color1 == color2 }
       capture.report("color == (not equal)") { color1 == color3 }
@@ -77,19 +78,24 @@ module Termisu::Bench
       BenchGroup.new("Color Equality", capture.results)
     end
 
-    private def run_escape_sequence_benchmarks : BenchGroup
-      capture = BenchCapture.new
+    private def run_escape_sequence_benchmarks(config : BenchConfig) : BenchGroup
+      capture = BenchCapture.new(config)
+      index = 0_u8
+      reset_index = -> { index = 0_u8; nil }
 
-      capture.report("build fg sequence") do
-        "\e[38;5;#{rand(256)}m"
+      capture.report("build fg sequence", before_sample: reset_index) do
+        index &+= 1
+        "\e[38;5;#{index}m"
       end
 
-      capture.report("build rgb sequence") do
-        "\e[38;2;#{rand(256)};#{rand(256)};#{rand(256)}m"
+      capture.report("build rgb sequence", before_sample: reset_index) do
+        index &+= 1
+        "\e[38;2;#{index};#{index &+ 1};#{index &+ 2}m"
       end
 
-      capture.report("build combined") do
-        "\e[38;5;#{rand(256)};48;5;#{rand(256)}m"
+      capture.report("build combined", before_sample: reset_index) do
+        index &+= 1
+        "\e[38;5;#{index};48;5;#{index &+ 1}m"
       end
 
       BenchGroup.new("Escape Sequence Building", capture.results)

--- a/bench/suites/parser_suite.cr
+++ b/bench/suites/parser_suite.cr
@@ -33,20 +33,20 @@ module Termisu::Bench
       io.to_slice
     end
 
-    def run : Array(BenchGroup)
+    def run(config : BenchConfig = BenchConfig.from_env) : Array(BenchGroup)
       mock_data = create_mock_data
       groups = [] of BenchGroup
 
-      groups << run_parser_creation(mock_data)
-      groups << run_capability_parsing(mock_data)
-      groups << run_full_parse_cycle(mock_data)
-      groups << run_error_handling(mock_data)
+      groups << run_parser_creation(mock_data, config)
+      groups << run_capability_parsing(mock_data, config)
+      groups << run_full_parse_cycle(mock_data, config)
+      groups << run_error_handling(mock_data, config)
 
       groups
     end
 
-    private def run_parser_creation(mock_data : Bytes) : BenchGroup
-      capture = BenchCapture.new
+    private def run_parser_creation(mock_data : Bytes, config : BenchConfig) : BenchGroup
+      capture = BenchCapture.new(config)
 
       capture.report("Parser.new") do
         Terminfo::Parser.new(mock_data)
@@ -55,9 +55,9 @@ module Termisu::Bench
       BenchGroup.new("Parser Creation", capture.results)
     end
 
-    private def run_capability_parsing(mock_data : Bytes) : BenchGroup
+    private def run_capability_parsing(mock_data : Bytes, config : BenchConfig) : BenchGroup
       parser = Terminfo::Parser.new(mock_data)
-      capture = BenchCapture.new
+      capture = BenchCapture.new(config)
 
       capture.report("parse 1 cap") do
         parser.parse(["clear"])
@@ -75,8 +75,8 @@ module Termisu::Bench
       BenchGroup.new("Capability Parsing", capture.results)
     end
 
-    private def run_full_parse_cycle(mock_data : Bytes) : BenchGroup
-      capture = BenchCapture.new
+    private def run_full_parse_cycle(mock_data : Bytes, config : BenchConfig) : BenchGroup
+      capture = BenchCapture.new(config)
 
       capture.report("Parser.parse (1 cap)") do
         Terminfo::Parser.parse(mock_data, ["clear"])
@@ -93,13 +93,13 @@ module Termisu::Bench
       BenchGroup.new("Full Parse Cycle", capture.results)
     end
 
-    private def run_error_handling(mock_data : Bytes) : BenchGroup
+    private def run_error_handling(mock_data : Bytes, config : BenchConfig) : BenchGroup
       corrupt_data = Bytes[1, 2, 3]
       invalid_magic = mock_data.clone
       invalid_magic[0] = 0xFF_u8
       invalid_magic[1] = 0xFF_u8
 
-      capture = BenchCapture.new
+      capture = BenchCapture.new(config)
 
       capture.report("parse? (corrupt - nil)") do
         Terminfo::Parser.parse?(corrupt_data, ["clear"])

--- a/spec/termisu/bench_runner_spec.cr
+++ b/spec/termisu/bench_runner_spec.cr
@@ -1,0 +1,247 @@
+require "../spec_helper"
+require "../../bench/suites/buffer_suite"
+
+private def fast_bench_config
+  Termisu::Bench::BenchConfig.new(5, 50.microseconds)
+end
+
+describe Termisu::Bench::BenchSink do
+  it "consumes constant-cost identities instead of payload-dependent hashes" do
+    reference = "reference payload"
+    bytes = Bytes[1, 2, 3]
+    before = Termisu::Bench::BenchSink.value
+
+    Termisu::Bench::BenchSink.consume(reference)
+    Termisu::Bench::BenchSink.consume(bytes)
+
+    byte_identity = bytes.to_unsafe.address.to_u64 ^ bytes.size.to_u64
+    expected = before &+ reference.object_id.to_u64 &+ byte_identity
+    Termisu::Bench::BenchSink.value.should eq(expected)
+  end
+end
+
+describe Termisu::Bench::BenchCapture do
+  it "retains repeated raw samples in report order" do
+    capture = Termisu::Bench::BenchCapture.new(fast_bench_config)
+    value = 0_u64
+
+    capture.report("first") { value &+= 1 }
+    capture.report("second") { value &+= 1 }
+
+    capture.results.map(&.name).should eq(["first", "second"])
+    capture.results.each do |result|
+      result.samples.size.should eq(5)
+      result.samples.each do |sample|
+        sample.iterations.should be > 0
+        sample.elapsed.should be > Time::Span.zero
+      end
+    end
+  end
+
+  it "counts only mutations proved from observable Buffer state" do
+    capture = Termisu::Bench::BenchCapture.new(fast_bench_config)
+    probe = Termisu::Bench::MutationProbe.new
+    buffer = Termisu::Buffer.new(1, 1)
+    expected_a = Termisu::Cell.new("A")
+    expected_b = Termisu::Cell.new("B")
+    alternate = false
+
+    capture.report(
+      "A/B mutation",
+      before_sample: -> { probe.reset },
+      sample_metrics: -> { probe.metrics },
+      mutations_per_iteration: true
+    ) do
+      alternate = !alternate
+      before = buffer.get_cell(0, 0).as(Termisu::Cell)
+      expected = alternate ? expected_a : expected_b
+      buffer.set_cell(0, 0, expected.grapheme)
+      probe.observe_cell_change(buffer, 0, 0, before, expected)
+    end
+
+    capture.results.first.samples.each do |sample|
+      sample.metrics.mutations.should eq(sample.iterations.to_u64)
+    end
+
+    current = buffer.get_cell(0, 0).as(Termisu::Cell)
+    expect_raises(Exception, /did not produce the expected state/) do
+      probe.observe_cell_change(buffer, 0, 0, current, current)
+    end
+  end
+
+  it "reports measured allocation rather than placeholder values" do
+    capture = Termisu::Bench::BenchCapture.new(fast_bench_config)
+    state = 0_u64
+
+    capture.report("zero") do
+      state &+= 1
+      state &* 3_u64
+    end
+    capture.report("allocating") { Bytes.new(64, (state & 0xff).to_u8) }
+
+    capture.results[0].bytes_per_op.should eq(0.0)
+    capture.results[1].bytes_per_op.should be > 0.0
+    capture.results[1].samples.sum(&.allocated_bytes).should be > 0
+  end
+end
+
+describe Termisu::Bench::BufferSuite do
+  it "validates every real stateful job and its rendered payload" do
+    groups = Termisu::Bench::BufferSuite.run(fast_bench_config)
+    results = groups.flat_map(&.results)
+
+    results.map(&.name).should eq([
+      "set_cell (small)",
+      "set_cell (large)",
+      "set_cell with attrs",
+      "refill + clear (small)",
+      "refill + clear (medium)",
+      "refill + clear (large)",
+      "fill small A/B (80x24)",
+      "fill medium A/B (120x40)",
+      "render_to (no changes)",
+      "render_to (1 cell A/B)",
+      "render_to (10% A/B)",
+      "sync (small)",
+      "sync (medium)",
+      "sync (large)",
+      "resize alternating 80x24 / 120x40",
+      "construct + resize grow",
+      "resize same (no-op control)",
+    ])
+
+    stateful_names = [
+      "set_cell (small)",
+      "set_cell (large)",
+      "set_cell with attrs",
+      "refill + clear (small)",
+      "refill + clear (medium)",
+      "refill + clear (large)",
+      "fill small A/B (80x24)",
+      "fill medium A/B (120x40)",
+      "render_to (1 cell A/B)",
+      "render_to (10% A/B)",
+      "resize alternating 80x24 / 120x40",
+      "construct + resize grow",
+    ]
+    stateful_names.each do |name|
+      result = results.find! { |candidate| candidate.name == name }
+      result.samples.each do |sample|
+        sample.metrics.mutations.should eq(sample.iterations.to_u64)
+      end
+    end
+
+    expected_bytes = {
+      "render_to (no changes)" => 0_u64,
+      "render_to (1 cell A/B)" => 1_u64,
+      "render_to (10% A/B)"    => 192_u64,
+      "sync (small)"           => 80_u64 * 24,
+      "sync (medium)"          => 120_u64 * 40,
+      "sync (large)"           => 200_u64 * 60,
+    }
+    expected_bytes.each do |name, bytes_per_iteration|
+      result = results.find! { |candidate| candidate.name == name }
+      result.samples.each do |sample|
+        sample.metrics.emitted_bytes.should eq(bytes_per_iteration * sample.iterations.to_u64)
+        sample.metrics.string_writes.should eq(0_u64)
+        sample.metrics.flushes.should eq(sample.iterations.to_u64)
+      end
+    end
+  end
+end
+
+describe Termisu::Bench::NullRenderer do
+  it "counts String and production-like Bytes writes separately" do
+    renderer = Termisu::Bench::NullRenderer.new
+
+    renderer.write("abc")
+    renderer.write(Bytes[1, 2, 3, 4])
+    renderer.move_cursor(1, 2)
+    renderer.flush
+
+    renderer.metrics.should eq(Termisu::Bench::BenchMetrics.new(
+      mutations: 0_u64,
+      emitted_bytes: 7_u64,
+      string_writes: 1_u64,
+      byte_writes: 1_u64,
+      callback_calls: 1_u64,
+      flushes: 1_u64
+    ))
+  end
+
+  it "receives Buffer payload through Bytes without materializing a String" do
+    renderer = Termisu::Bench::NullRenderer.new
+    renderer.expect_uniform_payload('A'.ord.to_u8)
+    buffer = Termisu::Buffer.new(1, 1)
+    buffer.set_cell(0, 0, 'A').should be_true
+
+    buffer.render_to(renderer)
+
+    renderer.emitted_bytes.should eq(1_u64)
+    renderer.string_writes.should eq(0_u64)
+    renderer.byte_writes.should eq(1_u64)
+    renderer.flushes.should eq(1_u64)
+  end
+
+  it "rejects an unexpected rendered payload" do
+    renderer = Termisu::Bench::NullRenderer.new
+    renderer.expect_uniform_payload('A'.ord.to_u8)
+
+    expect_raises(Exception, /unexpected payload/) do
+      renderer.write(Bytes['B'.ord.to_u8])
+    end
+  end
+end
+
+describe Termisu::Bench::ConcurrentRunner do
+  it "buffers out-of-order completions across partial run_all calls" do
+    runner = Termisu::Bench::ConcurrentRunner.new
+    started = Channel(String).new
+    second_completed = Channel(Nil).new
+    release_first = Channel(Nil).new
+    executions = Hash(String, Int32).new(0)
+
+    runner.add_suite("first") do
+      started.send("first")
+      release_first.receive
+      executions["first"] += 1
+      [] of Termisu::Bench::BenchGroup
+    end
+    runner.add_suite("second") do
+      started.send("second")
+      executions["second"] += 1
+      second_completed.send(nil)
+      [] of Termisu::Bench::BenchGroup
+    end
+
+    outcome = Channel(Array(Termisu::Bench::BenchSuite) | Exception).new
+    spawn do
+      outcome.send(runner.run_all(1))
+    rescue error
+      outcome.send(error)
+    end
+
+    2.times { started.receive }
+    second_completed.receive
+    # Let the second suite return and deliver its out-of-window result while
+    # the first suite remains blocked on the explicit barrier.
+    Fiber.yield
+    Fiber.yield
+    release_first.send(nil)
+    first = outcome.receive
+    first.should be_a(Array(Termisu::Bench::BenchSuite))
+    first.as(Array(Termisu::Bench::BenchSuite)).map(&.name).should eq(["first"])
+
+    runner.run_all(1).map(&.name).should eq(["second"])
+    executions.should eq({"first" => 1, "second" => 1})
+  end
+
+  it "propagates suite failures instead of waiting forever" do
+    runner = Termisu::Bench::ConcurrentRunner.new
+    runner.add_suite("broken") do
+      raise "suite failed"
+    end
+
+    expect_raises(Exception, "suite failed") { runner.run_all(1) }
+  end
+end


### PR DESCRIPTION
## Rationale

The old harness took one short sample, read the clock inside the operation loop, and printed fabricated zero variation/allocation values. Mutable Buffer fixtures also saturated during warmup, so named mutations could benchmark no-ops.

## Design

- calibrates one batch, then retains at least five raw batch samples without per-operation clock reads
- runs suites/jobs serially in stable registration order and sends pure results to an observable sink
- reports variation and `Benchmark.memory` allocation bytes separately from renderer bytes/calls/flushes
- alternates Buffer states and validates observable before/after cells, dimensions, and exact rendered payload/byte counts on every iteration/sample
- gives the null renderer a production-like `write(Bytes)` path and rejects String-path or payload regressions
- preserves `ConcurrentRunner` for yielding/future workloads while buffering out-of-order completions across partial `run_all(count)` calls

## Correctness constraints

The run aborts if a stateful operation does not reach its expected state, if mutation count differs from iteration count, if rendered bytes/flushes differ from the workload contract, or if allocation controls cannot distinguish zero-allocation and allocating work. The same-size resize and clean render remain explicit no-op controls.

## Evidence

- Crystal 1.17 focused benchmark specs: **10 examples, 0 failures**
- Crystal 1.21 focused benchmark specs: **10 examples, 0 failures**
- Crystal 1.21 full PTY-aware unit suite: **1373 examples, 0 failures, 1 pending** (expected controlling-TTY pending)
- Crystal-native E2E/PTY suite: **82 examples, 0 failures**
- Crystal 1.17 release benchmark build/run smoke: **43 jobs, 215 raw samples**, exit 0
- Crystal 1.21 release benchmark build and five repeated processes: each **43 jobs / 215 raw samples**, identical order
- all repeated runs: zero-allocation samples were 0 bytes; every allocating-control sample was nonzero; all stateful sample mutation counts equaled iterations; renderer validators passed
- Crystal format check, Ameba (**162 files, 0 failures**), and `git diff --check`: passed

C ABI/native and Bun checks were not run because this patch changes only the standalone Crystal benchmark harness/specs and no production, ABI, or JavaScript surface.

### Measurement limitations

The five Crystal 1.21 release processes used 5 × 10 ms batch samples and were pinned with `taskset` to CPU 7 on Linux 6.12/KVM (AMD EPYC-Rome). The environment exposed no cpufreq governor and concurrent host load was uncontrolled. These runs establish raw-distribution retention, deterministic ordering, allocation controls, and workload counters only; **no timing ratio or performance baseline is claimed**. Full raw outputs are published in follow-up PR comments.
