### PR TITLE
perf: skip clean render frames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /docs/
-/lib/
+/lib
 /.shards/
 *.dwarf
 
@@ -23,7 +23,7 @@
 .croupier
 
 # E2E test artifacts
-/node_modules/
+/node_modules
 /javascript/**/node_modules/
 /javascript/node_modules/
 /e2e/node_modules/

--- a/spec/termisu/terminal/sync_update_spec.cr
+++ b/spec/termisu/terminal/sync_update_spec.cr
@@ -52,6 +52,133 @@ private class PrimaryAndCleanupFaultTerminal < CaptureTerminal
   end
 end
 
+private class OrderedFrameTerminfo < Termisu::Terminfo
+  def cup_is_standard? : Bool
+    true
+  end
+
+  def attrs_are_standard? : Bool
+    true
+  end
+
+  def show_cursor_seq : String
+    "\e[?12l\e[?25h"
+  end
+
+  def hide_cursor_seq : String
+    "\e[?25l"
+  end
+
+  def reset_attrs_seq : String
+    "\e[m\e(B"
+  end
+end
+
+private class OrderedFrameTerminal < CaptureTerminal
+  enum Failure
+    Content
+    Restoration
+    Flush
+  end
+
+  CUP         = "\e[1;1H"
+  HIDE_CURSOR = "\e[?25l"
+  SHOW_CURSOR = "\e[?12l\e[?25h"
+  property failure : Failure?
+  getter events = [] of String
+
+  @ordered_size : {Int32, Int32}
+  @cup_writes : Int32 = 0
+
+  def initialize(*, sync_updates : Bool, size : {Int32, Int32} = {3, 1})
+    @ordered_size = size
+    super(sync_updates: sync_updates, terminfo: OrderedFrameTerminfo.new)
+  end
+
+  def size : {Int32, Int32}
+    @ordered_size
+  end
+
+  def write(data : String, columns_advanced = 0)
+    capture_write(data)
+    super(data)
+  end
+
+  def write(data : Bytes, columns_advanced = 0)
+    text = String.new(data)
+    capture_write(text)
+    super(data, columns_advanced)
+  end
+
+  def flush
+    @events << "<flush>"
+    fail_once(Failure::Flush)
+    super
+  end
+
+  def clear_events
+    @events.clear
+    @cup_writes = 0
+    clear_captured
+  end
+
+  private def capture_write(data : String) : Nil
+    @events << data
+    if data == CUP
+      @cup_writes += 1
+      fail_once(Failure::Restoration) if @cup_writes == 2
+    elsif data == "X"
+      fail_once(Failure::Content)
+    end
+  end
+
+  private def fail_once(phase : Failure) : Nil
+    return unless @failure == phase
+
+    @failure = nil
+    raise "injected #{phase.to_s.downcase} failure"
+  end
+end
+
+private class DirectFailureBackend < Termisu::Terminal::Backend
+  enum Failure
+    Write
+    Flush
+  end
+
+  property failure : Failure?
+  getter events = [] of String
+
+  def size : {Int32, Int32}
+    {3, 1}
+  end
+
+  def write(data : String)
+    capture(data)
+  end
+
+  def write(data : Bytes)
+    capture(String.new(data))
+  end
+
+  def flush
+    @events << "<flush>"
+    fail_once(Failure::Flush)
+  end
+
+  private def capture(data : String) : Nil
+    @events << data
+    fail_once(Failure::Write)
+  end
+
+  private def fail_once(phase : Failure) : Nil
+    return unless @failure == phase
+
+    @failure = nil
+    raise "injected direct #{phase.to_s.downcase} failure"
+  end
+end
+
 private class SyncFaultTerminal < CaptureTerminal
   enum Phase
     Begin
@@ -107,6 +234,277 @@ private class SyncFaultTerminal < CaptureTerminal
 end
 
 describe "Synchronized Update Emission" do
+  describe "clean frame fast path" do
+    {false, true}.each do |sync_updates|
+      suffix = sync_updates ? "with synchronized updates" : "without synchronized updates"
+      frame_prefix = sync_updates ? [Termisu::Terminal::BSU] : [] of String
+      frame_suffix = sync_updates ? [Termisu::Terminal::ESU, "<flush>"] : ["<flush>"]
+
+      it "captures exact dirty frame ordering #{suffix}" do
+        terminal = OrderedFrameTerminal.new(sync_updates: sync_updates)
+        terminal.set_cell(0, 0, 'X')
+
+        terminal.render
+
+        terminal.events.should eq(
+          frame_prefix + [OrderedFrameTerminal::CUP, OrderedFrameTerminal::HIDE_CURSOR, "\e[37;49m", "X",
+                          OrderedFrameTerminal::CUP, OrderedFrameTerminal::HIDE_CURSOR] + frame_suffix
+        )
+        terminal.captured_flush_count.should eq(1)
+      ensure
+        terminal.try &.close
+      end
+
+      it "establishes the first clean frame and skips bytes on the second #{suffix}" do
+        terminal = OrderedFrameTerminal.new(sync_updates: sync_updates)
+
+        terminal.render
+        terminal.events.should eq(
+          frame_prefix + [OrderedFrameTerminal::CUP, OrderedFrameTerminal::HIDE_CURSOR,
+                          OrderedFrameTerminal::CUP, OrderedFrameTerminal::HIDE_CURSOR] + frame_suffix
+        )
+        frame_bytes = terminal.events.reject { |event| event == "<flush>" }.sum(&.bytesize)
+        frame_bytes.should eq(sync_updates ? 40 : 24)
+
+        terminal.clear_events
+        terminal.render
+        terminal.events.should eq(["<flush>"])
+        terminal.captured_flush_count.should eq(1)
+      ensure
+        terminal.try &.close
+      end
+
+      it "re-establishes a mutated cursor position #{suffix}" do
+        terminal = OrderedFrameTerminal.new(sync_updates: sync_updates)
+        terminal.render
+        terminal.clear_events
+
+        terminal.cursor.x = 1
+        terminal.render
+
+        terminal.events.should eq(
+          frame_prefix + [OrderedFrameTerminal::CUP, OrderedFrameTerminal::HIDE_CURSOR,
+                          "\e[1;2H", OrderedFrameTerminal::HIDE_CURSOR] + frame_suffix
+        )
+
+        terminal.clear_events
+        terminal.render
+        terminal.events.should eq(["<flush>"])
+      ensure
+        terminal.try &.close
+      end
+
+      it "re-establishes mutated cursor visibility #{suffix}" do
+        terminal = OrderedFrameTerminal.new(sync_updates: sync_updates)
+        terminal.render
+        terminal.clear_events
+
+        terminal.cursor.visible = true
+        terminal.render
+
+        terminal.events.should eq(
+          frame_prefix + [OrderedFrameTerminal::CUP, OrderedFrameTerminal::HIDE_CURSOR,
+                          OrderedFrameTerminal::CUP, OrderedFrameTerminal::SHOW_CURSOR, "\e[2 q"] + frame_suffix
+        )
+
+        terminal.clear_events
+        terminal.render
+        terminal.events.should eq(["<flush>"])
+      ensure
+        terminal.try &.close
+      end
+
+      it "restores a visible cursor before the final flush #{suffix}" do
+        terminal = OrderedFrameTerminal.new(sync_updates: sync_updates)
+        terminal.show_cursor
+        terminal.clear_events
+
+        terminal.render
+
+        terminal.events.should eq(
+          frame_prefix + [OrderedFrameTerminal::CUP, OrderedFrameTerminal::HIDE_CURSOR,
+                          OrderedFrameTerminal::CUP, OrderedFrameTerminal::SHOW_CURSOR, "\e[2 q"] + frame_suffix
+        )
+        terminal.events[-2].should eq(sync_updates ? Termisu::Terminal::ESU : "\e[2 q")
+        terminal.events.last.should eq("<flush>")
+
+        terminal.clear_events
+        terminal.render
+        terminal.events.should eq(["<flush>"])
+      ensure
+        terminal.try &.close
+      end
+
+      it "flushes pending direct writes after re-establishing cursor state #{suffix}" do
+        backend = DirectFailureBackend.new
+        terminal = Termisu::Terminal.new(
+          backend: backend,
+          terminfo: OrderedFrameTerminfo.new,
+          sync_updates: sync_updates
+        )
+        terminal.render
+        backend.events.clear
+
+        terminal.write("pending")
+        terminal.render
+
+        backend.events.should eq(
+          ["pending"] + frame_prefix + [OrderedFrameTerminal::CUP, OrderedFrameTerminal::HIDE_CURSOR,
+                                        OrderedFrameTerminal::CUP, OrderedFrameTerminal::HIDE_CURSOR] + frame_suffix
+        )
+      ensure
+        terminal.try &.close
+      end
+
+      it "re-establishes a clean buffer after render state reset #{suffix}" do
+        terminal = OrderedFrameTerminal.new(sync_updates: sync_updates)
+        terminal.render
+        terminal.clear_events
+        terminal.reset_render_state
+
+        terminal.render
+
+        terminal.events.should eq(
+          frame_prefix + [OrderedFrameTerminal::CUP, OrderedFrameTerminal::HIDE_CURSOR,
+                          OrderedFrameTerminal::CUP, OrderedFrameTerminal::HIDE_CURSOR] + frame_suffix
+        )
+      ensure
+        terminal.try &.close
+      end
+
+      it "preserves logical cursor state for a zero-size terminal #{suffix}" do
+        terminal = OrderedFrameTerminal.new(sync_updates: sync_updates, size: {0, 0})
+        terminal.move_cursor(7, 4)
+
+        terminal.render
+
+        terminal.events.should eq(
+          frame_prefix + [OrderedFrameTerminal::HIDE_CURSOR,
+                          OrderedFrameTerminal::HIDE_CURSOR] + frame_suffix
+        )
+        terminal.cursor.x.should eq(7)
+        terminal.cursor.y.should eq(4)
+
+        terminal.clear_events
+        terminal.render
+        terminal.events.should eq(["<flush>"])
+      ensure
+        terminal.try &.close
+      end
+
+      it "clears right-margin pending wrap before the final flush #{suffix}" do
+        terminal = OrderedFrameTerminal.new(sync_updates: sync_updates)
+        terminal.set_cell(0, 0, 'A')
+        terminal.set_cell(1, 0, 'B')
+        terminal.set_cell(2, 0, 'C')
+
+        terminal.render
+
+        terminal.events.should eq(
+          frame_prefix + [OrderedFrameTerminal::CUP, OrderedFrameTerminal::HIDE_CURSOR, "\e[37;49m", "ABC",
+                          OrderedFrameTerminal::CUP, OrderedFrameTerminal::HIDE_CURSOR] + frame_suffix
+        )
+      ensure
+        terminal.try &.close
+      end
+
+      OrderedFrameTerminal::Failure.each do |failure|
+        it "invalidates and retries after a #{failure.to_s.downcase} failure #{suffix}" do
+          terminal = OrderedFrameTerminal.new(sync_updates: sync_updates)
+          terminal.set_cell(0, 0, 'X')
+          terminal.failure = failure
+
+          expect_raises(Exception, "injected #{failure.to_s.downcase} failure") do
+            terminal.render
+          end
+
+          terminal.clear_events
+          terminal.render
+
+          terminal.events.should contain("X  ")
+          terminal.events.last.should eq("<flush>")
+          terminal.events.count("<flush>").should eq(1)
+          terminal.events.includes?(Termisu::Terminal::BSU).should eq(sync_updates)
+          terminal.events.includes?(Termisu::Terminal::ESU).should eq(sync_updates)
+        ensure
+          terminal.try &.close
+        end
+      end
+
+      it "invalidates an established clean frame when its flush fails #{suffix}" do
+        terminal = OrderedFrameTerminal.new(sync_updates: sync_updates)
+        terminal.set_cell(0, 0, 'X')
+        terminal.render
+        terminal.clear_events
+        terminal.failure = OrderedFrameTerminal::Failure::Flush
+
+        expect_raises(Exception, "injected flush failure") { terminal.render }
+
+        terminal.clear_events
+        terminal.render
+        terminal.events.should contain("X  ")
+        terminal.events.last.should eq("<flush>")
+      ensure
+        terminal.try &.close
+      end
+
+      it "never shortcuts an explicit sync #{suffix}" do
+        terminal = OrderedFrameTerminal.new(sync_updates: sync_updates)
+        terminal.render
+        terminal.clear_events
+
+        terminal.sync
+
+        terminal.events.should contain("   ")
+        terminal.events.last.should eq("<flush>")
+        terminal.events.includes?(Termisu::Terminal::BSU).should eq(sync_updates)
+        terminal.events.includes?(Termisu::Terminal::ESU).should eq(sync_updates)
+      ensure
+        terminal.try &.close
+      end
+
+      {"write", "move", "visibility", "flush"}.each do |operation|
+        it "re-establishes after a direct #{operation} failure #{suffix}" do
+          backend = DirectFailureBackend.new
+          terminal = Termisu::Terminal.new(
+            backend: backend,
+            terminfo: OrderedFrameTerminfo.new,
+            sync_updates: sync_updates
+          )
+          terminal.render
+          backend.events.clear
+
+          if operation == "flush"
+            backend.failure = DirectFailureBackend::Failure::Flush
+            expect_raises(Exception, "injected direct flush failure") { terminal.flush }
+          else
+            backend.failure = DirectFailureBackend::Failure::Write
+            expect_raises(Exception, "injected direct write failure") do
+              case operation
+              when "write"      then terminal.write("pending")
+              when "move"       then terminal.move_cursor(1, 0)
+              when "visibility" then terminal.show_cursor
+              end
+            end
+          end
+
+          backend.events.clear
+          terminal.render
+
+          backend.events.should contain("   ")
+          backend.events.should contain(OrderedFrameTerminal::CUP)
+          backend.events.should contain(OrderedFrameTerminal::HIDE_CURSOR)
+          backend.events.last.should eq("<flush>")
+          backend.events.count("<flush>").should eq(1)
+          backend.events.includes?(Termisu::Terminal::BSU).should eq(sync_updates)
+          backend.events.includes?(Termisu::Terminal::ESU).should eq(sync_updates)
+        ensure
+          terminal.try &.close
+        end
+      end
+    end
+  end
+
   describe "#render" do
     it "emits BSU before content and ESU after when sync_updates enabled" do
       terminal = CaptureTerminal.new(sync_updates: true)

--- a/src/termisu/terminal.cr
+++ b/src/termisu/terminal.cr
@@ -30,6 +30,11 @@ class Termisu::Terminal < Termisu::Renderer
   @bracketed_paste : Bool = false
   @sync_updates : Bool = true
   @terminal_closed = Atomic(Bool).new(false)
+
+  # A clean buffer may skip frame control bytes only while its requested cursor
+  # state still matches the state established by a successful render.
+  @established_cursor : Cursor?
+  @buffer_may_be_dirty : Bool = false
   getter cursor : Cursor = Cursor.new
   getter title : String = ""
 
@@ -167,6 +172,7 @@ class Termisu::Terminal < Termisu::Renderer
     @cached_bg = nil
     @cached_attr = Attribute::None
     @cached_attr_known = false
+    @established_cursor = nil
   end
 
   # Precomputed SGR color sequences, indexed by color index.
@@ -461,6 +467,9 @@ class Termisu::Terminal < Termisu::Renderer
   # Delegates flush to backend.
   def flush
     @backend.flush
+  rescue error
+    invalidate_physical_render_state
+    raise error
   end
 
   # Returns the terminal size as {width, height}.
@@ -704,6 +713,11 @@ class Termisu::Terminal < Termisu::Renderer
     error || ex
   end
 
+  private def invalidate_physical_render_state : Nil
+    @buffer.invalidate
+    reset_render_state
+  end
+
   private def lifecycle_log(&) : Nil
     yield
   rescue
@@ -724,7 +738,31 @@ class Termisu::Terminal < Termisu::Renderer
   #
   # Returns false if coordinates are out of bounds.
   # Call render() to display changes on screen.
-  delegate set_cell, to: @buffer
+  def set_cell(
+    x : Int32,
+    y : Int32,
+    grapheme : String,
+    fg : Color = Color.white,
+    bg : Color = Color.default,
+    attr : Attribute = Attribute::None,
+  ) : Bool
+    accepted = @buffer.set_cell(x, y, grapheme, fg, bg, attr)
+    @buffer_may_be_dirty = true if accepted
+    accepted
+  end
+
+  def set_cell(
+    x : Int32,
+    y : Int32,
+    ch : Char,
+    fg : Color = Color.white,
+    bg : Color = Color.default,
+    attr : Attribute = Attribute::None,
+  ) : Bool
+    accepted = @buffer.set_cell(x, y, ch, fg, bg, attr)
+    @buffer_may_be_dirty = true if accepted
+    accepted
+  end
 
   # Gets a cell at the specified position from the buffer.
   #
@@ -737,6 +775,7 @@ class Termisu::Terminal < Termisu::Renderer
   #
   # Call render() to display changes on screen.
   def clear_cells
+    @buffer_may_be_dirty = true
     @buffer.clear
   end
 
@@ -747,10 +786,21 @@ class Termisu::Terminal < Termisu::Renderer
   #
   # When sync_updates is enabled, wraps the render in DEC mode 2026 sequences
   # (BSU/ESU) to prevent screen tearing during rapid updates.
-  def render
-    render_transaction do
-      @buffer.render_to(self, auto_flush: !@sync_updates)
+  def render : Nil
+    if !@buffer_may_be_dirty && @established_cursor == @cursor
+      flush
+      return
     end
+
+    render_transaction do
+      @buffer.render_to(self, auto_flush: false)
+    end
+    @established_cursor = @cursor
+    @buffer_may_be_dirty = false
+    nil
+  rescue error
+    invalidate_physical_render_state
+    raise error
   end
 
   # Forces a full redraw of all cells.
@@ -759,10 +809,16 @@ class Termisu::Terminal < Termisu::Renderer
   #
   # When sync_updates is enabled, wraps the sync in DEC mode 2026 sequences
   # (BSU/ESU) to prevent screen tearing during the full redraw.
-  def sync
+  def sync : Nil
     render_transaction do
-      @buffer.sync_to(self, auto_flush: !@sync_updates)
+      @buffer.sync_to(self, auto_flush: false)
     end
+    @established_cursor = @cursor
+    @buffer_may_be_dirty = false
+    nil
+  rescue error
+    invalidate_physical_render_state
+    raise error
   end
 
   # Keeps Buffer and Terminal caches provisional until every operation around
@@ -778,21 +834,13 @@ class Termisu::Terminal < Termisu::Renderer
     rescue error
       primary_error = error
     ensure
-      # BSU writes can fail after partial output, so attempt ESU even when
-      # beginning the synchronized update raises. If rendering already failed,
-      # preserve that primary error when cleanup fails too.
-      begin
-        end_sync_update
-      rescue exception
-        raise exception unless primary_error
-      end
+      # BSU writes can fail after partial output, so attempt ESU and the final
+      # flush even when beginning or rendering fails. Preserve the first error.
+      primary_error = capture_cleanup_error(primary_error) { end_sync_update }
+      primary_error = capture_cleanup_error(primary_error) { flush }
     end
 
     raise primary_error if primary_error
-  rescue error
-    @buffer.invalidate
-    reset_render_state
-    raise error
   end
 
   # Emits BSU (Begin Synchronized Update) sequence if sync_updates is enabled.
@@ -800,11 +848,10 @@ class Termisu::Terminal < Termisu::Renderer
     write(BSU) if @sync_updates
   end
 
-  # Emits ESU (End Synchronized Update) sequence and flushes if sync_updates is enabled.
+  # Emits ESU (End Synchronized Update) sequence if sync_updates is enabled.
+  # The transaction flushes after cursor restoration and this closing sequence.
   private def end_sync_update
-    return unless @sync_updates
-    write(ESU)
-    flush
+    write(ESU) if @sync_updates
   end
 
   # Invalidates the buffer, forcing a full re-render on next render().
@@ -813,6 +860,7 @@ class Termisu::Terminal < Termisu::Renderer
   # Unlike sync(), this doesn't render immediately - it marks the buffer
   # so the next render() call will redraw everything.
   def invalidate_buffer
+    @established_cursor = nil
     @buffer.invalidate
   end
 
@@ -821,6 +869,7 @@ class Termisu::Terminal < Termisu::Renderer
   # Preserves existing content where possible. Also refreshes the cached
   # size so subsequent size calls reflect the new dimensions.
   def resize(width : Int32, height : Int32)
+    @buffer_may_be_dirty = true
     @cached_size = {width, height}
     @buffer.resize(width, height)
     move_cursor

--- a/src/termisu/terminal/cursor.cr
+++ b/src/termisu/terminal/cursor.cr
@@ -20,8 +20,15 @@ class Termisu::Terminal
     desired = @cursor
     begin
       x, y = desired.x, desired.y
-      @cursor.x, @cursor.y = -1, -1
-      move_cursor(x, y)
+      width, height = size
+      if width > 0 && height > 0
+        @cursor.x, @cursor.y = -1, -1
+        move_cursor(x, y)
+      else
+        # There is no physical position to establish yet. Keep the logical
+        # request intact so a later resize can apply it.
+        @cursor.x, @cursor.y = x, y
+      end
 
       if desired.visible?
         @cursor.visible = false
@@ -42,6 +49,9 @@ class Termisu::Terminal
     return unless @cursor.visible?
     write(@terminfo.hide_cursor_seq)
     @cursor.visible = false
+  rescue error
+    invalidate_physical_render_state
+    raise error
   end
 
   def show_cursor
@@ -49,18 +59,27 @@ class Termisu::Terminal
     write(@terminfo.show_cursor_seq)
     @cursor.visible = true
     write_cursor
+  rescue error
+    invalidate_physical_render_state
+    raise error
   end
 
   def enable_cursor_blink
     return if @cursor.blink?
     @cursor.blink = true
     write_cursor
+  rescue error
+    invalidate_physical_render_state
+    raise error
   end
 
   def disable_cursor_blink
     return unless @cursor.blink?
     @cursor.blink = false
     write_cursor
+  rescue error
+    invalidate_physical_render_state
+    raise error
   end
 
   def cursor_shape=(shape : Cursor::Shape)
@@ -68,6 +87,9 @@ class Termisu::Terminal
     @cursor.shape = shape
     write_cursor
     shape
+  rescue error
+    invalidate_physical_render_state
+    raise error
   end
 
   private def write_cursor
@@ -89,7 +111,13 @@ class Termisu::Terminal
     y : Int32 = @cursor.y,
   )
     width, height = size
-    return if width <= 0 || height <= 0
+    if width <= 0 || height <= 0
+      if x != @cursor.x || y != @cursor.y
+        @cursor.x, @cursor.y = x, y
+        @established_cursor = nil
+      end
+      return
+    end
 
     x = x.clamp(0, width - 1)
     y = y.clamp(0, height - 1)
@@ -108,6 +136,9 @@ class Termisu::Terminal
     end
 
     @cursor.x, @cursor.y = x, y
+  rescue error
+    invalidate_physical_render_state
+    raise error
   end
 
   # Streams the standard CSI cursor-position sequence through the scratch
@@ -136,14 +167,20 @@ class Termisu::Terminal
 
   private def with_ephemeral_cursor(visible : Bool = false, &)
     cursor_backup = @cursor
+    primary_error : Exception? = nil
     @cursor = Cursor.new visible
+
     begin
       apply_cursor_state
       yield
+    rescue error
+      primary_error = error
     ensure
       @cursor = cursor_backup
-      apply_cursor_state
+      primary_error = capture_cleanup_error(primary_error) { apply_cursor_state }
     end
+
+    raise primary_error if primary_error
   end
 
   # Write *data* to the terminal. Use *columns_advanced* to specify how
@@ -152,6 +189,10 @@ class Termisu::Terminal
   def write(data : String, columns_advanced = 0)
     @backend.write(data)
     advance_cursor(columns_advanced)
+    @established_cursor = nil
+  rescue error
+    invalidate_physical_render_state
+    raise error
   end
 
   # Byte overload of `write` for pre-composed escape sequences and batch
@@ -159,6 +200,10 @@ class Termisu::Terminal
   def write(data : Bytes, columns_advanced = 0)
     @backend.write(data)
     advance_cursor(columns_advanced)
+    @established_cursor = nil
+  rescue error
+    invalidate_physical_render_state
+    raise error
   end
 
   private def advance_cursor(columns_advanced : Int32) : Nil


### PR DESCRIPTION
## Rationale

Established clean frames were still emitting the synchronized-update and cursor envelope, while non-synchronized frames flushed before ephemeral cursor restoration. This made clean renders noisier and could leave restoration buffered when `render` returned.

## Design

- Perform one final flush after cursor restoration and the optional ESU sequence.
- Track a conservative established cursor snapshot plus possible buffer dirtiness; only an established, cursor-matching clean `render` skips frame bytes, and it still flushes pending direct writes.
- Never shortcut `sync`; reset establishment after direct output or resets, invalidate the buffer after write/flush/render failure for a full retry, and preserve first-error cleanup behavior.
- Preserve zero-sized cursor requests and force re-establishment after public cursor mutation. No public helper API is added.

## Correctness coverage

Exact ordered write/byte/flush captures cover synchronized updates on/off, dirty and first/second clean frames, visible/hidden and mutated cursors, pending direct writes, resets, zero size, right-margin pending wrap, explicit sync, and injected content/restoration/final-flush failures. Direct write, move, visibility, and flush failures are also followed by full render retries.

## Evidence

- Crystal 1.21.0 full core suite: 1,399 examples, 0 failures/errors, 1 pending
- Crystal 1.17.0 full core suite: 1,399 examples, 0 failures/errors, 1 pending
- Focused terminal/buffer suite: 241 examples, 0 failures/errors
- Focused ordering suite on Crystal 1.21.0 and 1.17.0: 58 examples each, 0 failures/errors
- Ameba: 161 files, 0 failures; Crystal format and `git diff --check` passed
- PTY E2E: 82 examples, 0 failures/errors
- C ABI build/native tests passed; C format/lint passed
- Bun 1.4.0: check and typecheck passed; 48 tests passed

Linux PTY/strace probe (80x24 xterm, one dirty render followed by 1,000 established clean renders), repeated five times: each run emitted 49 tty bytes in one tty `write` syscall. Deterministic captures separately show 0 frame bytes for an established clean render and 40/24 bytes for the first clean render with synchronized updates on/off. The syscall observation is Linux/workload-specific; no portable timing claim is made.
