### PR TITLE
fix: serialize terminal mode scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,26 @@ termisu.with_mode(mode) { }       # Custom mode
 - `preserve_screen: true` - Stay in alternate screen (overlay mode)
 - `preserve_screen: false` - Exit alternate screen (shell-out mode)
 
+#### Fiber ownership
+
+Mode scopes may be nested in the same fiber. Across fibers, Termisu serializes the
+entire scope: snapshot, transition, user block, and restoration all finish before
+the next fiber enters. `close` called from another fiber waits for an active scope
+to restore, then rejects scopes that were queued when closing began. Calling
+`close` from the fiber that owns a mode scope is rejected before teardown; close
+the instance after the block returns instead.
+
+Because ownership is held while your block runs, do not wait inside a mode block
+for another fiber to enter a mode scope or close the same `Termisu` or `Terminal`.
+Those are prohibited wait cycles: the other fiber cannot proceed until the first
+block returns. Coordinate unrelated work outside the mode scope instead.
+
+The facade mode gate is held while its input-pause depth is updated and while the
+terminal mode gate runs. The input lock is never held while waiting for the
+terminal gate or running user code. Close uses each mode gate only as a barrier
+and releases it before stopping or joining event sources. Applications should
+use the scoped APIs rather than coordinating these ownership domains themselves.
+
 ### Colors
 
 ```crystal

--- a/docs-web/content/guide/terminal-modes.md
+++ b/docs-web/content/guide/terminal-modes.md
@@ -36,3 +36,16 @@ end
 ```
 
 Mode transitions emit `Event::ModeChange` events.
+
+## Fiber Ownership
+
+Mode scopes are reentrant in the calling fiber, so same-fiber nesting is safe.
+A scope started by another fiber waits for the active scope's user block and
+restoration to finish. Closing from another fiber waits for restoration and
+prevents queued scopes from entering. Closing from inside the owning mode block
+is rejected before teardown; close the instance after the block returns.
+
+Do not wait inside a mode block for another fiber to enter a mode scope or close
+the same `Termisu` or `Terminal`. The first fiber owns the mode until its block
+returns, so those cross-fiber wait cycles cannot complete. Coordinate that work
+before entering or after leaving the mode scope.

--- a/spec/e2e/pty_spec.cr
+++ b/spec/e2e/pty_spec.cr
@@ -10,12 +10,14 @@ describe Termisu::Testing::Pty do
     Termisu::Testing.terminal(
       "bin/input-ownership-fixture",
       cols: 80,
-      rows: 11,
+      rows: 13,
       env: {"TERM" => "xterm-256color"},
     ) do |term|
       term.get_by_text("LEASE REQUIRED").should be_true
       term.get_by_text("COOKED RAW OK").should be_true
       term.get_by_text("RAW COOKED OK").should be_true
+      term.get_by_text("CROSSED MODES OK").should be_true
+      term.get_by_text("SCOPE CLOSE OK").should be_true
       term.get_by_text("PROBE READY").should be_true
 
       term.write("\e[200~")
@@ -32,8 +34,8 @@ describe Termisu::Testing::Pty do
 
       term.write("z")
       term.get_by_text("EVENT z").should be_true
-      term.row(9).rstrip.should eq("EVENT READY")
-      term.row(10).rstrip.should eq("EVENT z")
+      term.row(11).rstrip.should eq("EVENT READY")
+      term.row(12).rstrip.should eq("EVENT z")
     end
   end
 

--- a/spec/termisu/terminal_spec.cr
+++ b/spec/termisu/terminal_spec.cr
@@ -427,6 +427,174 @@ describe Termisu::Terminal do
       terminal.try &.close
     end
 
+    it "serializes crossed scopes and restores all terminal state" do
+      terminal = CaptureTerminal.new(sync_updates: false)
+      terminal.mode = Termisu::Terminal::Mode.raw
+      terminal.enter_alternate_screen
+      terminal.enable_mouse
+      terminal.enable_bracketed_paste
+      terminal.move_cursor(7, 4)
+      terminal.hide_cursor
+
+      first_entered = Channel(Nil).new
+      release_first = Channel(Nil).new
+      first_done = Channel(Exception?).new(1)
+      second_started = Channel(Nil).new
+      second_entered = Channel(Nil).new(1)
+      release_second = Channel(Nil).new
+      second_done = Channel(Exception?).new(1)
+
+      spawn do
+        error = nil.as(Exception?)
+        begin
+          terminal.with_mode(Termisu::Terminal::Mode.cooked, preserve_screen: true) do
+            first_entered.send(nil)
+            release_first.receive
+            terminal.current_mode.should eq(Termisu::Terminal::Mode.cooked)
+          end
+        rescue ex
+          error = ex
+        ensure
+          first_done.send(error)
+        end
+      end
+
+      first_entered.receive
+      spawn do
+        error = nil.as(Exception?)
+        begin
+          second_started.send(nil)
+          terminal.with_mode(Termisu::Terminal::Mode.password, preserve_screen: true) do
+            second_entered.send(nil)
+            release_second.receive
+          end
+        rescue ex
+          error = ex
+        ensure
+          second_done.send(error)
+        end
+      end
+
+      # The rendezvous and yield let the second fiber reach the scope gate.
+      # It must not change any state until the first scope has restored.
+      second_started.receive
+      Fiber.yield
+      terminal.current_mode.should eq(Termisu::Terminal::Mode.cooked)
+      select
+      when second_entered.receive
+        fail "cross-fiber mode scope entered before the active scope restored"
+      else
+      end
+
+      release_first.send(nil)
+      first_done.receive.should be_nil
+      second_entered.receive
+      terminal.current_mode.should eq(Termisu::Terminal::Mode.password)
+      release_second.send(nil)
+      second_done.receive.should be_nil
+
+      terminal.current_mode.should eq(Termisu::Terminal::Mode.raw)
+      terminal.alternate_screen?.should be_true
+      terminal.mouse_enabled?.should be_true
+      terminal.bracketed_paste?.should be_true
+      terminal.cursor.x.should eq(7)
+      terminal.cursor.y.should eq(4)
+      terminal.cursor.visible?.should be_false
+    ensure
+      terminal.try &.close
+    end
+
+    it "lets close finish the active scope and reject a queued scope" do
+      terminal = LoggingLifecycleTerminal.new(sync_updates: false)
+      terminal.enable_raw_mode
+      active_entered = Channel(Nil).new
+      release_active = Channel(Nil).new
+      active_done = Channel(Exception?).new(1)
+      queued_started = Channel(Nil).new
+      queued_ran = Atomic(Bool).new(false)
+      queued_done = Channel(Exception?).new(1)
+      close_done = Channel(Exception?).new(1)
+
+      spawn do
+        error = nil.as(Exception?)
+        begin
+          terminal.with_mode(Termisu::Terminal::Mode.cooked, preserve_screen: true) do
+            active_entered.send(nil)
+            release_active.receive
+          end
+        rescue ex
+          error = ex
+        ensure
+          active_done.send(error)
+        end
+      end
+
+      active_entered.receive
+      spawn do
+        error = nil.as(Exception?)
+        begin
+          queued_started.send(nil)
+          terminal.with_mode(Termisu::Terminal::Mode.password, preserve_screen: true) do
+            queued_ran.set(true)
+          end
+        rescue ex
+          error = ex
+        ensure
+          queued_done.send(error)
+        end
+      end
+      queued_started.receive
+      Fiber.yield
+
+      spawn do
+        error = nil.as(Exception?)
+        begin
+          terminal.close
+        rescue ex
+          error = ex
+        ensure
+          close_done.send(error)
+        end
+      end
+      until terminal.@terminal_closed.get
+        Fiber.yield
+      end
+
+      select
+      when close_done.receive
+        fail "close returned before the active mode scope restored"
+      else
+      end
+
+      release_active.send(nil)
+      active_done.receive.should be_nil
+      queued_done.receive.should be_a(IO::Error)
+      queued_ran.get.should be_false
+      close_done.receive.should be_nil
+    ensure
+      terminal.try &.close
+    end
+
+    it "rejects same-fiber close before teardown and restores the scope" do
+      terminal = LoggingLifecycleTerminal.new(sync_updates: false)
+      terminal.enable_raw_mode
+
+      terminal.with_mode(Termisu::Terminal::Mode.cooked, preserve_screen: true) do
+        expect_raises(IO::Error, "cannot close Terminal from inside") do
+          terminal.close
+        end
+        terminal.current_mode.should eq(Termisu::Terminal::Mode.cooked)
+        terminal.@terminal_closed.get.should be_false
+      end
+
+      terminal.current_mode.should eq(Termisu::Terminal::Mode.raw)
+      terminal.@terminal_closed.get.should be_false
+      terminal.close
+      terminal.@terminal_closed.get.should be_true
+    ensure
+      terminal.try &.close
+    end
+
     it "defaults to raw mode when no previous mode was set" do
       terminal = CaptureTerminal.new
       terminal.current_mode.should be_nil

--- a/spec/termisu_spec.cr
+++ b/spec/termisu_spec.cr
@@ -79,6 +79,59 @@ private class CloseDuringRestartInputSource < PausableInputSource
   end
 end
 
+# Event source whose worker enters a mode scope and whose stop synchronously
+# joins that worker. This exercises the close lock order: close must not retain
+# the facade mode gate while Event::Loop#stop joins a source queued on it.
+private class JoiningModeSource < Termisu::Event::Source
+  @running = Atomic(Bool).new(false)
+  @termisu : Termisu? = nil
+  @trigger = Channel(Nil).new
+  @attempting = Channel(Nil).new
+  @done = Channel(Nil).new
+
+  def termisu=(termisu : Termisu) : Termisu
+    @termisu = termisu
+  end
+
+  def start(output : Channel(Termisu::Event::Any)) : Nil
+    _ = output
+    return unless @running.compare_and_set(false, true)[1]
+
+    spawn do
+      @trigger.receive
+      @attempting.send(nil)
+      if termisu = @termisu
+        termisu.with_mode(Termisu::Terminal::Mode.raw) { }
+      else
+        raise "joining mode source has no Termisu instance"
+      end
+    rescue Termisu::Error
+      # Close began before the queued scope entered, so rejection is expected.
+    ensure
+      @running.set(false)
+      @done.close
+    end
+  end
+
+  def enter_mode : Nil
+    @trigger.send(nil)
+    @attempting.receive
+  end
+
+  def stop : Nil
+    @running.set(false)
+    @done.receive?
+  end
+
+  def running? : Bool
+    @running.get
+  end
+
+  def name : String
+    "joining-mode"
+  end
+end
+
 private class FailingStopEventLoop < Termisu::Event::Loop
   getter stop_count : Int32 = 0
 
@@ -160,6 +213,7 @@ class Termisu
     @ownership = TerminalOwnership.acquire
     @closed = Atomic(Bool).new(false)
     @timer_source = nil
+    @mode_scope_gate = ModeScopeGate.new
     @input_ownership_lock = Mutex.new
     @raw_input_owner = nil
     @raw_input_depth = 0
@@ -290,6 +344,193 @@ describe Termisu do
       LibC.close(write_fd) if write_fd
     end
 
+    it "waits for an active mode scope and rejects queued scopes" do
+      read_fd, write_fd = create_pipe
+      reader = Termisu::Reader.new(read_fd)
+      parser = Termisu::Input::Parser.new(reader)
+      input_source = PausableInputSource.new(reader, parser)
+      resize_source = Termisu::Event::Source::Resize.new(-> { {80, 24} })
+      event_loop = Termisu::Event::Loop.new
+      terminal = CaptureTerminal.new(sync_updates: false)
+      terminal.mode = Termisu::Terminal::Mode.raw
+      termisu = Termisu.new(terminal, reader, parser, input_source, resize_source, event_loop)
+      event_loop.add_source(input_source).start
+
+      active_entered = Channel(Nil).new
+      release_active = Channel(Nil).new
+      active_done = Channel(Exception?).new(1)
+      queued_started = Channel(Nil).new
+      queued_ran = Atomic(Bool).new(false)
+      queued_done = Channel(Exception?).new(1)
+      close_done = Channel(Exception?).new(1)
+
+      spawn do
+        error = nil.as(Exception?)
+        begin
+          termisu.with_cooked_mode(preserve_screen: true) do
+            active_entered.send(nil)
+            release_active.receive
+          end
+        rescue ex
+          error = ex
+        ensure
+          active_done.send(error)
+        end
+      end
+      active_entered.receive
+
+      spawn do
+        error = nil.as(Exception?)
+        begin
+          queued_started.send(nil)
+          termisu.with_password_mode(preserve_screen: true) do
+            queued_ran.set(true)
+          end
+        rescue ex
+          error = ex
+        ensure
+          queued_done.send(error)
+        end
+      end
+      queued_started.receive
+      Fiber.yield
+
+      spawn do
+        error = nil.as(Exception?)
+        begin
+          termisu.close
+        rescue ex
+          error = ex
+        ensure
+          close_done.send(error)
+        end
+      end
+      until termisu.@closed.get
+        Fiber.yield
+      end
+
+      select
+      when close_done.receive
+        fail "close returned before the active mode scope restored"
+      else
+      end
+
+      release_active.send(nil)
+      active_done.receive.should be_nil
+      queued_done.receive.should be_a(Termisu::Error)
+      queued_ran.get.should be_false
+      close_done.receive.should be_nil
+      # One transition stop plus Event::Loop's idempotent shutdown stop.
+      input_source.stop_count.should eq(2)
+      input_source.start_count.should eq(1)
+      event_loop.output.closed?.should be_true
+    ensure
+      termisu.try &.close
+      reader.try &.close
+      LibC.close(read_fd) if read_fd
+      LibC.close(write_fd) if write_fd
+    end
+
+    it "releases the mode barrier before joining an event source queued on it" do
+      read_fd, write_fd = create_pipe
+      reader = Termisu::Reader.new(read_fd)
+      parser = Termisu::Input::Parser.new(reader)
+      input_source = PausableInputSource.new(reader, parser)
+      resize_source = Termisu::Event::Source::Resize.new(-> { {80, 24} })
+      joining_source = JoiningModeSource.new
+      event_loop = Termisu::Event::Loop.new
+      terminal = CaptureTerminal.new(sync_updates: false)
+      terminal.mode = Termisu::Terminal::Mode.raw
+      termisu = Termisu.new(terminal, reader, parser, input_source, resize_source, event_loop)
+      joining_source.termisu = termisu
+      event_loop.add_source(input_source).add_source(joining_source).start
+
+      active_entered = Channel(Nil).new
+      release_active = Channel(Nil).new
+      active_done = Channel(Exception?).new(1)
+      close_done = Channel(Exception?).new(1)
+
+      spawn do
+        error = nil.as(Exception?)
+        begin
+          termisu.with_cooked_mode(preserve_screen: true) do
+            active_entered.send(nil)
+            release_active.receive
+          end
+        rescue ex
+          error = ex
+        ensure
+          active_done.send(error)
+        end
+      end
+      active_entered.receive
+
+      spawn do
+        error = nil.as(Exception?)
+        begin
+          termisu.close
+        rescue ex
+          error = ex
+        ensure
+          close_done.send(error)
+        end
+      end
+      until termisu.@closed.get
+        Fiber.yield
+      end
+
+      # Queue the source behind close while the first scope still owns the gate.
+      # Its synchronous stop will join this same worker.
+      joining_source.enter_mode
+      Fiber.yield
+      release_active.send(nil)
+      active_done.receive.should be_nil
+
+      select
+      when error = close_done.receive
+        error.should be_nil
+      when timeout(2.seconds)
+        fail "close retained the mode gate while joining its event source"
+      end
+      event_loop.output.closed?.should be_true
+    ensure
+      termisu.try &.close
+      reader.try &.close
+      LibC.close(read_fd) if read_fd
+      LibC.close(write_fd) if write_fd
+    end
+
+    it "rejects same-fiber close before teardown and restores the scope" do
+      read_fd, write_fd = create_pipe
+      reader = Termisu::Reader.new(read_fd)
+      parser = Termisu::Input::Parser.new(reader)
+      input_source = PausableInputSource.new(reader, parser)
+      resize_source = Termisu::Event::Source::Resize.new(-> { {80, 24} })
+      event_loop = Termisu::Event::Loop.new
+      terminal = CaptureTerminal.new(sync_updates: false)
+      terminal.mode = Termisu::Terminal::Mode.raw
+      termisu = Termisu.new(terminal, reader, parser, input_source, resize_source, event_loop)
+      event_loop.add_source(input_source).start
+
+      termisu.with_cooked_mode(preserve_screen: true) do
+        expect_raises(Termisu::Error, "cannot close Termisu from inside") do
+          termisu.close
+        end
+        termisu.current_mode.should eq(Termisu::Terminal::Mode.cooked)
+        termisu.@closed.get.should be_false
+      end
+
+      termisu.current_mode.should eq(Termisu::Terminal::Mode.raw)
+      input_source.running?.should be_true
+      termisu.close
+      event_loop.output.closed?.should be_true
+    ensure
+      termisu.try &.close
+      reader.try &.close
+      LibC.close(read_fd) if read_fd
+      LibC.close(write_fd) if write_fd
+    end
+
     it "preserves the first failure while completing cleanup and releasing ownership" do
       read_fd, write_fd = create_pipe
       reader = Termisu::Reader.new(read_fd)
@@ -345,6 +586,84 @@ describe Termisu do
   end
 
   describe "#with_mode" do
+    it "serializes crossed cooked and password scopes across fibers" do
+      read_fd, write_fd = create_pipe
+      reader = Termisu::Reader.new(read_fd)
+      parser = Termisu::Input::Parser.new(reader)
+      input_source = PausableInputSource.new(reader, parser)
+      resize_source = Termisu::Event::Source::Resize.new(-> { {80, 24} })
+      event_loop = Termisu::Event::Loop.new
+      terminal = CaptureTerminal.new(sync_updates: false)
+      terminal.mode = Termisu::Terminal::Mode.raw
+      termisu = Termisu.new(terminal, reader, parser, input_source, resize_source, event_loop)
+      input_source.start(event_loop.output)
+
+      cooked_entered = Channel(Nil).new
+      release_cooked = Channel(Nil).new
+      cooked_done = Channel(Exception?).new(1)
+      password_started = Channel(Nil).new
+      password_entered = Channel(Nil).new(1)
+      release_password = Channel(Nil).new
+      password_done = Channel(Exception?).new(1)
+
+      spawn do
+        error = nil.as(Exception?)
+        begin
+          termisu.with_cooked_mode(preserve_screen: true) do
+            cooked_entered.send(nil)
+            release_cooked.receive
+            termisu.current_mode.should eq(Termisu::Terminal::Mode.cooked)
+          end
+        rescue ex
+          error = ex
+        ensure
+          cooked_done.send(error)
+        end
+      end
+      cooked_entered.receive
+
+      spawn do
+        error = nil.as(Exception?)
+        begin
+          password_started.send(nil)
+          termisu.with_password_mode(preserve_screen: true) do
+            password_entered.send(nil)
+            release_password.receive
+          end
+        rescue ex
+          error = ex
+        ensure
+          password_done.send(error)
+        end
+      end
+      password_started.receive
+      Fiber.yield
+
+      termisu.current_mode.should eq(Termisu::Terminal::Mode.cooked)
+      input_source.running?.should be_false
+      select
+      when password_entered.receive
+        fail "password scope entered before cooked scope restored"
+      else
+      end
+
+      release_cooked.send(nil)
+      cooked_done.receive.should be_nil
+      password_entered.receive
+      termisu.current_mode.should eq(Termisu::Terminal::Mode.password)
+      release_password.send(nil)
+      password_done.receive.should be_nil
+
+      termisu.current_mode.should eq(Termisu::Terminal::Mode.raw)
+      input_source.running?.should be_true
+      input_source.stop_count.should eq(2)
+      input_source.start_count.should eq(3)
+    ensure
+      termisu.try &.close
+      LibC.close(read_fd) if read_fd
+      LibC.close(write_fd) if write_fd
+    end
+
     it "pauses input for single and combined non-raw modes, but not raw mode" do
       read_fd, write_fd = create_pipe
       reader = Termisu::Reader.new(read_fd)
@@ -393,20 +712,37 @@ describe Termisu do
       termisu = Termisu.new(terminal, reader, parser, input_source, resize_source, event_loop)
       input_source.start(event_loop.output)
 
-      termisu.with_mode(Termisu::Terminal::Mode.cooked, preserve_screen: true) do
+      result = termisu.with_mode(Termisu::Terminal::Mode.cooked, preserve_screen: true) do
         input_source.running?.should be_false
 
-        termisu.with_mode(Termisu::Terminal::Mode.password, preserve_screen: true) do
+        nested_result = termisu.with_mode(
+          Termisu::Terminal::Mode.password,
+          preserve_screen: true,
+        ) do
           input_source.running?.should be_false
+          42
         end
+        nested_result.should eq(42)
 
         input_source.running?.should be_false
         input_source.start_count.should eq(1)
-        input_source.stop_count.should eq(2)
+        input_source.stop_count.should eq(1)
+        "outer result"
       end
 
+      result.should eq("outer result")
       input_source.running?.should be_true
       input_source.start_count.should eq(2)
+      input_source.stop_count.should eq(1)
+
+      expect_raises(Exception, "mode block failed") do
+        termisu.with_mode(Termisu::Terminal::Mode.cooked, preserve_screen: true) do
+          raise "mode block failed"
+        end
+      end
+      termisu.current_mode.should eq(Termisu::Terminal::Mode.raw)
+      input_source.running?.should be_true
+      input_source.start_count.should eq(3)
       input_source.stop_count.should eq(2)
     ensure
       termisu.try &.close
@@ -448,7 +784,12 @@ describe Termisu do
 
         termisu.input_available?.should be_true
         termisu.read_bytes(2).should eq("AB".to_slice)
+        input_source.stop_count.should eq(1)
+        input_source.start_count.should eq(1)
       end
+
+      input_source.stop_count.should eq(1)
+      input_source.start_count.should eq(2)
     ensure
       termisu.try &.close
       LibC.close(read_fd) if read_fd
@@ -483,7 +824,7 @@ describe Termisu do
 
         mode_entered.receive
         input_source.running?.should be_false
-        input_source.stop_count.should eq(2)
+        input_source.stop_count.should eq(1)
       end
 
       input_source.running?.should be_false
@@ -494,7 +835,7 @@ describe Termisu do
 
       input_source.running?.should be_true
       input_source.start_count.should eq(2)
-      input_source.stop_count.should eq(2)
+      input_source.stop_count.should eq(1)
     ensure
       termisu.try &.close
       LibC.close(read_fd) if read_fd

--- a/src/termisu.cr
+++ b/src/termisu.cr
@@ -32,6 +32,7 @@ class Termisu
   @resize_source : Event::Source::Resize
   @event_loop : Event::Loop
   @timer_source : Event::Source::Timer | Event::Source::SystemTimer | Nil
+  @mode_scope_gate : ModeScopeGate
   @input_ownership_lock : Mutex
   @raw_input_owner : Fiber?
   @raw_input_depth : Int32
@@ -54,6 +55,7 @@ class Termisu
   def initialize(*, sync_updates : Bool = true)
     @ownership = TerminalOwnership.acquire
     @closed = Atomic(Bool).new(false)
+    @mode_scope_gate = ModeScopeGate.new
     @input_ownership_lock = Mutex.new
     @raw_input_owner = nil
     @raw_input_depth = 0
@@ -165,10 +167,21 @@ class Termisu
   # The event loop is stopped first to ensure fibers that might be using
   # the reader are terminated before the reader is closed.
   def close
+    if @mode_scope_gate.owned_by_current_fiber?
+      raise Termisu::Error.new("cannot close Termisu from inside its terminal mode scope")
+    end
+
+    # Mark closing while holding the input lock so an in-flight raw lease
+    # release either finishes its restart first or observes the closed state.
     won_close = @input_ownership_lock.synchronize do
       @closed.compare_and_set(false, true)[1]
     end
     return unless won_close
+
+    # Use the mode gate only as a barrier. Once the active scope restores, the
+    # closed flag rejects every queued/new scope, so teardown must not retain
+    # the gate while synchronously stopping and joining event-source fibers.
+    @mode_scope_gate.synchronize { }
 
     lifecycle_log { Log.info { "Closing Termisu" } }
 
@@ -315,13 +328,18 @@ class Termisu
     fiber = Fiber.current
 
     @input_ownership_lock.synchronize do
+      raise InputOwnershipError.new("raw input cannot be leased after Termisu is closed") if @closed.get
+
       if owner = @raw_input_owner
         unless owner.same?(fiber)
           raise InputOwnershipError.new("raw input is already leased by another fiber")
         end
         @raw_input_depth += 1
       else
-        @input_source.stop
+        # Raw ownership and mode scopes share one parser-pause depth. The first
+        # owner stops the parser; overlap in either direction only increments
+        # the depth and cannot produce a second stop/restart cycle.
+        @input_source.stop if @input_pause_depth == 0
         unless @input_source.prepare_raw_handoff
           start_input_processing_if_unpaused
           raise InputOwnershipError.new(
@@ -332,6 +350,7 @@ class Termisu
 
         @raw_input_owner = fiber
         @raw_input_depth = 1
+        @input_pause_depth += 1
       end
     end
 
@@ -389,6 +408,7 @@ class Termisu
       return unless @raw_input_depth == 0
 
       @raw_input_owner = nil
+      @input_pause_depth -= 1
       start_input_processing_if_unpaused
     end
   end
@@ -767,6 +787,13 @@ class Termisu
 
   # Executes a block with specific terminal mode, restoring previous mode after.
   #
+  # Mode scopes are fiber-reentrant: nesting in the calling fiber is supported.
+  # Scopes entered by other fibers wait until the complete active scope,
+  # including its user block and restoration, has returned. Consequently, a
+  # mode block must not wait for another fiber to enter a mode scope or close
+  # this instance; those wait cycles cannot complete. Calling close directly
+  # from the owning block is rejected before teardown.
+  #
   # This is the recommended way to temporarily switch modes for operations
   # like shell-out or password input. Handles:
   # - Event loop coordination (pauses input for user-interactive modes)
@@ -786,29 +813,31 @@ class Termisu
   # # Terminal state fully restored
   # ```
   def with_mode(mode : Terminal::Mode, preserve_screen : Bool = false, &)
-    Log.debug { "Termisu.with_mode: #{mode}, preserve_screen: #{preserve_screen}" }
+    @mode_scope_gate.synchronize do
+      raise Termisu::Error.new("cannot enter a terminal mode scope after Termisu is closed") if @closed.get
 
-    # Terminal::Mode.raw uses the zero-valued None member, so every other mode
-    # needs input processing paused to avoid conflicts between our input reader
-    # and direct STDIN access. Every non-raw scope participates in pause-depth
-    # accounting so overlapping raw leases cannot restart input prematurely.
-    owns_input_pause = mode != Terminal::Mode::None
-    previous_mode = @terminal.current_mode
+      Log.debug { "Termisu.with_mode: #{mode}, preserve_screen: #{preserve_screen}" }
 
-    # Pause input processing to avoid conflict with shell/external program.
-    # Nested and overlapping non-raw scopes each own one pause-depth entry.
-    pause_input_processing if owns_input_pause
+      # Terminal::Mode.raw uses the zero-valued None member, so every other mode
+      # needs input processing paused to avoid conflicts between our input reader
+      # and direct STDIN access.
+      owns_input_pause = mode != Terminal::Mode::None
+      previous_mode = @terminal.current_mode
+      pause_input_processing if owns_input_pause
 
-    @terminal.with_mode(mode, preserve_screen) do
-      emit_mode_change(mode, previous_mode)
-      yield
+      begin
+        @terminal.with_mode(mode, preserve_screen) do
+          emit_mode_change(mode, previous_mode)
+          yield
+        end
+      ensure
+        # Emit event for restoration (back to previous mode or raw default).
+        restored_mode = @terminal.current_mode
+        emit_mode_change(restored_mode, mode) if restored_mode
+        resume_input_processing if owns_input_pause
+        Log.debug { "Termisu.with_mode: restored" }
+      end
     end
-  ensure
-    # Emit event for restoration (back to previous mode or raw default)
-    restored_mode = @terminal.current_mode
-    emit_mode_change(restored_mode, mode) if restored_mode
-    resume_input_processing if owns_input_pause
-    Log.debug { "Termisu.with_mode: restored" }
   end
 
   # Executes a block with cooked (shell-like) mode.
@@ -906,28 +935,35 @@ class Termisu
 
   # Pauses input processing for mode transitions.
   #
-  # Stops the input source and clears any pending event input to avoid conflicts
-  # when switching to user-interactive modes. Buffered input is preserved if a
-  # raw lease acquired ownership while mode scopes overlapped across fibers.
+  # Stop and clear are edge-triggered. Nested mode scopes and overlapping raw
+  # leases only increase the shared depth, leaving the parser quiesced once.
   private def pause_input_processing
     Log.debug { "Pausing input processing" }
     @input_ownership_lock.synchronize do
-      @input_source.stop
+      if @input_pause_depth == 0
+        @input_source.stop
+        @reader.clear_buffer if @raw_input_owner.nil?
+      end
       @input_pause_depth += 1
-      @reader.clear_buffer if @raw_input_owner.nil?
     end
   end
 
   # Resumes input processing after mode transitions.
   #
-  # Clears stale event input and restarts the input source only after every mode
-  # pause and raw lease has ended. An active raw owner's buffer is left intact.
+  # Clears stale direct input and restarts the parser only on the final 1 -> 0
+  # transition. An active raw owner's buffer is always left intact.
   private def resume_input_processing
     Log.debug { "Resuming input processing" }
     @input_ownership_lock.synchronize do
-      @reader.clear_buffer if @raw_input_owner.nil?
-      @input_pause_depth -= 1 if @input_pause_depth > 0
-      start_input_processing_if_unpaused
+      return if @input_pause_depth == 0
+
+      if @input_pause_depth == 1
+        @reader.clear_buffer if @raw_input_owner.nil?
+        @input_pause_depth = 0
+        start_input_processing_if_unpaused
+      else
+        @input_pause_depth -= 1
+      end
     end
   end
 

--- a/src/termisu/mode_scope_gate.cr
+++ b/src/termisu/mode_scope_gate.cr
@@ -1,0 +1,69 @@
+# Fiber-reentrant ownership gate for terminal mode scopes.
+#
+# The owner and recursion depth here are the only mode-scope ownership state.
+# The ordinary mutex only protects that state; waiters park cooperatively on
+# channels instead of blocking a scheduler thread.
+class Termisu::ModeScopeGate
+  @state_lock = Mutex.new
+  @owner : Fiber? = nil
+  @depth : Int32 = 0
+  @waiters = Deque({Fiber, Channel(Nil)}).new
+
+  def synchronize(&)
+    acquire
+    begin
+      yield
+    ensure
+      release
+    end
+  end
+
+  def owned_by_current_fiber? : Bool
+    @state_lock.synchronize do
+      @owner.try(&.same?(Fiber.current)) || false
+    end
+  end
+
+  private def acquire : Nil
+    fiber = Fiber.current
+    ready = nil.as(Channel(Nil)?)
+
+    @state_lock.synchronize do
+      if @owner.try(&.same?(fiber))
+        @depth += 1
+      elsif @owner.nil?
+        @owner = fiber
+        @depth = 1
+      else
+        channel = Channel(Nil).new(1)
+        ready = channel
+        @waiters << {fiber, channel}
+      end
+    end
+
+    ready.try(&.receive)
+  end
+
+  private def release : Nil
+    ready = nil.as(Channel(Nil)?)
+
+    @state_lock.synchronize do
+      unless @owner.try(&.same?(Fiber.current))
+        raise Termisu::Error.new("mode scope gate released by a fiber that does not own it")
+      end
+
+      @depth -= 1
+      return unless @depth == 0
+
+      if waiter = @waiters.shift?
+        @owner = waiter[0]
+        @depth = 1
+        ready = waiter[1]
+      else
+        @owner = nil
+      end
+    end
+
+    ready.try(&.send(nil))
+  end
+end

--- a/src/termisu/terminal.cr
+++ b/src/termisu/terminal.cr
@@ -29,6 +29,7 @@ class Termisu::Terminal < Termisu::Renderer
   @enhanced_keyboard : Bool = false
   @bracketed_paste : Bool = false
   @sync_updates : Bool = true
+  @mode_scope_gate = ModeScopeGate.new
   @terminal_closed = Atomic(Bool).new(false)
   getter cursor : Cursor = Cursor.new
   getter title : String = ""
@@ -543,6 +544,12 @@ class Termisu::Terminal < Termisu::Renderer
 
   # Executes a block with specific terminal mode, restoring previous mode after.
   #
+  # Mode scopes may nest in the same fiber. A scope in another fiber waits for
+  # the active scope's user block and complete restoration. A mode block must
+  # therefore not wait for another fiber to enter a mode scope or close this
+  # terminal; those cross-fiber wait cycles cannot complete. Calling close
+  # directly from the owning block is rejected before teardown.
+  #
   # This is the recommended way to temporarily switch modes for operations
   # like shell-out or password input. Handles:
   # - Mode switching via Backend
@@ -562,66 +569,73 @@ class Termisu::Terminal < Termisu::Renderer
   # # Previous mode and screen state restored
   # ```
   def with_mode(mode : Terminal::Mode, preserve_screen : Bool = false, &)
-    lifecycle_log { Log.debug { "Entering with_mode: #{mode}, preserve_screen: #{preserve_screen}" } }
-    user_interactive = mode.canonical? || mode.echo?
+    @mode_scope_gate.synchronize do
+      raise IO::Error.new("Terminal is closed") if @terminal_closed.get
 
-    # Track state to restore
-    was_in_alternate = @alternate_screen
-    was_mouse_enabled = @mouse_enabled
-    was_bracketed_paste = @bracketed_paste
+      lifecycle_log { Log.debug { "Entering with_mode: #{mode}, preserve_screen: #{preserve_screen}" } }
+      user_interactive = mode.canonical? || mode.echo?
 
-    # Mouse off before the block gets the tty, restored in the `ensure` from the local
-    # above. The block hands fd 0 to another program — an editor, a shell, a pager — and
-    # with tracking still on the emulator writes `\e[<0;40;12M` into THAT program's stdin
-    # on every click. A pager shows garbage; an editor inserts the bytes into the buffer
-    # being edited, which for anything editing wire-exact data is corruption.
-    #
-    # Must be the first thing written for the switch: neither the cursor writes below nor
-    # exit_alternate_screen are guaranteed to flush on every path. Clearing the flag is
-    # what makes nesting safe — an inner `with_mode` then sees it already off and its
-    # restore cannot re-enable reporting while this block still owns the tty.
-    if was_mouse_enabled
-      apply_mouse_state false
-      flush
-      @mouse_enabled = false
+      # Track state to restore while holding the scope lock. The same lock stays
+      # held through transition, user code, and restoration.
+      was_in_alternate = @alternate_screen
+      was_mouse_enabled = @mouse_enabled
+      was_bracketed_paste = @bracketed_paste
+      backup_cursor = @cursor
+
+      begin
+        # Mouse off before the block gets the tty, restored in the `ensure` from the local
+        # above. The block hands fd 0 to another program — an editor, a shell, a pager — and
+        # with tracking still on the emulator writes `\e[<0;40;12M` into THAT program's stdin
+        # on every click. A pager shows garbage; an editor inserts the bytes into the buffer
+        # being edited, which for anything editing wire-exact data is corruption.
+        #
+        # Must be the first thing written for the switch: neither the cursor writes below nor
+        # exit_alternate_screen are guaranteed to flush on every path. Clearing the flag is
+        # what makes nesting safe — an inner `with_mode` then sees it already off and its
+        # restore cannot re-enable reporting while this block still owns the tty.
+        if was_mouse_enabled
+          apply_mouse_state false
+          flush
+          @mouse_enabled = false
+        end
+
+        # Mode 2004 off for the same window and by the same rule as the mouse above. Kept in
+        # a method rather than inlined next to it only to hold `with_mode` under the
+        # cyclomatic-complexity limit; the ordering requirement is identical.
+        suspend_bracketed_paste
+
+        @cursor = Cursor.new visible: true
+        apply_cursor_state
+
+        # For canonical/echo modes, exit alternate screen unless preserving
+        exit_alternate_screen if !preserve_screen && user_interactive && was_in_alternate
+
+        # Switch mode via backend (handles termios and tracking)
+        with_backend_mode(mode) { yield }
+      ensure
+        lifecycle_log { Log.debug { "Exiting with_mode, restoring state" } }
+        if was_in_alternate && !@alternate_screen
+          enter_alternate_screen
+        end
+
+        @cursor = backup_cursor
+        apply_cursor_state
+        @mouse_enabled = was_mouse_enabled
+        restore_bracketed_paste was_bracketed_paste
+        apply_terminal_state
+        # Always invalidate after non-raw modes - screen content is
+        # unpredictable after puts/print/gets during the mode block
+        invalidate_buffer unless mode == Terminal::Mode::None
+        # Reset cached style state so next render re-emits all escape sequences.
+        # External programs during the mode block may have changed terminal
+        # styling, making our cached fg/bg/attr assumptions stale.
+        reset_render_state
+        # Drop the cached size - external programs during the mode block may
+        # have resized the terminal, so the next size call re-queries live.
+        @cached_size = nil
+        flush
+      end
     end
-
-    # Mode 2004 off for the same window and by the same rule as the mouse above. Kept in
-    # a method rather than inlined next to it only to hold `with_mode` under the
-    # cyclomatic-complexity limit; the ordering requirement is identical.
-    suspend_bracketed_paste
-
-    backup_cursor = @cursor
-    @cursor = Cursor.new visible: true
-    apply_cursor_state
-
-    # For canonical/echo modes, exit alternate screen unless preserving
-    exit_alternate_screen if !preserve_screen && user_interactive && was_in_alternate
-
-    # Switch mode via backend (handles termios and tracking)
-    with_backend_mode(mode) { yield }
-  ensure
-    lifecycle_log { Log.debug { "Exiting with_mode, restoring state" } }
-    if was_in_alternate && !@alternate_screen
-      enter_alternate_screen
-    end
-
-    @cursor = backup_cursor unless backup_cursor.nil?
-    apply_cursor_state
-    @mouse_enabled = was_mouse_enabled unless was_mouse_enabled.nil?
-    restore_bracketed_paste was_bracketed_paste
-    apply_terminal_state
-    # Always invalidate after non-raw modes - screen content is
-    # unpredictable after puts/print/gets during the mode block
-    invalidate_buffer unless mode == Terminal::Mode::None
-    # Reset cached style state so next render re-emits all escape sequences.
-    # External programs during the mode block may have changed terminal
-    # styling, making our cached fg/bg/attr assumptions stale.
-    reset_render_state
-    # Drop the cached size - external programs during the mode block may
-    # have resized the terminal, so the next size call re-queries live.
-    @cached_size = nil
-    flush
   end
 
   # Executes a block with cooked (shell-like) mode.
@@ -684,7 +698,14 @@ class Termisu::Terminal < Termisu::Renderer
 
   # Closes the terminal and underlying backend.
   def close
+    if @mode_scope_gate.owned_by_current_fiber?
+      raise IO::Error.new("cannot close Terminal from inside its terminal mode scope")
+    end
     return unless @terminal_closed.compare_and_set(false, true)[1]
+
+    # Wait for an active scope to restore, then release the barrier before
+    # teardown. The closed flag makes queued/new scopes fail before transition.
+    @mode_scope_gate.synchronize { }
 
     lifecycle_log { Log.debug { "Closing terminal" } }
     error = capture_cleanup_error(nil) { disable_mouse }

--- a/tests/fixtures/input_ownership.cr
+++ b/tests/fixtures/input_ownership.cr
@@ -7,6 +7,13 @@ private def show(termisu : Termisu, message : String, row : Int32) : Nil
   termisu.render
 end
 
+private def same_fiber_close_rejected?(termisu : Termisu) : Bool
+  termisu.close
+  false
+rescue Termisu::Error
+  !termisu.@closed.get && termisu.current_mode == Termisu::Terminal::Mode.cooked
+end
+
 private def wait_for_key(
   termisu : Termisu,
   expected : Termisu::Input::Key,
@@ -53,15 +60,77 @@ begin
   raw_nested &&= termisu.@input_source.running?
   show(termisu, "RAW COOKED #{raw_nested ? "OK" : "BAD"}", 2)
 
-  show(termisu, "PROBE READY", 3)
+  first_entered = Channel(Nil).new
+  release_first = Channel(Nil).new
+  first_done = Channel(Exception?).new(1)
+  second_started = Channel(Nil).new
+  second_entered = Channel(Nil).new(1)
+  release_second = Channel(Nil).new
+  second_done = Channel(Exception?).new(1)
+
+  spawn do
+    error = nil.as(Exception?)
+    begin
+      termisu.with_cooked_mode(preserve_screen: true) do
+        first_entered.send(nil)
+        release_first.receive
+      end
+    rescue ex
+      error = ex
+    ensure
+      first_done.send(error)
+    end
+  end
+  first_entered.receive
+
+  spawn do
+    error = nil.as(Exception?)
+    begin
+      second_started.send(nil)
+      termisu.with_password_mode(preserve_screen: true) do
+        second_entered.send(nil)
+        release_second.receive
+      end
+    rescue ex
+      error = ex
+    ensure
+      second_done.send(error)
+    end
+  end
+  second_started.receive
+  Fiber.yield
+
+  crossed = termisu.current_mode == Termisu::Terminal::Mode.cooked
+  select
+  when second_entered.receive
+    crossed = false
+  else
+  end
+  release_first.send(nil)
+  crossed &&= first_done.receive.nil?
+  second_entered.receive
+  crossed &&= termisu.current_mode == Termisu::Terminal::Mode.password
+  release_second.send(nil)
+  crossed &&= second_done.receive.nil?
+  crossed &&= termisu.current_mode == Termisu::Terminal::Mode.raw
+  show(termisu, "CROSSED MODES #{crossed ? "OK" : "BAD"}", 3)
+
+  same_fiber_close = false
+  termisu.with_cooked_mode(preserve_screen: true) do
+    same_fiber_close = same_fiber_close_rejected?(termisu)
+  end
+  same_fiber_close &&= termisu.current_mode == Termisu::Terminal::Mode.raw
+  show(termisu, "SCOPE CLOSE #{same_fiber_close ? "OK" : "BAD"}", 4)
+
+  show(termisu, "PROBE READY", 5)
   if wait_for_key(termisu, Termisu::Input::Key::PasteStart)
-    show(termisu, "PROBE ESC", 4)
+    show(termisu, "PROBE ESC", 6)
     sleep 100.milliseconds
 
     begin
       termisu.with_raw_input { }
     rescue Termisu::InputOwnershipError
-      show(termisu, "PROBE RETAINED", 5)
+      show(termisu, "PROBE RETAINED", 7)
     end
 
     # Complete the event-owned probe under explicit source quiescence. The
@@ -71,23 +140,23 @@ begin
     retained = termisu.@input_parser.poll_event(2_000)
     termisu.@input_source.start(termisu.@event_loop.output)
     if retained.as?(Termisu::Event::Key).try(&.key) == Termisu::Input::Key::PasteEnd
-      show(termisu, "PROBE COMPLETE", 6)
+      show(termisu, "PROBE COMPLETE", 8)
     end
   end
 
   termisu.with_raw_input do
-    show(termisu, "RAW READY", 7)
+    show(termisu, "RAW READY", 9)
     if termisu.wait_for_input(2_000)
       if bytes = termisu.read_bytes(3)
-        show(termisu, "RAW #{bytes.hexstring}", 8)
+        show(termisu, "RAW #{bytes.hexstring}", 10)
       end
     end
   end
 
-  show(termisu, "EVENT READY", 9)
+  show(termisu, "EVENT READY", 11)
   if event = termisu.poll_event(2.seconds)
     if key = event.as?(Termisu::Event::Key)
-      show(termisu, "EVENT #{key.char}", 10)
+      show(termisu, "EVENT #{key.char}", 12)
     end
   end
   sleep 100.milliseconds


### PR DESCRIPTION
## Rationale

Overlapping cooked/password scopes could snapshot the same raw state and restore out of order. Nested non-raw scopes also stopped and restarted input repeatedly, and close needed an explicit contract with active and queued scopes.

## Design and constraints

- Serialize snapshot, transition, user block, and restoration with a fiber-reentrant gate at both facade and terminal layers.
- Share parser-pause depth with raw-input leases: stop only on 0→1 and restart only on 1→0.
- Mark close first, use mode ownership only as a restoration barrier, and release it before stopping/joining event sources.
- Reject same-owner close before teardown; cross-fiber close waits for restoration and queued scopes then reject.
- Preserve same-fiber nesting, first-error cleanup, cursor/screen/mouse/paste restoration, and both raw-lease overlap orders.
- Document prohibited cross-fiber wait cycles. No performance claim is made.

## Evidence

Deterministic assertions record exactly one parser stop/restart pair for nested non-raw scopes and for each raw-lease/mode overlap order. The crossed-scope, same-owner close, queued-close, and event-source join regressions use channel handshakes rather than timing assumptions. Five repeated Crystal 1.21 focused runs with four workers each passed: 114 examples, 0 failures, 1 environment-dependent pending per run.

Local Linux:

- Crystal 1.21 full unit suite: 1370 examples, 0 failures, 1 controlling-TTY pending
- Crystal 1.17 focused facade/terminal suite: 114 examples, 0 failures, 1 controlling-TTY pending
- Crystal 1.21 Crystal-native E2E/PTy suite: 82 examples, 0 failures
- Crystal 1.17 crossed-mode/raw-ownership PTY fixture: 1 example, 0 failures
- Ameba: 162 files, 0 failures; formatter and `git diff --check` passed
- C formatting/lint and native C ABI tests passed
- Bun typecheck/Biome passed; 48 Bun tests passed

CI:

- unit matrix passed on Linux/macOS for Crystal 1.17, 1.18, 1.19, 1.20, and 1.21, plus FreeBSD 15
- PTY E2E matrix passed on Linux, mac and FreeBSD 15
- formatting, Ameba, CodeQL, Sonar, and security checks passed
