### PR TITLE
fix: make resize completion-safe

### DIFF
--- a/spec/e2e/animation_spec.cr
+++ b/spec/e2e/animation_spec.cr
@@ -61,6 +61,18 @@ describe "Animation example (e2e)" do
     end
   end
 
+  describe "resize handling" do
+    it "responds to a PTY resize signal at the new terminal bounds" do
+      with_animation do |term|
+        term.resize(100, 10)
+        moved = term.wait_until do
+          term.find("Q=quit").try { |position| position[1] == 9 } || false
+        end
+        moved.should be_true
+      end
+    end
+  end
+
   describe "layout snapshot" do
     it "matches the chrome snapshot (moving ball + live FPS masked)" do
       with_animation do |term|

--- a/spec/termisu/event/source/resize_spec.cr
+++ b/spec/termisu/event/source/resize_spec.cr
@@ -1,5 +1,18 @@
 require "../../../spec_helper"
 
+unless ENV.delete("TERMISU_RESIZE_SIGNAL_STOP_CHILD").nil?
+  source = Termisu::Event::Source::Resize.new(-> { {80, 24} }, poll_interval: 1.hour)
+  child_output = Channel(Termisu::Event::Any).new(1)
+
+  16.times do
+    source.start(child_output)
+    Process.signal(Signal::WINCH, Process.pid)
+    source.stop
+  end
+  sleep 10.milliseconds
+  LibC._exit(0)
+end
+
 describe Termisu::Event::Source::Resize do
   describe "#initialize" do
     it "creates with a size provider" do
@@ -307,6 +320,262 @@ describe Termisu::Event::Source::Resize do
 
       source.stop
       channel.close
+    end
+  end
+
+  describe "completion-safe lifecycle" do
+    it "leaves a synchronous provider failure restartable" do
+      calls = 0
+      provider = -> do
+        calls += 1
+        raise "injected initial provider failure" if calls == 1
+        {80, 24}
+      end
+      source = Termisu::Event::Source::Resize.new(provider)
+      output = Channel(Termisu::Event::Any).new(1)
+
+      expect_raises(Exception, "injected initial provider failure") { source.start(output) }
+      source.running?.should be_false
+      source.stop
+
+      source.start(output)
+      source.running?.should be_true
+      source.stop
+      output.close
+    end
+
+    it "survives a queued SIGWINCH during immediate stop" do
+      executable = Process.executable_path || fail "spec executable path is unavailable"
+      process_output = IO::Memory.new
+      status = Process.run(
+        executable,
+        env: {"TERMISU_RESIZE_SIGNAL_STOP_CHILD" => "1"},
+        output: process_output,
+        error: process_output,
+      )
+
+      fail "resize shutdown subprocess failed: #{process_output}" unless status.success?
+    end
+
+    it "wakes immediately for real SIGWINCH with a long fallback interval" do
+      size = MutableSize.new(80, 24)
+      source = Termisu::Event::Source::Resize.new(-> { size.to_tuple }, poll_interval: 5.seconds)
+      output = Channel(Termisu::Event::Any).new(1)
+
+      source.start(output)
+
+      3.times do |index|
+        size.width = 81 + index
+        Process.signal(Signal::WINCH, Process.pid)
+
+        select
+        when event = output.receive
+          event.as(Termisu::Event::Resize).width.should eq(81 + index)
+        when timeout(500.milliseconds)
+          fail "SIGWINCH did not wake the resize source"
+        end
+      end
+
+      source.stop
+      output.close
+    end
+
+    it "deactivates the captured run callback before stop returns" do
+      source = Termisu::Event::Source::Resize.new(-> { {80, 24} }, poll_interval: 1.hour)
+      output = Channel(Termisu::Event::Any).new(1)
+
+      source.start(output)
+      wake = source.@wake || fail "resize wake was not installed"
+      handler = Signal::WINCH.trap_handler? || fail "SIGWINCH handler was not installed"
+      source.stop
+
+      handler.call(Signal::WINCH)
+      select
+      when wake.receive
+        fail "stopped run callback enqueued a wake"
+      else
+      end
+      output.close
+    end
+
+    it "coalesces a burst into one pending size check" do
+      calls = Atomic(Int32).new(0)
+      second_call = Channel(Nil).new
+      release_second = Channel(Nil).new
+      third_call = Channel(Nil).new
+      provider = -> do
+        call = calls.add(1) + 1
+        if call == 2
+          second_call.send(nil)
+          release_second.receive
+        elsif call == 3
+          third_call.send(nil)
+        end
+        {80, 24}
+      end
+      source = Termisu::Event::Source::Resize.new(provider, poll_interval: 1.hour)
+      output = Channel(Termisu::Event::Any).new(1)
+
+      source.start(output)
+      wake = source.@wake || fail "resize wake was not installed"
+      wake.send(nil)
+      second_call.receive
+
+      accepted = 0
+      32.times do
+        select
+        when wake.send(nil)
+          accepted += 1
+        else
+        end
+      end
+      accepted.should eq(1)
+
+      release_second.send(nil)
+      third_call.receive
+      source.stop
+      calls.get.should eq(3)
+      output.close
+    end
+
+    it "cancels a send blocked by output backpressure before returning" do
+      size = MutableSize.new(80, 24)
+      queried = Channel(Nil).new(1)
+      calls = 0
+      provider = -> do
+        calls += 1
+        queried.send(nil) if calls == 2
+        size.to_tuple
+      end
+      source = Termisu::Event::Source::Resize.new(provider, poll_interval: 1.hour)
+      output = Channel(Termisu::Event::Any).new
+
+      source.start(output)
+      size.width = 100
+      (source.@wake || fail "resize wake was not installed").send(nil)
+      queried.receive
+      Fiber.yield
+
+      source.stop
+      source.running?.should be_false
+      calls.should eq(2)
+      select
+      when event = output.receive
+        fail "received event after stop: #{event}"
+      else
+      end
+      output.close
+    end
+
+    it "handles output closure while delivering a changed size" do
+      size = MutableSize.new(80, 24)
+      queried = Channel(Nil).new(1)
+      calls = 0
+      provider = -> do
+        calls += 1
+        queried.send(nil) if calls == 2
+        size.to_tuple
+      end
+      source = Termisu::Event::Source::Resize.new(provider, poll_interval: 1.hour)
+      output = Channel(Termisu::Event::Any).new
+
+      source.start(output)
+      output.close
+      size.width = 100
+      (source.@wake || fail "resize wake was not installed").send(nil)
+      queried.receive
+      Fiber.yield
+
+      source.stop
+      source.running?.should be_false
+    end
+
+    it "joins a provider race and excludes stale wakes from a rapid restart" do
+      calls = Atomic(Int32).new(0)
+      second_call = Channel(Nil).new
+      release_second = Channel(Nil).new
+      fourth_call = Channel(Nil).new
+      provider = -> do
+        call = calls.add(1) + 1
+        if call == 2
+          second_call.send(nil)
+          release_second.receive
+        elsif call == 4
+          fourth_call.send(nil)
+        end
+        {80, 24}
+      end
+      source = Termisu::Event::Source::Resize.new(provider, poll_interval: 1.hour)
+      first_output = Channel(Termisu::Event::Any).new(1)
+      second_output = Channel(Termisu::Event::Any).new(1)
+      stopped = Channel(Nil).new
+      restarted = Channel(Nil).new
+
+      source.start(first_output)
+      old_wake = source.@wake || fail "resize wake was not installed"
+      Process.signal(Signal::WINCH, Process.pid)
+      second_call.receive
+
+      spawn do
+        source.stop
+        stopped.send(nil)
+      end
+      Fiber.yield
+      select
+      when stopped.receive
+        fail "stop returned while the provider was still running"
+      else
+      end
+
+      spawn do
+        source.start(second_output)
+        restarted.send(nil)
+      end
+      Fiber.yield
+      release_second.send(nil)
+      stopped.receive
+      restarted.receive
+      calls.get.should eq(3)
+
+      old_wake.send(nil)
+      Fiber.yield
+      calls.get.should eq(3)
+
+      Process.signal(Signal::WINCH, Process.pid)
+      fourth_call.receive
+      source.stop
+      calls.get.should eq(4)
+      first_output.close
+      second_output.close
+    end
+
+    it "reports a provider failure once and leaves the source restartable" do
+      calls = Atomic(Int32).new(0)
+      failed_call = Channel(Nil).new(1)
+      provider = -> do
+        call = calls.add(1) + 1
+        if call == 2
+          failed_call.send(nil)
+          raise "injected resize provider failure"
+        end
+        {80, 24}
+      end
+      source = Termisu::Event::Source::Resize.new(provider, poll_interval: 1.hour)
+      output = Channel(Termisu::Event::Any).new(1)
+
+      source.start(output)
+      (source.@wake || fail "resize wake was not installed").send(nil)
+      failed_call.receive
+      Fiber.yield
+
+      expect_raises(Exception, "injected resize provider failure") { source.stop }
+      source.running?.should be_false
+      source.stop
+
+      source.start(output)
+      calls.get.should eq(3)
+      source.stop
+      output.close
     end
   end
 

--- a/src/termisu/event/source/resize.cr
+++ b/src/termisu/event/source/resize.cr
@@ -28,9 +28,8 @@
 # ## Detection Strategy
 #
 # Uses a hybrid approach:
-# 1. **SIGWINCH Signal**: Sets the `@signal_received` atomic flag; the
-#    polling fiber checks this flag each iteration and skips the sleep
-#    when set, providing near-immediate resize detection.
+# 1. **SIGWINCH Signal**: Non-blockingly wakes the monitoring fiber for an
+#    immediate size check. A capacity-one channel coalesces signal bursts.
 # 2. **Polling Fallback**: Periodic size checks (default 100ms) catch
 #    resizes that signals might miss.
 #
@@ -41,14 +40,14 @@
 #
 # ## Thread Safety
 #
-# Uses `Atomic(Bool)` for the running state. Safe to call `start`/`stop`
-# from different fibers. Uses `compare_and_set` for idempotent lifecycle
-# operations - calling `start` twice or `stop` twice is safe.
+# Lifecycle changes are serialized. `stop` cancels waits and blocked output,
+# then waits for the current run to finish before allowing a restart.
 #
 # ## Lifecycle
 #
-# The source can be restarted after stopping. Each `start` resets the
-# signal flag and reinstalls the SIGWINCH handler.
+# The source can be restarted after stopping. Every run owns its wake,
+# cancellation, completion, and signal-handler state, so stale signals cannot
+# affect a replacement run.
 class Termisu::Event::Source::Resize < Termisu::Event::Source
   Log = Termisu::Logs::Event
 
@@ -60,15 +59,26 @@ class Termisu::Event::Source::Resize < Termisu::Event::Source
   # Type alias for the size provider proc.
   alias SizeProvider = -> {Int32, Int32}
 
+  private class RunState
+    @active = Atomic(Bool).new(true)
+
+    def active? : Bool
+      @active.get
+    end
+
+    def deactivate : Nil
+      @active.set(false)
+    end
+  end
+
   @running : Atomic(Bool)
-  @signal_received : Atomic(Bool)
-  @generation : Atomic(Int32)
+  @lifecycle_lock : Mutex
   @poll_interval : Time::Span
   @size_provider : SizeProvider
-  @output : Channel(Event::Any)?
-  @fiber : Fiber?
-  @last_width : Int32?
-  @last_height : Int32?
+  @wake : Channel(Nil)?
+  @stop_signal : Channel(Nil)?
+  @done : Channel(Exception?)?
+  @run_state : RunState?
 
   # Creates a new resize source.
   #
@@ -88,8 +98,7 @@ class Termisu::Event::Source::Resize < Termisu::Event::Source
   # ```
   def initialize(@size_provider : SizeProvider, @poll_interval : Time::Span = DEFAULT_POLL_INTERVAL)
     @running = Atomic(Bool).new(false)
-    @signal_received = Atomic(Bool).new(false)
-    @generation = Atomic(Int32).new(0)
+    @lifecycle_lock = Mutex.new
   end
 
   # Returns the current polling interval.
@@ -108,52 +117,71 @@ class Termisu::Event::Source::Resize < Termisu::Event::Source
 
   # Starts monitoring for resize events.
   #
-  # Installs a SIGWINCH signal handler and spawns a fiber that
-  # polls for size changes. Events are sent to the output channel.
-  #
-  # Prevents double-start with `compare_and_set`.
+  # Installs a SIGWINCH signal handler and spawns a fiber that polls for size
+  # changes. Starting an already-running source is an idempotent no-op.
   def start(output : Channel(Event::Any)) : Nil
-    return unless @running.compare_and_set(false, true)
+    @lifecycle_lock.synchronize do
+      return if @running.get
 
-    @output = output
+      initial_width, initial_height = @size_provider.call
+      wake = Channel(Nil).new(1)
+      stop_signal = Channel(Nil).new
+      done = Channel(Exception?).new(1)
+      run_state = RunState.new
 
-    # Reset signal flag for this run
-    @signal_received.set(false)
+      begin
+        install_signal_handler(wake, run_state)
 
-    # Get initial size
-    initial_width, initial_height = @size_provider.call
-    @last_width = initial_width
-    @last_height = initial_height
+        @wake = wake
+        @stop_signal = stop_signal
+        @done = done
+        @run_state = run_state
+        @running.set(true)
 
-    # Install SIGWINCH handler
-    install_signal_handler
+        spawn(name: "termisu-resize") do
+          run(output, wake, stop_signal, done, run_state, initial_width, initial_height)
+        end
+      rescue error
+        run_state.deactivate
+        @running.set(false)
+        clear_run
+        install_inactive_signal_handler rescue nil
+        raise error
+      end
 
-    generation = @generation.add(1) &+ 1
-    @fiber = spawn(name: "termisu-resize") do
-      run_loop(generation)
+      lifecycle_log { Log.debug { "Resize source started, initial size: #{initial_width}x#{initial_height}" } }
     end
-
-    lifecycle_log { Log.debug { "Resize source started, initial size: #{initial_width}x#{initial_height}" } }
   end
 
   # Stops monitoring for resize events.
   #
-  # Sets the running flag to false, causing the fiber to exit
-  # on its next poll cycle. Resets the SIGWINCH handler.
+  # Disables the run-local signal callback, cancels any wait or blocked output
+  # send, and waits for the monitoring fiber to acknowledge completion. Once
+  # this method returns, the old run cannot query the provider or emit events.
   def stop : Nil
-    return unless @running.compare_and_set(true, false)
+    @lifecycle_lock.synchronize do
+      return unless @running.get
 
-    # Invalidate the current generation so any stale fiber self-terminates
-    @generation.add(1)
+      @running.set(false)
+      @run_state.try(&.deactivate)
 
-    # Reset signal handler first to prevent new signals from arriving
-    Signal::WINCH.reset
+      # Crystal defers signal dispatch through an internal pipe. Replace the
+      # run callback with a valid no-op instead of resetting it: an already
+      # queued SIGWINCH would otherwise have no handler and terminate Crystal.
+      handler_error = begin
+        install_inactive_signal_handler
+        nil
+      rescue error
+        error
+      end
 
-    # Give fiber time to exit gracefully (it will notice @running is false
-    # on its next poll cycle, up to one @poll_interval delay)
-    Fiber.yield
+      @stop_signal.try { |signal| signal.close unless signal.closed? }
+      run_error = @done.try(&.receive)
+      clear_run
 
-    lifecycle_log { Log.debug { "Resize source stopped" } }
+      lifecycle_log { Log.debug { "Resize source stopped" } }
+      raise error if error = run_error || handler_error
+    end
   end
 
   # Returns true if the resize source is currently running.
@@ -166,75 +194,110 @@ class Termisu::Event::Source::Resize < Termisu::Event::Source
     "resize"
   end
 
-  # Installs the SIGWINCH signal handler.
-  #
-  # Uses an `Atomic(Bool)` flag instead of a channel send, because
-  # `Channel#send` can block when the buffer is full, which is unsafe
-  # inside a signal handler. `Atomic#set` is always non-blocking.
-  private def install_signal_handler : Nil
-    signal_received = @signal_received
+  # Installs a run-local SIGWINCH handler. The callback never blocks and
+  # deliberately swallows all failures because exceptions must not escape a
+  # signal trap. A full wake channel means a check is already pending.
+  private def install_signal_handler(wake : Channel(Nil), run_state : RunState) : Nil
     Signal::WINCH.trap do
-      signal_received.set(true)
+      if run_state.active?
+        select
+        when wake.send(nil)
+        else
+        end
+      end
+    rescue
+      # Signal traps are best-effort and must never throw.
     end
   end
 
-  # Main resize monitoring loop - runs in a spawned fiber.
-  #
-  # Checks the `@signal_received` atomic flag each iteration. If SIGWINCH
-  # was received, it skips the sleep and checks for a resize immediately.
-  # Otherwise it sleeps for `@poll_interval` before checking again.
-  private def run_loop(generation : Int32) : Nil
-    output = @output
-    return unless output
+  # Crystal may dispatch an already-received signal after stop. This callback
+  # keeps that dispatch harmless without retaining any run-local resources.
+  private def install_inactive_signal_handler : Nil
+    Signal::WINCH.trap do
 
-    while @running.get
-      # If a SIGWINCH was received, process immediately with minimal delay;
-      # otherwise sleep for the full poll interval.
-      signaled = @signal_received.swap(false)
-      unless signaled
-        sleep(@poll_interval)
+    rescue
+      # Signal traps are best-effort and must never throw.
+    end
+  end
+
+  private def run(
+    output : Channel(Event::Any),
+    wake : Channel(Nil),
+    stop_signal : Channel(Nil),
+    done : Channel(Exception?),
+    run_state : RunState,
+    initial_width : Int32,
+    initial_height : Int32,
+  ) : Nil
+    error = begin
+      run_loop(output, wake, stop_signal, run_state, initial_width, initial_height)
+      nil
+    rescue Channel::ClosedError
+      lifecycle_log { Log.debug { "Resize channel closed, exiting" } }
+      nil
+    rescue ex
+      ex
+    end
+
+    # Capacity one makes this final acknowledgement nonblocking. No source
+    # state is accessed after it, so receiving it establishes run completion.
+    done.send(error)
+  end
+
+  # Waits for either a coalesced signal wake or the polling fallback. The stop
+  # channel participates in every potentially blocking operation.
+  private def run_loop(
+    output : Channel(Event::Any),
+    wake : Channel(Nil),
+    stop_signal : Channel(Nil),
+    run_state : RunState,
+    initial_width : Int32,
+    initial_height : Int32,
+  ) : Nil
+    last_width = initial_width
+    last_height = initial_height
+
+    while run_state.active?
+      select
+      when wake.receive
+      when timeout(@poll_interval)
+      when stop_signal.receive?
+        return
       end
 
-      # Check generation after sleep — if it changed, a stop+start cycle
-      # occurred and a new fiber owns this generation. Self-terminate.
-      break unless @generation.get == generation
-      break unless @running.get
+      return unless run_state.active?
 
-      check_and_emit_resize(output)
-    end
-  end
+      new_width, new_height = @size_provider.call
+      return unless run_state.active?
+      next if last_width == new_width && last_height == new_height
 
-  # Checks for size changes and emits resize event if changed.
-  #
-  # Compares current size from the provider against the last known size.
-  # If different, creates a `Event::Resize` with both old and new dimensions
-  # and sends it to the output channel. Updates last known size for the
-  # next comparison.
-  #
-  # If the output channel is closed during shutdown, `output.send` raises
-  # `Channel::ClosedError` and the fiber exits.
-  private def check_and_emit_resize(output : Channel(Event::Any)) : Nil
-    new_width, new_height = @size_provider.call
-
-    old_width = @last_width
-    old_height = @last_height
-
-    # Detect if size changed (comparing against last emitted dimensions)
-    if old_width != new_width || old_height != new_height
       resize_event = Event::Resize.new(
         width: new_width,
         height: new_height,
-        old_width: old_width,
-        old_height: old_height,
+        old_width: last_width,
+        old_height: last_height,
       )
 
-      # Update last known size BEFORE sending to ensure consistency
-      # even if the channel send blocks briefly
-      @last_width = new_width
-      @last_height = new_height
+      delivered = select
+      when output.send(resize_event)
+        true
+      when stop_signal.receive?
+        false
+      end
+      return unless delivered
 
-      output.send(resize_event)
-      Log.debug { "Resize detected: #{old_width}x#{old_height} -> #{new_width}x#{new_height}" }
+      last_width = new_width
+      last_height = new_height
+      lifecycle_log do
+        Log.debug { "Resize detected: #{resize_event.old_width}x#{resize_event.old_height} -> #{new_width}x#{new_height}" }
+      end
     end
+  end
+
+  private def clear_run : Nil
+    @wake = nil
+    @stop_signal = nil
+    @done = nil
+    @run_state = nil
   end
 end


### PR DESCRIPTION
## Rationale

Resize polling could sleep through SIGWINCH until the fallback interval, and shutdown could return while a provider call or output send was still active. Resetting the Crystal signal trap during stop also raced deferred SIGWINCH dispatch and could terminate the process with `FATAL: missing handler for WINCH`.

## Design

- Give each run a capacity-one nonblocking wake channel, cancellation channel, completion acknowledgement, and active token.
- Select signal wake versus fallback timeout, and select output delivery versus cancellation.
- Serialize start/stop, join the run before stop returns, and keep all provider/output state run-local.
- Replace a stopped run's trap with a nonthrowing no-op rather than resetting it, so already-queued Crystal signal dispatch remains safe without retaining run resources.
- Preserve graceful output closure, provider-error propagation, first-error behavior, restartability, and idempotent lifecycle calls.

## Correctness constraints

Signal callbacks never block and rescue all exceptions. Stop disables the run before cancellation and waits for its final acknowledgement; no provider access or output emission from that run can occur after stop returns. Restart installs fresh wake/cancellation state, and old run-local wakes cannot reach the replacement.

## Validation

- Resize specs: 31 examples, 0 failures on Crystal 1.17.0, 1.18.2, 1.19.1, and 1.21.0; the final 1.21 implementation passed locally.
- Regression coverage includes a subprocess-only immediate SIGWINCH/stop loop (required because Crystal's fatal path uses `_exit`), real SIGWINCH with a 5-second fallback, fallback polling, burst coalescing, blocked-send cancellation, closed output, provider/stop races, and rapid restart.
- Full Linux PTY suite: 1372 examples, 0 failures, 1 environment-specific pending.
- Animation PTY E2E: 9 examples, 0 failures.
- Crystal 1.21 `-Dwithout_mt` resize specs: 31 examples, 0 failures.
- Ameba: 161 files, 0 failures; Crystal format and `git diff --check` passed.
- C format/lint and native C ABI tests passed.
- Bun: Biome and typecheck passed; 48 tests, 0 failures.

Local runtime validation was Linux-only. Hosted CI passed the Crystal 1.17–1.21 Linux/macOS matrix, FreeBSD tests, and Linux/macOS/FreeBSD PTY E2E; local macOS/FreeBSD measurements are not claimed.
