### PR TITLE
fix: make system timer cooperative

### DIFF
--- a/spec/termisu/event/source/system_timer_spec.cr
+++ b/spec/termisu/event/source/system_timer_spec.cr
@@ -9,6 +9,156 @@ private class SystemTimerTokenProbe < Termisu::Event::Source::SystemTimer
   def current_token : UInt64
     @run_token.get
   end
+
+  def effective_interval(interval : Time::Span) : Time::Span
+    cooperative_interval(interval)
+  end
+end
+
+private class SystemTimerFakePoller < Termisu::Event::Poller
+  getter add_calls = 0
+  getter modify_calls = 0
+  getter wait_calls = 0
+  getter close_calls = 0
+  getter operation_fibers = [] of Fiber
+  getter added_intervals = [] of Time::Span
+  getter modified_intervals = [] of Time::Span
+  property add_error : Exception?
+  property modify_error : Exception?
+  property wait_error : Exception?
+  property close_error : Exception?
+  property drain_started : Channel(Nil)?
+  property drain_release : Channel(Nil)?
+
+  @results : Array(PollResult)
+
+  def initialize(@results = [] of PollResult)
+  end
+
+  def register_fd(fd : Int32, events : FDEvents) : Nil
+  end
+
+  def unregister_fd(fd : Int32) : Nil
+  end
+
+  def add_timer(interval : Time::Span, repeating : Bool = true) : TimerHandle
+    record_operation
+    @add_calls += 1
+    @added_intervals << interval
+    if error = @add_error
+      raise error
+    end
+    TimerHandle.new(0_u64)
+  end
+
+  def modify_timer(handle : TimerHandle, interval : Time::Span) : Nil
+    record_operation
+    @modify_calls += 1
+    @modified_intervals << interval
+    if error = @modify_error
+      raise error
+    end
+  end
+
+  def remove_timer(handle : TimerHandle) : Nil
+  end
+
+  def wait : PollResult?
+    wait(0.nanoseconds)
+  end
+
+  def wait(timeout : Time::Span) : PollResult?
+    record_operation
+    @wait_calls += 1
+    @drain_started.try(&.send(nil))
+    @drain_release.try(&.receive)
+    if error = @wait_error
+      raise error
+    end
+    @results.shift?
+  end
+
+  def close : Nil
+    record_operation
+    @close_calls += 1
+    if error = @close_error
+      raise error
+    end
+  end
+
+  private def record_operation : Nil
+    @operation_fibers << Fiber.current
+  end
+end
+
+private class SystemTimerHarness < Termisu::Event::Source::SystemTimer
+  getter wait_started = Channel(UInt64).new
+  getter wait_release = Channel(Nil).new
+  getter deadlines = [] of MonotonicTime
+  getter create_calls = 0
+
+  @pollers : Array(Termisu::Event::Poller)
+
+  def initialize(@pollers : Array(Termisu::Event::Poller), interval = 16.milliseconds)
+    super(interval)
+  end
+
+  protected def create_poller : Termisu::Event::Poller
+    @create_calls += 1
+    @pollers.shift
+  end
+
+  protected def wait_for_readiness(
+    wakeups : Channel(Nil),
+    deadline : MonotonicTime,
+  ) : Nil
+    @deadlines << deadline
+    @wait_started.send(current_token)
+    @wait_release.receive
+  end
+
+  private def current_token : UInt64
+    @run_token.get
+  end
+end
+
+private class SystemTimerWaitProbe < Termisu::Event::Source::SystemTimer
+  getter wait_started = Channel(Nil).new(1)
+
+  protected def wait_for_readiness(
+    wakeups : Channel(Nil),
+    deadline : MonotonicTime,
+  ) : Nil
+    select
+    when @wait_started.send(nil)
+    else
+    end
+    super
+  end
+end
+
+private class SystemTimerCooperativeHarness < SystemTimerWaitProbe
+  def initialize(@poller : Termisu::Event::Poller, interval = 16.milliseconds)
+    super(interval)
+  end
+
+  protected def create_poller : Termisu::Event::Poller
+    @poller
+  end
+end
+
+private class SystemTimerPollFallback < Termisu::Event::Source::SystemTimer
+  protected def create_poller : Termisu::Event::Poller
+    Termisu::Event::Poller::Poll.new
+  end
+end
+
+private def wait_until_system_timer_stops(timer : Termisu::Event::Source::SystemTimer) : Nil
+  1_000.times do
+    return unless timer.running?
+    Fiber.yield
+  end
+  fail "system timer did not stop"
 end
 
 describe Termisu::Event::Source::SystemTimer do
@@ -41,6 +191,19 @@ describe Termisu::Event::Source::SystemTimer do
       tokens.size.should eq(thread_count * per_thread)
       tokens.uniq.size.should eq(thread_count * per_thread)
       probe.current_token.should eq(start + (thread_count * per_thread).to_u64)
+    end
+  end
+
+  describe "#cooperative_interval" do
+    it "matches native backend granularity without producing a zero interval" do
+      probe = SystemTimerTokenProbe.new
+      effective = probe.effective_interval(0.5.milliseconds)
+
+      {% if flag?(:darwin) || flag?(:freebsd) || flag?(:openbsd) %}
+        effective.should eq(1.millisecond)
+      {% else %}
+        effective.should eq(0.5.milliseconds)
+      {% end %}
     end
   end
 
@@ -183,6 +346,416 @@ describe Termisu::Event::Source::SystemTimer do
 
       timer.stop
       channel.close
+    end
+  end
+
+  describe "cooperative scheduling" do
+    it "lets an independent 1ms fiber progress throughout repeating 50ms waits" do
+      progress_samples = [] of Int32
+
+      3.times do
+        timer = Termisu::Event::Source::SystemTimer.new(interval: 50.milliseconds)
+        channel = Channel(Termisu::Event::Any).new(4)
+        progress = Atomic(Int32).new(0)
+        progressing = Atomic(Bool).new(true)
+
+        timer.start(channel)
+        spawn do
+          while progressing.get
+            sleep 1.millisecond
+            progress.add(1)
+          end
+        end
+
+        2.times do
+          select
+          when channel.receive
+          when timeout(250.milliseconds)
+            fail "Timeout waiting for cooperative timer tick"
+          end
+        end
+
+        progressing.set(false)
+        timer.stop
+        progress_samples << progress.get
+        channel.close
+      end
+
+      progress_samples.each(&.should(be >= 5))
+    end
+
+    it "cancels a confirmed long wait promptly across repeated runs" do
+      stop_samples = [] of Time::Span
+
+      5.times do
+        timer = SystemTimerWaitProbe.new(interval: 2.seconds)
+        channel = Channel(Termisu::Event::Any).new(1)
+        timer.start(channel)
+        timer.wait_started.receive
+
+        stop_samples << Time.measure { timer.stop }
+        channel.close
+      end
+
+      stop_samples.each(&.should(be < 100.milliseconds))
+    end
+
+    it "wakes a long wait when the interval changes" do
+      timer = SystemTimerWaitProbe.new(interval: 2.seconds)
+      channel = Channel(Termisu::Event::Any).new(1)
+      timer.start(channel)
+      timer.wait_started.receive
+
+      timer.interval = 10.milliseconds
+      select
+      when channel.receive
+      when timeout(100.milliseconds)
+        fail "interval change did not wake the timer wait"
+      end
+
+      timer.stop
+      channel.close
+    end
+
+    it "preserves sustained cadence and tick fields at representative intervals" do
+      [6.9.milliseconds, 16.milliseconds, 50.milliseconds].each do |interval|
+        timer = Termisu::Event::Source::SystemTimer.new(interval: interval)
+        channel = Channel(Termisu::Event::Any).new(32)
+        ticks = [] of Termisu::Event::Tick
+        timer.start(channel)
+
+        20.times do
+          select
+          when event = channel.receive
+            ticks << event.as(Termisu::Event::Tick)
+          when timeout(1.5.seconds)
+            fail "Timeout at #{interval} after #{ticks.size} ticks"
+          end
+        end
+
+        timer.stop
+        channel.close
+
+        ticks.map(&.frame).should eq((0_u64...20_u64).to_a)
+        ticks.each_cons_pair do |previous, current|
+          current.elapsed.should be > previous.elapsed
+          current.delta.should be > 0.nanoseconds
+        end
+        ticks.sum(0.nanoseconds, &.delta).should eq(ticks.last.elapsed)
+
+        effective_interval = {% if flag?(:darwin) || flag?(:freebsd) || flag?(:openbsd) %}
+                               interval.total_milliseconds.to_i64.milliseconds
+                             {% else %}
+                               interval
+                             {% end %}
+        missed = ticks.sum(0_u64, &.missed_ticks)
+        missed.should be <= (effective_interval >= 50.milliseconds ? 4_u64 : 100_u64)
+
+        average_emission_period = ticks.last.elapsed / ticks.size
+        average_emission_period.should be > effective_interval * 0.7
+        average_emission_period.should be < effective_interval * 6.0
+      end
+    end
+
+    it "handles sustained interval changes with the Poll fallback" do
+      timer = SystemTimerPollFallback.new(interval: 2.seconds)
+      channel = Channel(Termisu::Event::Any).new(1)
+      completed = Channel(Exception?).new(1)
+      timer.start(channel)
+
+      spawn do
+        5_000.times { timer.interval = 2.seconds }
+        completed.send(nil)
+      rescue error
+        completed.send(error)
+      end
+
+      select
+      when error = completed.receive
+        raise error if error
+      when timeout(10.seconds)
+        fail "Poll fallback interval changes did not complete"
+      end
+
+      timer.stop
+      channel.close
+    end
+  end
+
+  describe "deterministic run ownership" do
+    it "checks the original token after cooperative readiness before draining" do
+      poller = SystemTimerFakePoller.new([
+        Termisu::Event::Poller::PollResult.new(type: :timer, timer_expirations: 1_u64),
+      ])
+      timer = SystemTimerHarness.new([poller] of Termisu::Event::Poller)
+      output = Channel(Termisu::Event::Any).new(1)
+      timer.start(output)
+      timer.wait_started.receive
+
+      stopped = Channel(Exception?).new(1)
+      spawn do
+        timer.stop
+        stopped.send(nil)
+      rescue error
+        stopped.send(error)
+      end
+      wait_until_system_timer_stops(timer)
+
+      timer.wait_release.send(nil)
+      stopped.receive.should be_nil
+      poller.wait_calls.should eq(0)
+      poller.close_calls.should eq(1)
+      select
+      when event = output.receive
+        fail "stale run emitted #{event.inspect}"
+      else
+      end
+      output.close
+    end
+
+    it "checks the original token after the nonblocking Poller drain before emission" do
+      drain_started = Channel(Nil).new
+      drain_release = Channel(Nil).new
+      poller = SystemTimerFakePoller.new([
+        Termisu::Event::Poller::PollResult.new(type: :timer, timer_expirations: 1_u64),
+      ])
+      poller.drain_started = drain_started
+      poller.drain_release = drain_release
+      timer = SystemTimerHarness.new([poller] of Termisu::Event::Poller)
+      output = Channel(Termisu::Event::Any).new(1)
+      timer.start(output)
+      timer.wait_started.receive
+      timer.wait_release.send(nil)
+      drain_started.receive
+
+      stopped = Channel(Exception?).new(1)
+      spawn do
+        timer.stop
+        stopped.send(nil)
+      rescue error
+        stopped.send(error)
+      end
+      wait_until_system_timer_stops(timer)
+
+      drain_release.send(nil)
+      stopped.receive.should be_nil
+      select
+      when event = output.receive
+        fail "stale run emitted #{event.inspect}"
+      else
+      end
+      poller.close_calls.should eq(1)
+      output.close
+    end
+
+    it "finishes old resource cleanup before a restart acquires replacements" do
+      first = SystemTimerFakePoller.new
+      second = SystemTimerFakePoller.new
+      timer = SystemTimerHarness.new([first, second] of Termisu::Event::Poller)
+      first_output = Channel(Termisu::Event::Any).new(1)
+      second_output = Channel(Termisu::Event::Any).new(1)
+      timer.start(first_output)
+      first_token = timer.wait_started.receive
+
+      stopped = Channel(Nil).new
+      spawn do
+        timer.stop
+        stopped.send(nil)
+      end
+      wait_until_system_timer_stops(timer)
+
+      restarted = Channel(Nil).new
+      spawn do
+        timer.start(second_output)
+        restarted.send(nil)
+      end
+      100.times { Fiber.yield }
+      timer.create_calls.should eq(1)
+      first.close_calls.should eq(0)
+      second.add_calls.should eq(0)
+
+      timer.wait_release.send(nil)
+      stopped.receive
+      restarted.receive
+      second_token = timer.wait_started.receive
+
+      first.close_calls.should eq(1)
+      second.add_calls.should eq(1)
+      second_token.should_not eq(first_token)
+
+      stopped_again = Channel(Nil).new
+      spawn do
+        timer.stop
+        stopped_again.send(nil)
+      end
+      wait_until_system_timer_stops(timer)
+      timer.wait_release.send(nil)
+      stopped_again.receive
+      second.close_calls.should eq(1)
+      first_output.close
+      second_output.close
+    end
+
+    it "keeps every Poller operation on the owning run fiber" do
+      poller = SystemTimerFakePoller.new
+      timer = SystemTimerCooperativeHarness.new(poller)
+      output = Channel(Termisu::Event::Any).new(1)
+      timer.start(output)
+      timer.wait_started.receive
+
+      timer.interval = 30.milliseconds
+      timer.stop
+
+      poller.add_calls.should eq(1)
+      poller.modify_calls.should eq(1)
+      poller.close_calls.should eq(1)
+      poller.operation_fibers.uniq.size.should eq(1)
+      output.close
+    end
+
+    it "keeps fallback readiness on absolute cadence deadlines" do
+      poller = SystemTimerFakePoller.new([
+        Termisu::Event::Poller::PollResult.new(type: :timer, timer_expirations: 1_u64),
+        Termisu::Event::Poller::PollResult.new(type: :timer, timer_expirations: 1_u64),
+      ])
+      interval = 6.milliseconds
+      timer = SystemTimerHarness.new([poller] of Termisu::Event::Poller, interval)
+      output = Channel(Termisu::Event::Any).new(2)
+      timer.start(output)
+
+      2.times do
+        timer.wait_started.receive
+        timer.wait_release.send(nil)
+        output.receive
+      end
+      timer.wait_started.receive
+
+      (timer.deadlines[1] - timer.deadlines[0]).should eq(interval)
+      (timer.deadlines[2] - timer.deadlines[1]).should eq(interval)
+
+      stopped = Channel(Nil).new
+      spawn do
+        timer.stop
+        stopped.send(nil)
+      end
+      wait_until_system_timer_stops(timer)
+      timer.wait_release.send(nil)
+      stopped.receive
+      output.close
+    end
+
+    it "preserves kernel expirations, frames, and timing fields" do
+      poller = SystemTimerFakePoller.new([
+        Termisu::Event::Poller::PollResult.new(type: :timer, timer_expirations: 3_u64),
+        Termisu::Event::Poller::PollResult.new(type: :timer, timer_expirations: 1_u64),
+      ])
+      timer = SystemTimerHarness.new([poller] of Termisu::Event::Poller)
+      output = Channel(Termisu::Event::Any).new(2)
+      timer.start(output)
+
+      timer.wait_started.receive
+      timer.wait_release.send(nil)
+      first = output.receive.as(Termisu::Event::Tick)
+      timer.wait_started.receive
+      timer.wait_release.send(nil)
+      second = output.receive.as(Termisu::Event::Tick)
+      timer.wait_started.receive
+
+      first.frame.should eq(0_u64)
+      first.missed_ticks.should eq(2_u64)
+      second.frame.should eq(1_u64)
+      second.missed_ticks.should eq(0_u64)
+      second.elapsed.should be >= first.elapsed
+      first.delta.should be >= 0.nanoseconds
+      second.delta.should be >= 0.nanoseconds
+
+      stopped = Channel(Nil).new
+      spawn do
+        timer.stop
+        stopped.send(nil)
+      end
+      wait_until_system_timer_stops(timer)
+      timer.wait_release.send(nil)
+      stopped.receive
+      poller.close_calls.should eq(1)
+      output.close
+    end
+  end
+
+  describe "failure cleanup" do
+    it "preserves an add failure when startup cleanup also fails" do
+      poller = SystemTimerFakePoller.new
+      poller.add_error = Exception.new("add failed")
+      poller.close_error = Exception.new("close failed")
+      timer = SystemTimerHarness.new([poller] of Termisu::Event::Poller)
+      output = Channel(Termisu::Event::Any).new(1)
+
+      expect_raises(Exception, "add failed") { timer.start(output) }
+      poller.add_calls.should eq(1)
+      poller.close_calls.should eq(1)
+      timer.running?.should be_false
+      timer.stop
+      output.close
+    end
+
+    it "reports owner-fiber interval modification failure without stale cleanup" do
+      poller = SystemTimerFakePoller.new
+      poller.modify_error = Exception.new("modify failed")
+      timer = SystemTimerCooperativeHarness.new(poller)
+      output = Channel(Termisu::Event::Any).new(1)
+      timer.start(output)
+      timer.wait_started.receive
+
+      expect_raises(Exception, "modify failed") { timer.interval = 30.milliseconds }
+      timer.interval.should eq(16.milliseconds)
+      poller.modify_calls.should eq(1)
+
+      timer.stop
+      poller.close_calls.should eq(1)
+      output.close
+    end
+
+    it "keeps a wait failure ahead of a cleanup failure and stays idempotent" do
+      poller = SystemTimerFakePoller.new
+      poller.wait_error = Exception.new("wait failed")
+      poller.close_error = Exception.new("close failed")
+      timer = SystemTimerHarness.new([poller] of Termisu::Event::Poller)
+      output = Channel(Termisu::Event::Any).new(1)
+      timer.start(output)
+      timer.wait_started.receive
+      timer.wait_release.send(nil)
+      wait_until_system_timer_stops(timer)
+
+      expect_raises(Exception, "wait failed") { timer.stop }
+      poller.close_calls.should eq(1)
+      timer.stop
+      poller.close_calls.should eq(1)
+      output.close
+    end
+
+    it "reports a close failure once" do
+      poller = SystemTimerFakePoller.new
+      poller.close_error = Exception.new("close failed")
+      timer = SystemTimerHarness.new([poller] of Termisu::Event::Poller)
+      output = Channel(Termisu::Event::Any).new(1)
+      timer.start(output)
+      timer.wait_started.receive
+
+      stopped = Channel(Exception?).new(1)
+      spawn do
+        timer.stop
+        stopped.send(nil)
+      rescue error
+        stopped.send(error)
+      end
+      wait_until_system_timer_stops(timer)
+      timer.wait_release.send(nil)
+
+      stopped.receive.try(&.message).should eq("close failed")
+      poller.close_calls.should eq(1)
+      timer.stop
+      poller.close_calls.should eq(1)
+      output.close
     end
   end
 

--- a/src/termisu/event/source/system_timer.cr
+++ b/src/termisu/event/source/system_timer.cr
@@ -37,80 +37,153 @@ class Termisu::Event::Source::SystemTimer < Termisu::Event::Source
   # Default tick interval (~60 FPS).
   DEFAULT_INTERVAL = 16.milliseconds
 
+  private class IntervalChange
+    getter interval : Time::Span
+    getter result : Channel(Exception?)
+
+    def initialize(@interval : Time::Span)
+      @result = Channel(Exception?).new(1)
+    end
+  end
+
+  private class Run
+    getter token : UInt64
+    getter output : Channel(Event::Any)
+    getter wakeups : Channel(Nil)
+    getter started : Channel(Exception?)
+    getter done : Channel(Nil)
+    getter interval_changes : Channel(IntervalChange)
+    getter start_time : MonotonicTime
+    property poller : Event::Poller?
+    property timer_handle : Event::Poller::TimerHandle?
+    property interval : Time::Span
+    property wait_interval : Time::Span
+    property next_deadline : MonotonicTime?
+    property error : Exception?
+
+    def initialize(
+      @token : UInt64,
+      @output : Channel(Event::Any),
+      @interval : Time::Span,
+      @start_time : MonotonicTime,
+    )
+      @wait_interval = @interval
+      @wakeups = Channel(Nil).new(1)
+      @started = Channel(Exception?).new(1)
+      @done = Channel(Nil).new
+      @interval_changes = Channel(IntervalChange).new(1)
+    end
+  end
+
   @running : Atomic(Bool)
   @interval : Time::Span
-  @output : Channel(Event::Any)?
-  @fiber : Fiber?
-  @poller : Event::Poller?
-  @timer_handle : Event::Poller::TimerHandle?
-  @start_time : MonotonicTime?
-  @last_tick : MonotonicTime?
-  @frame : UInt64
   @run_token : Atomic(UInt64)
+  @lifecycle_lock : Mutex
+  @run : Run?
 
   # Creates a new system timer with the specified interval.
   #
   # - `interval` - Time between tick events (default: 16ms for ~60 FPS)
   def initialize(@interval : Time::Span = DEFAULT_INTERVAL)
     @running = Atomic(Bool).new(false)
-    @frame = 0_u64
     @run_token = Atomic(UInt64).new(0_u64)
+    @lifecycle_lock = Mutex.new
+    @run = nil
   end
 
   # Returns the current interval between ticks.
   def interval : Time::Span
-    @interval
+    @lifecycle_lock.synchronize { @interval }
   end
 
   # Sets the interval between ticks.
   #
-  # If the timer is running, updates the system timer's interval.
+  # Poller instances are not thread-safe, so a running timer applies the change
+  # on its owning fiber before this method returns.
   def interval=(value : Time::Span)
-    @interval = value
-    if handle = @timer_handle
-      @poller.try(&.modify_timer(handle, value))
+    @lifecycle_lock.synchronize do
+      previous = @interval
+      @interval = value
+      begin
+        if (run = @run) && owns_run?(run)
+          request = IntervalChange.new(value)
+          run.interval_changes.send(request)
+          signal_run(run)
+
+          select
+          when error = request.result.receive
+            raise error if error
+          when run.done.receive?
+            raise run.error || Termisu::Error.new("SystemTimer stopped before changing interval")
+          end
+        end
+      rescue error
+        @interval = previous
+        raise error
+      end
     end
-    Log.debug { "SystemTimer interval changed to #{value}" }
+    lifecycle_log { Log.debug { "SystemTimer interval changed to #{value}" } }
   end
 
   # Starts generating tick events to the output channel.
   #
-  # Creates a platform-specific Poller and timer, then spawns a fiber
-  # to wait on timer events and emit Tick events to the channel.
+  # The owning fiber creates and manages the Poller. Startup remains synchronous
+  # so acquisition failures are still reported to the caller.
   def start(output : Channel(Event::Any)) : Nil
-    return unless @running.compare_and_set(false, true)
+    @lifecycle_lock.synchronize do
+      return if @running.get
+      reap_finished_run
 
-    run_token = advance_run_token
+      run = Run.new(advance_run_token, output, @interval, monotonic_now)
+      @run = run
+      @running.set(true)
 
-    @output = output
-    @frame = 0_u64
-    @start_time = monotonic_now
-    @last_tick = @start_time
+      spawn(name: "termisu-system-timer") do
+        run_loop(run)
+      end
 
-    # Create platform-specific poller and timer
-    poller = Event::Poller.create
-    @poller = poller
-    @timer_handle = poller.add_timer(@interval, repeating: true)
+      if error = run.started.receive
+        run.done.receive?
+        @run = nil if @run.same?(run)
+        advance_run_token if @run_token.get == run.token
+        raise error
+      end
 
-    @fiber = spawn(name: "termisu-system-timer") do
-      run_loop(run_token)
+      lifecycle_log do
+        if poller = run.poller
+          Log.debug { "SystemTimer started with interval=#{@interval} using #{poller.class.name}" }
+        end
+      end
     end
-
-    lifecycle_log { Log.debug { "SystemTimer started with interval=#{@interval} using #{poller.class.name}" } }
+  rescue error
+    @running.set(false)
+    raise error
   end
 
   # Stops generating tick events and releases resources.
+  #
+  # Stop only invalidates and wakes the run. The owning fiber closes its Poller
+  # before this method returns, preventing a stale run from touching descriptors
+  # acquired by a restart.
   def stop : Nil
-    return unless @running.compare_and_set(true, false)
+    @lifecycle_lock.synchronize do
+      run = @run
+      return unless run
 
-    # Invalidate ownership for any in-flight waiters before closing poller fds.
-    advance_run_token
+      if @run_token.get == run.token
+        @running.set(false)
+        advance_run_token
+        signal_run(run)
+      end
 
-    @poller.try(&.close)
-    @poller = nil
-    @timer_handle = nil
+      run.done.receive?
+      @run = nil if @run.same?(run)
+      if error = run.error
+        raise error
+      end
 
-    lifecycle_log { Log.debug { "SystemTimer stopped" } }
+      lifecycle_log { Log.debug { "SystemTimer stopped" } }
+    end
   end
 
   # Returns true if the timer is currently running.
@@ -123,77 +196,167 @@ class Termisu::Event::Source::SystemTimer < Termisu::Event::Source
     "system-timer"
   end
 
-  # Main timer loop - waits on poller for timer events.
-  #
-  # Yields before each blocking poll wait to keep cooperative scheduling fair.
-  private def run_loop(run_token : UInt64) : Nil
-    output = @output
-    poller = @poller
-    start_time = @start_time
-    last_tick = @last_tick
-    return unless output && poller && start_time && last_tick
+  # Factory seam used by focused lifecycle specs. The public Poller contract is
+  # unchanged: SystemTimer alone arranges cooperative waiting around zero-time
+  # Poller drains.
+  protected def create_poller : Event::Poller
+    Event::Poller.create
+  end
 
-    current_last_tick = last_tick
+  # Suspends only this fiber until cancellation or an absolute timer deadline.
+  # Absolute deadlines avoid accumulating scheduling and processing overhead.
+  protected def wait_for_readiness(
+    wakeups : Channel(Nil),
+    deadline : MonotonicTime,
+  ) : Nil
+    remaining = deadline - monotonic_now
+    return unless remaining > 0.nanoseconds
+
+    # Sub-millisecond event-loop timeouts are rounded inconsistently across
+    # supported Crystal/platform combinations. Rounding only the final wait up
+    # cannot accumulate drift because every deadline remains absolute.
+    delay = remaining < 1.millisecond ? 1.millisecond : remaining
+    select
+    when wakeups.receive
+    when timeout(delay)
+    end
+  end
+
+  # Kqueue timers use integer milliseconds. Match that native granularity so the
+  # private readiness deadline follows the kernel timer's actual cadence.
+  protected def cooperative_interval(interval : Time::Span) : Time::Span
+    {% if flag?(:darwin) || flag?(:freebsd) || flag?(:openbsd) %}
+      milliseconds = interval.total_milliseconds.to_i64
+      Math.max(milliseconds, 1_i64).milliseconds
+    {% else %}
+      interval
+    {% end %}
+  end
+
+  private def run_loop(run : Run) : Nil
+    poller = begin
+      setup_run(run)
+    rescue error
+      finish_failed_start(run, error)
+      return
+    end
+
+    run.started.send(nil)
+
+    begin
+      run_events(run, poller)
+    rescue Channel::ClosedError
+      lifecycle_log { Log.debug { "SystemTimer channel closed, exiting" } }
+    rescue error
+      run.error ||= error
+    ensure
+      @running.set(false) if @run_token.get == run.token
+      close_run_resources(run)
+      reject_pending_interval_change(run)
+      run.done.close
+    end
+  end
+
+  private def setup_run(run : Run) : Event::Poller
+    poller = create_poller
+    run.poller = poller
+    run.wait_interval = cooperative_interval(run.interval)
+    run.timer_handle = poller.add_timer(run.wait_interval, repeating: true)
+    run.next_deadline = monotonic_now + run.wait_interval
+    poller
+  end
+
+  private def finish_failed_start(run : Run, error : Exception) : Nil
+    run.error = error
+    @running.set(false) if @run_token.get == run.token
+    close_run_resources(run)
+    reject_pending_interval_change(run)
+    run.done.close
+    run.started.send(error)
+  end
+
+  private def run_events(run : Run, poller : Event::Poller) : Nil
+    start_time = run.start_time
+    current_last_tick = start_time
+    frame = 0_u64
     pending_missed = 0_u64
-    wait_token = run_token
+    deadline = run.next_deadline
+    return unless deadline
 
-    while @running.get
-      # Capture ownership immediately before the blocking wait.
-      wait_token = @run_token.get
-      result = wait_for_poll_result(poller)
-      break unless @running.get
+    while owns_run?(run)
+      wait_for_readiness(run.wakeups, deadline)
+      break unless owns_run?(run)
 
-      timer_result = as_timer_result(result)
-      next unless timer_result
+      if apply_interval_change(run, poller)
+        next_deadline = run.next_deadline
+        return unless next_deadline
+        deadline = next_deadline
+        next
+      end
 
-      current_last_tick, pending_missed = emit_tick(
-        output,
+      result = poller.wait(0.nanoseconds)
+      break unless owns_run?(run)
+
+      unless result && result.type.timer?
+        Fiber.yield
+        break unless owns_run?(run)
+        deadline = monotonic_now + 1.millisecond
+        run.next_deadline = deadline
+        next
+      end
+
+      emitted = emit_tick(
+        run,
         start_time,
         current_last_tick,
+        frame,
         pending_missed,
-        timer_result
+        result
       )
+      break unless emitted
+
+      current_last_tick, frame, pending_missed = emitted
+      deadline += run.wait_interval * expiration_count(result.timer_expirations)
+      run.next_deadline = deadline
     end
-  rescue Channel::ClosedError
-    Log.debug { "SystemTimer channel closed, exiting" }
-  rescue ex : IO::Error
-    # Expected shutdown race: stop closes poller fds while this fiber may still be
-    # blocked in poller.wait (epoll_wait/kevent/poll), which can raise EBADF.
-    # Re-raise only if this fiber still owns the active run.
-    if @running.get && wait_token == @run_token.get
-      raise ex
+  end
+
+  private def apply_interval_change(run : Run, poller : Event::Poller) : Bool
+    request = select
+    when value = run.interval_changes.receive
+      value
+    else
+      return false
     end
-    Log.debug { "SystemTimer stopped during poll wait (#{ex.message}), exiting" }
+
+    error = begin
+      handle = run.timer_handle
+      raise Termisu::Error.new("SystemTimer has no timer handle") unless handle
+      wait_interval = cooperative_interval(request.interval)
+      poller.modify_timer(handle, wait_interval)
+      run.interval = request.interval
+      run.wait_interval = wait_interval
+      run.next_deadline = monotonic_now + wait_interval
+      nil
+    rescue ex
+      ex
+    end
+    request.result.send(error)
+    true
   end
 
-  # Yields before blocking on poller.wait to keep other fibers responsive.
-  private def wait_for_poll_result(poller : Event::Poller) : Event::Poller::PollResult?
-    Fiber.yield
-    # Timer is already registered via add_timer, so blocking wait is expected.
-    poller.wait
-  end
-
-  # Returns only timer results, ignoring fd/timeout events.
-  private def as_timer_result(result : Event::Poller::PollResult?) : Event::Poller::PollResult?
-    return unless result
-    return result if result.type.timer?
-
-    nil
-  end
-
-  # Emits one Tick event for a timer result and returns updated state:
-  # {next_last_tick, next_pending_missed}.
+  # Emits one Tick event and returns updated per-run state.
   private def emit_tick(
-    output : Channel(Event::Any),
+    run : Run,
     start_time : MonotonicTime,
     current_last_tick : MonotonicTime,
+    frame : UInt64,
     pending_missed : UInt64,
     result : Event::Poller::PollResult,
-  ) : {MonotonicTime, UInt64}
+  ) : {MonotonicTime, UInt64, UInt64}?
     now = monotonic_now
     elapsed = now - start_time
     delta = now - current_last_tick
-    frame = @frame
     missed = missed_ticks_for(result.timer_expirations, pending_missed)
 
     tick = Event::Tick.new(
@@ -203,22 +366,73 @@ class Termisu::Event::Source::SystemTimer < Termisu::Event::Source
       missed_ticks: missed,
     )
 
-    @last_tick = now
-    @frame += 1
+    # Keep the original-run check adjacent to emission. A stop or restart that
+    # happens during either wait must never deliver through this stale run.
+    return unless owns_run?(run)
+    delivered = send_nonblocking(run.output, tick)
 
-    pending_missed_next = next_pending_missed(send_nonblocking(output, tick), missed)
-
-    if missed > 0
-      Log.warn { "SystemTimer missed #{missed} tick(s) at frame #{frame}" }
+    if delivered && missed > 0
+      lifecycle_log { Log.warn { "SystemTimer missed #{missed} tick(s) at frame #{frame}" } }
     end
 
-    {now, pending_missed_next}
+    {now, frame &+ 1_u64, next_pending_missed(delivered, missed)}
   end
 
-  # Expirations > 1 means kernel observed dropped intervals.
+  # Expirations > 1 means the kernel observed dropped intervals.
   private def missed_ticks_for(timer_expirations : UInt64, pending_missed : UInt64) : UInt64
     base_missed = timer_expirations > 0 ? timer_expirations - 1 : 0_u64
     base_missed + pending_missed
+  end
+
+  private def expiration_count(value : UInt64) : Int64
+    value.clamp(1_u64, Int64::MAX.to_u64).to_i64
+  end
+
+  private def owns_run?(run : Run) : Bool
+    @running.get && @run_token.get == run.token
+  end
+
+  private def signal_run(run : Run) : Nil
+    select
+    when run.wakeups.send(nil)
+    else
+      # A pending wakeup already covers this state change.
+    end
+  end
+
+  # Called only by the run fiber that created and used the Poller.
+  private def close_run_resources(run : Run) : Nil
+    first_error = run.error
+
+    if poller = run.poller
+      error = begin
+        poller.close
+        nil
+      rescue ex
+        ex
+      end
+      first_error ||= error
+    end
+
+    run.error = first_error
+  end
+
+  private def reject_pending_interval_change(run : Run) : Nil
+    select
+    when request = run.interval_changes.receive
+      request.result.send(run.error || Termisu::Error.new("SystemTimer run stopped"))
+    else
+    end
+  end
+
+  private def reap_finished_run : Nil
+    return unless run = @run
+
+    run.done.receive?
+    @run = nil
+    if error = run.error
+      raise error
+    end
   end
 
   # Advances the run token and returns the new value.


### PR DESCRIPTION
## Rationale

`SystemTimer` yielded and then blocked the scheduler in a native Poller wait. Its shared lifecycle state also allowed stop/restart races to expose replacement resources to an old run.

## Design

- keep cooperative readiness/cancellation private to `SystemTimer`; public `Event::Poller` semantics are unchanged
- use absolute scheduler deadlines followed by zero-time Poller drains; match kqueue's integer-millisecond granularity and clamp its minimum to 1 ms
- queue interval changes to the owning run fiber so every Poller create/add/modify/wait/close operation has one owner
- check the original run token after each cooperative/native wait and immediately before delivery
- serialize stop/restart, join owner cleanup before replacement acquisition, rollback rejected interval changes, and retain first-error/idempotent cleanup behavior

## Correctness evidence

Deterministic specs cover absolute (non-reanchored) deadlines, stale-run invalidation on both sides of the Poller drain, cleanup-before-restart, owner-fiber Poller access, startup/modify/wait/close failures, fallback interval-change stress, expiration/missed accounting, backend granularity, and sustained 6.9/16/50 ms cadence. A confirmed 2 s wait is cancelled before stop returns.

Linux Crystal 1.21 measurements (directional timing only):
- independent 1 ms fiber increments during two 50 ms periods: `26, 26, 26, 26, 26`
- confirmed-wait stop samples: `0.005-0.012 ms`
- 20 emissions: 6.9 ms => 139.65 ms/0 missed; 16 ms => 323.93 ms/0 missed; 50 ms => 1000.08 ms/0 missed

## Validation

Local:
- Crystal 1.17.0 and 1.18.2 focused Poller/SystemTimer: 91 examples, 0 failures; final Crystal 1.21 focused: 93 examples, 0 failures
- Crystal 1.21 full suite under PTY: 1377 examples, 0 failures, 15 environment-related pending
- Crystal E2E/PTY: 82 examples, 0 failures
- Crystal format check and Ameba: 162 files, 0 failures
- C format/lint and native C ABI tests: passed
- Bun typecheck and native/unit tests: 48 passed
- `git diff --check`: passed

PR CI on the final SHA has passed Linux Crystal 1.17-1.21, FreeBSD runtime tests, and Linux/macOS/FreeBSD E2E. The five macOS full-test jobs remain queued for hosted runners. Local Biome execution was unavailable because its upstream ELF requests `/lib64/ld-linux-x86-64.so.2`, absent on this NixOS host; no JS files changed.
