### PR TITLE
perf: accelerate buffer cell writes

### DIFF
--- a/spec/termisu/buffer_spec.cr
+++ b/spec/termisu/buffer_spec.cr
@@ -123,6 +123,14 @@ describe Termisu::Buffer do
       buffer.set_cell(5, 5, 'A').should be_false
     end
 
+    it "rejects String, Char, and unsafe Char writes for zero dimensions" do
+      [Termisu::Buffer.new(0, 0), Termisu::Buffer.new(0, 2), Termisu::Buffer.new(2, 0)].each do |buffer|
+        buffer.set_cell(0, 0, "A").should be_false
+        buffer.set_cell(0, 0, 'A').should be_false
+        buffer.set_cell(0, 0, (-1).unsafe_chr).should be_false
+      end
+    end
+
     it "returns false for C0 control characters (except space)" do
       buffer = Termisu::Buffer.new(10, 5)
       buffer.set_cell(0, 0, '\u{0}').should be_false  # NUL
@@ -182,6 +190,104 @@ describe Termisu::Buffer do
       buffer.set_cell(0, 0, "\u{7F}").should be_false                  # DEL rejected as control
       buffer.set_cell(0, 0, '\u{80}').should be_false                  # C1 control rejected (2-byte UTF-8)
       buffer.set_cell(0, 0, String.new(Bytes[0xFF_u8])).should be_true # invalid byte keeps replacement-char acceptance
+    end
+
+    it "retains exact graphemes for equal-content String and Char rewrites" do
+      buffer = Termisu::Buffer.new(6, 1)
+      renderer = MockRenderer.new
+      style = Termisu::Attribute::Bold | Termisu::Attribute::Underline
+      original = String.new("e\u{301}".to_slice)
+
+      buffer.set_cell(1, 0, original,
+        fg: Termisu::Color.rgb(1, 2, 3), bg: Termisu::Color.ansi256(42), attr: style).should be_true
+      buffer.set_cell(3, 0, '中', fg: Termisu::Color.red, attr: Termisu::Attribute::Reverse).should be_true
+      buffer.render_to(renderer)
+      renderer.clear
+
+      equal_copy = String.new(original.to_slice)
+      equal_copy.should_not be(original)
+      buffer.set_cell(1, 0, equal_copy,
+        fg: Termisu::Color.rgb(1, 2, 3), bg: Termisu::Color.ansi256(42), attr: style).should be_true
+      buffer.set_cell(3, 0, '中', fg: Termisu::Color.red, attr: Termisu::Attribute::Reverse).should be_true
+      buffer.render_to(renderer)
+
+      renderer.write_calls.should be_empty
+      buffer.get_cell(1, 0).as(Termisu::Cell).grapheme.should be(original)
+      buffer.get_cell(3, 0).as(Termisu::Cell).width.should eq(2u8)
+      buffer.get_cell(4, 0).as(Termisu::Cell).continuation?.should be_true
+
+      buffer.set_cell(1, 0, equal_copy,
+        fg: Termisu::Color.rgb(1, 2, 3), bg: Termisu::Color.ansi256(42),
+        attr: Termisu::Attribute::Bold).should be_true
+      buffer.get_cell(1, 0).as(Termisu::Cell).attr.should eq(Termisu::Attribute::Bold)
+    end
+
+    it "rejects unsafe non-scalar Char values without mutation" do
+      buffer = Termisu::Buffer.new(5, 1)
+      buffer.set_cell(1, 0, '中', fg: Termisu::Color.green).should be_true
+      before = Array.new(5) { |x| buffer.get_cell(x, 0) }
+
+      [-1, 0xD800, 0xDFFF, 0x110000, Int32::MAX].each do |codepoint|
+        buffer.set_cell(2, 0, codepoint.unsafe_chr, attr: Termisu::Attribute::Bold).should be_false
+        Array.new(5) { |x| buffer.get_cell(x, 0) }.should eq(before)
+      end
+
+      [0xD7FF, 0xE000, Char::MAX_CODEPOINT].each_with_index do |codepoint, x|
+        ch = codepoint.unsafe_chr
+        buffer.set_cell(x, 0, ch).should be_true
+        buffer.get_cell(x, 0).as(Termisu::Cell).grapheme.should eq(ch.to_s)
+      end
+    end
+
+    it "keeps wide neighbors intact when malformed submissions are rejected" do
+      buffer = Termisu::Buffer.new(5, 1)
+      buffer.set_cell(1, 0, '中', fg: Termisu::Color.blue).should be_true
+      buffer.set_cell(3, 0, 'X').should be_true
+      before = Array.new(5) { |x| buffer.get_cell(x, 0) }
+
+      ["", "AB", "\u{301}", "\u{7F}", String.new(Bytes[0xFF_u8, 0xFF_u8])].each do |invalid|
+        buffer.set_cell(2, 0, invalid, attr: Termisu::Attribute::Bold).should be_false
+        Array.new(5) { |x| buffer.get_cell(x, 0) }.should eq(before)
+      end
+
+      buffer.set_cell(4, 0, '中').should be_false
+      Array.new(5) { |x| buffer.get_cell(x, 0) }.should eq(before)
+    end
+
+    it "keeps Char and String submissions equivalent across generated overlaps" do
+      char_buffer = Termisu::Buffer.new(9, 3)
+      string_buffer = Termisu::Buffer.new(9, 3)
+      chars = ['A', ' ', 'é', '中', '😀', '\u{301}', '\u{7F}', 'Z']
+      colors = [Termisu::Color.white, Termisu::Color.red, Termisu::Color.ansi256(42)]
+      attrs = [Termisu::Attribute::None, Termisu::Attribute::Bold, Termisu::Attribute::Reverse]
+
+      240.times do |iteration|
+        ch = chars[(iteration * 7 + 3) % chars.size]
+        x = (iteration * 5 + iteration // 7) % 9
+        y = (iteration * 2 + iteration // 11) % 3
+        fg = colors[(iteration * 2 + 1) % colors.size]
+        bg = colors[(iteration + 2) % colors.size]
+        attr = attrs[(iteration * 5) % attrs.size]
+
+        char_result = char_buffer.set_cell(x, y, ch, fg: fg, bg: bg, attr: attr)
+        string_result = string_buffer.set_cell(x, y, ch.to_s, fg: fg, bg: bg, attr: attr)
+        char_result.should eq(string_result)
+
+        3.times do |row|
+          9.times do |col|
+            char_cell = char_buffer.get_cell(col, row).as(Termisu::Cell)
+            char_cell.should eq(string_buffer.get_cell(col, row))
+
+            if char_cell.continuation?
+              col.should be > 0
+              char_buffer.get_cell(col - 1, row).as(Termisu::Cell).width.should eq(2u8)
+            elsif char_cell.width == 2
+              col.should be < 8
+              char_buffer.get_cell(col + 1, row).as(Termisu::Cell).continuation?.should be_true
+            end
+          end
+        end
+      end
     end
 
     it "sets cell with attributes" do
@@ -374,6 +480,26 @@ describe Termisu::Buffer do
         renderer.write_calls.join.should contain("B")
         renderer.fg_calls.should contain(Termisu::Color.red)
       end
+    end
+
+    it "keeps an unchanged fast-path rewrite retryable after render failure" do
+      renderer = RenderFaultRenderer.new(RenderFaultRenderer::Phase::Write)
+      buffer = Termisu::Buffer.new(5, 1)
+      combining = "e\u{301}"
+      buffer.set_cell(0, 0, combining, fg: Termisu::Color.green).should be_true
+      buffer.set_cell(2, 0, '中', attr: Termisu::Attribute::Bold).should be_true
+
+      expect_raises(Exception, "injected Write failure") do
+        buffer.render_to(renderer)
+      end
+
+      buffer.set_cell(0, 0, String.new(combining.to_slice), fg: Termisu::Color.green).should be_true
+      buffer.set_cell(2, 0, '中', attr: Termisu::Attribute::Bold).should be_true
+      renderer.clear
+      buffer.render_to(renderer)
+
+      renderer.write_calls.join.should contain(combining)
+      renderer.write_calls.join.should contain("中")
     end
 
     it "clears stale cached attributes when retrying an unstyled frame" do

--- a/src/termisu/buffer.cr
+++ b/src/termisu/buffer.cr
@@ -97,29 +97,24 @@ class Termisu::Buffer
     attr : Attribute = Attribute::None,
   ) : Bool
     return false if out_of_bounds?(x, y)
+
+    index = y * @width + x
+    style_key = Cell.style_key(fg, bg, attr)
+    return true if current_cell_matches?(index, grapheme, style_key)
+
     return false unless single_grapheme?(grapheme)
     return false if control_char?(grapheme[0])
 
-    # Create cell to determine width
-    cell = Cell.new(grapheme, fg: fg, bg: bg, attr: attr)
-    width = cell.width
+    width = UnicodeWidth.grapheme_width(grapheme)
+    return false unless valid_width_at?(width, x)
 
-    # Reject wide writes that cannot fit
-    return false if width == 2 && x >= @width - 1
-
-    # Enforce width-0 policy: standalone width-0 characters (combining marks)
-    # are rejected so the Char API never consumes a logical grid cell without
-    # consuming columns. This prevents rendering anomalies where invisible
-    # characters would occupy buffer cells without visible content.
-    return false if width == 0
-
-    set_cell_internal(x, y, cell, width)
+    set_changed_cell(x, y, grapheme, width, style_key)
     true
   end
 
   # Interned single-character strings for ASCII, avoiding one Char#to_s heap
   # allocation per set_cell(Char) call. Control-char entries are harmless:
-  # they are rejected downstream by control_char?, identical to ch.to_s.
+  # the Char overload rejects them before looking up this table.
   private ASCII_GRAPHEMES = Array(String).new(128, &.unsafe_chr.to_s)
 
   def set_cell(
@@ -130,49 +125,55 @@ class Termisu::Buffer
     bg : Color = Color.default,
     attr : Attribute = Attribute::None,
   ) : Bool
-    # ch.ascii? proves ch.ord is in 0..127, so unsafe_fetch is in bounds.
-    grapheme = ch.ascii? ? ASCII_GRAPHEMES.unsafe_fetch(ch.ord) : ch.to_s
-    set_cell(x, y, grapheme, fg, bg, attr)
+    return false if out_of_bounds?(x, y)
+
+    codepoint = ch.ord
+    return false unless scalar_codepoint?(codepoint)
+    return false if control_codepoint?(codepoint)
+
+    index = y * @width + x
+    style_key = Cell.style_key(fg, bg, attr)
+    return true if current_cell_matches?(index, ch, style_key)
+
+    width = UnicodeWidth.codepoint_width(codepoint)
+    return false unless valid_width_at?(width, x)
+
+    grapheme = codepoint < 0x80 ? ASCII_GRAPHEMES.unsafe_fetch(codepoint) : ch.to_s
+    set_changed_cell(x, y, grapheme, width, style_key)
+    true
   end
 
-  # Internal cell writer that handles occupancy invariants and overlap clearing.
-  #
-  # This is the core write primitive that handles:
-  # - Wide character writes (creates leading + continuation cells)
-  # - Overlap clearing when overwriting wide cells or their continuations
-  # - Direct overwrite of target cells (assign_back_key handles count/dirty
-  #   deltas per transition)
-  #
-  # Assumes caller has validated bounds and fit constraints.
-  private def set_cell_internal(x : Int32, y : Int32, cell : Cell, width : UInt8) : Nil
+  # Core writer for a validated value known to differ from the current leading
+  # cell. It owns all wide-cell and overlap invariants for both public overloads.
+  private def set_changed_cell(
+    x : Int32,
+    y : Int32,
+    grapheme : String,
+    width : UInt8,
+    style_key : UInt128,
+  ) : Nil
     row_start = y * @width
+    index = row_start + x
+    key = Cell.validated_key(grapheme, width, style_key)
 
     # Clear overlap: if writing into a continuation cell, clear its owner first
-    if Cell.key_continuation?(@back_keys[row_start + x])
-      clear_continuation_owner(x, y)
-    end
+    clear_continuation_owner(x, y) if Cell.key_continuation?(@back_keys[index])
 
-    # Clear overlap: if overwriting a wide cell, clear its continuation
     if width == 2
       # If x+1 is a wide leading cell, clear its continuation at x+2 first
-      # to prevent orphan continuation cells (BUG-008)
-      if x + 2 < @width && Cell.key_width(@back_keys[row_start + x + 1]) == 2
-        assign_back_key(row_start + x + 2, y, Cell::DEFAULT_KEY, "")
+      # to prevent orphan continuation cells (BUG-008).
+      if x + 2 < @width && Cell.key_width(@back_keys[index + 1]) == 2
+        assign_back_key(index + 2, y, Cell::DEFAULT_KEY, "")
       end
 
-      # Overwrite targets directly: assign_back_key count/dirty updates depend
-      # only on old/new endpoints, so no pre-clear is needed; a rewrite of an
-      # identical wide cell is a no-op and leaves the row clean.
-      # Write leading cell
-      assign_back_key(row_start + x, y, cell.key, cell.grapheme)
-      # Write continuation cell
-      assign_back_key(row_start + x + 1, y, Cell::CONTINUATION_KEY, "")
+      assign_back_key(index, y, key, grapheme)
+      assign_back_key(index + 1, y, Cell::CONTINUATION_KEY, "")
     else
-      # Narrow write: clear any wide cell that overlaps next position
-      if x + 1 < @width && Cell.key_width(@back_keys[row_start + x]) == 2
-        assign_back_key(row_start + x + 1, y, Cell::DEFAULT_KEY, "")
+      # A narrow write over a wide leading cell releases its continuation.
+      if x + 1 < @width && Cell.key_width(@back_keys[index]) == 2
+        assign_back_key(index + 1, y, Cell::DEFAULT_KEY, "")
       end
-      assign_back_key(row_start + x, y, cell.key, cell.grapheme)
+      assign_back_key(index, y, key, grapheme)
     end
   end
 
@@ -366,12 +367,61 @@ class Termisu::Buffer
     x < 0 || x >= @width || y < 0 || y >= @height
   end
 
-  # Rejects C0 controls (0x00-0x1F except space) and C1 controls (0x7F-0x9F).
-  # These characters would desync render-state cursor tracking because
-  # the terminal interprets them as movement commands, not display characters.
+  # Exact retained-write checks happen before segmentation, width calculation,
+  # String conversion, or grapheme interning. Continuations never match: a
+  # submission at one must still clear its owner and establish a new lead.
+  private def current_cell_matches?(index : Int32, grapheme : String, style_key : UInt128) : Bool
+    key = @back_keys.unsafe_fetch(index)
+    return false if Cell.key_continuation?(key)
+    return false unless (key & Cell::KEY_STYLE_MASK) == style_key
+
+    if grapheme.bytesize == 1
+      byte = grapheme.to_unsafe[0]
+      return Cell.key_grapheme_id(key) == byte if byte < 0x80
+    end
+
+    Cell.key_grapheme_interned?(key) && @graphemes.unsafe_fetch(index) == grapheme
+  end
+
+  private def current_cell_matches?(index : Int32, ch : Char, style_key : UInt128) : Bool
+    key = @back_keys.unsafe_fetch(index)
+    return false if Cell.key_continuation?(key)
+    return false unless (key & Cell::KEY_STYLE_MASK) == style_key
+
+    codepoint = ch.ord
+    return Cell.key_grapheme_id(key) == codepoint if codepoint < 0x80
+    return false unless Cell.key_grapheme_interned?(key)
+
+    grapheme = @graphemes.unsafe_fetch(index)
+    return false unless grapheme.bytesize == ch.bytesize
+
+    offset = 0
+    ch.each_byte do |byte|
+      return false unless grapheme.to_unsafe[offset] == byte
+      offset += 1
+    end
+    true
+  end
+
+  # Rejects C0 controls (0x00-0x1F) and C1 controls (0x7F-0x9F). These would
+  # desync render-state cursor tracking because terminals interpret them as
+  # movement commands rather than displayed characters.
   private def control_char?(char : Char) : Bool
-    cp = char.ord
-    cp < 0x20 || (cp >= 0x7F && cp <= 0x9F)
+    control_codepoint?(char.ord)
+  end
+
+  private def control_codepoint?(codepoint : Int32) : Bool
+    codepoint < 0x20 || (codepoint >= 0x7F && codepoint <= 0x9F)
+  end
+
+  # Char can contain out-of-range values when constructed with unsafe_chr.
+  # Reject them before any table access or UTF-8 conversion.
+  private def scalar_codepoint?(codepoint : Int32) : Bool
+    codepoint >= 0 && codepoint <= Char::MAX_CODEPOINT && !(0xD800..0xDFFF).includes?(codepoint)
+  end
+
+  private def valid_width_at?(width : UInt8, x : Int32) : Bool
+    width > 0 && (width < 2 || x < @width - 1)
   end
 
   # Fast path: a single ASCII byte is always exactly one grapheme cluster,

--- a/src/termisu/cell.cr
+++ b/src/termisu/cell.cr
@@ -194,13 +194,41 @@ struct Termisu::Cell
   end
 
   private def compute_key : UInt128
-    key = UInt128.new(@attr.value)
-    key |= UInt128.new(Cell.color_key(@fg)) << 16
-    key |= UInt128.new(Cell.color_key(@bg)) << 50
-    key |= UInt128.new(Cell.grapheme_id(@grapheme)) << 84
-    key |= UInt128.new(@width) << 116
-    key |= CONTINUATION_BIT if @continuation
+    Cell.validated_key(@grapheme, @width, @fg, @bg, @attr, @continuation)
+  end
+
+  # Builds a packed key for fields whose grapheme and width invariants have
+  # already been validated. Buffer uses this after its submission fast paths so
+  # changed writes do not repeat segmentation or width calculation in Cell.
+  protected def self.validated_key(
+    grapheme : String,
+    width : UInt8,
+    fg : Color,
+    bg : Color,
+    attr : Attribute,
+    continuation : Bool = false,
+  ) : UInt128
+    validated_key(grapheme, width, style_key(fg, bg, attr), continuation)
+  end
+
+  protected def self.validated_key(
+    grapheme : String,
+    width : UInt8,
+    style_key : UInt128,
+    continuation : Bool = false,
+  ) : UInt128
+    key = style_key | (UInt128.new(grapheme_id(grapheme)) << 84)
+    key |= UInt128.new(width) << 116
+    key |= CONTINUATION_BIT if continuation
     key
+  end
+
+  # Packed style identity used to compare a submitted style with an existing
+  # Buffer key before grapheme conversion or interning.
+  protected def self.style_key(fg : Color, bg : Color, attr : Attribute) : UInt128
+    key = UInt128.new(attr.value)
+    key |= UInt128.new(color_key(fg)) << 16
+    key | (UInt128.new(color_key(bg)) << 50)
   end
 
   # 34-bit color key: bits 32..33 carry the mode so equal keys always imply


### PR DESCRIPTION
## Rationale

Repeated writes of an already-retained cell currently pay grapheme segmentation, width calculation, `Char#to_s`, and interning costs before discovering that nothing changed.

## Design

- Check bounds first, then compare the current leading cell's exact grapheme and packed style.
- Give `Char` its own scalar/control/width path so unchanged non-ASCII chars avoid `to_s` and unsafe non-scalars are rejected.
- Route changed, validated String and Char values through one writer that preserves wide-cell ownership, continuations, and overlap clearing.
- Keep malformed/control/zero-width/edge-wide writes non-mutating and preserve render-failure retry behavior.

## Evidence

- Focused Buffer/Cell/UnicodeWidth specs: 167 examples, 0 failures on Crystal 1.17.0, 1.18.2, and 1.21.0 (repeated on the final base for 1.17 and 1.21).
- Full PTY-backed Crystal suite on the final base (Crystal 1.21.0): 1412 examples, 0 failures, 15 environment-dependent pending. Full Crystal 1.17.0 run before the final unrelated main rebase: 1376 examples, 0 failures, 15 pending.
- Crystal-native E2E/PTTY suite: 82 examples, 0 failures.
- Ameba: 162 files, 0 failures; Crystal format check and `git diff --check` passed.
- C ABI tests and C format/lint passed.
- Bun 1.4.0: 48 tests, 0 failures; Biome and TypeScript checks passed.
- Independent fixed-seed 10,000-operation differential workload against `main` produced identical result/state output.

A release allocation probe used 10,000 warmups and 500,000 measured operations in five processes per toolchain. On Crystal 1.17.0, 1.18.2, and 1.21.0, unchanged ASCII/non-ASCII `Char`, changed ASCII `Char`, equal-content distinct unchanged `String`, and changed preallocated ASCII/non-ASCII `String` were 0 B/op apart from occasional 192-byte process-level noise on 1.21 (at most 0.000384 B/op). Alternating changed CJK `Char` remained about 32 B/op. String and Char results are intentionally separate.

No timing claim is made: this branch still has the known-invalid legacy benchmark harness. Crystal 1.19/1.20 were not locally installed; the repository CI matrix covers 1.17–1.21.
