### PR TITLE
perf: fast-path zero-timeout parsing

### DIFF
--- a/spec/termisu/input/parser_spec.cr
+++ b/spec/termisu/input/parser_spec.cr
@@ -127,6 +127,58 @@ private class ParserDripProbe < Termisu::Input::Parser
   end
 end
 
+# Supplies exactly one byte per read so parser continuation paths cannot rely on
+# Reader's internal buffering. It also records every requested wait and exact
+# byte consumption for deterministic nonblocking and differential assertions.
+private class ParserCountingReader < Termisu::Reader
+  getter waits = [] of Int32
+  getter consumed = 0
+
+  @bytes : Array(UInt8)
+
+  def initialize(bytes : Bytes)
+    super(-1)
+    @bytes = bytes.to_a
+  end
+
+  def append(bytes : Bytes) : Nil
+    bytes.each { |byte| @bytes << byte }
+  end
+
+  def read_byte(timeout_ms : Int32) : UInt8?
+    @waits << timeout_ms
+    return if @consumed >= @bytes.size
+
+    byte = @bytes[@consumed]
+    @consumed += 1
+    byte
+  end
+
+  def peek_byte(timeout_ms : Int32) : UInt8?
+    @waits << timeout_ms
+    return if @consumed >= @bytes.size
+
+    @bytes[@consumed]
+  end
+end
+
+private class ParserClockProbe < Termisu::Input::Parser
+  getter clock_reads = 0
+
+  def initialize(reader : ParserCountingReader, @now : MonotonicTime)
+    super(reader)
+  end
+
+  def advance(span : Time::Span) : Nil
+    @now += span
+  end
+
+  private def monotonic_now : MonotonicTime
+    @clock_reads += 1
+    @now
+  end
+end
+
 describe Termisu::Input::Parser do
   # A wait is rounded up so a live deadline never truncates to a 0ms spin, but a
   # whole number is already the answer — inflating it would overshoot the budget
@@ -909,6 +961,145 @@ describe Termisu::Input::Parser do
     end
 
     context "parser deadlines" do
+      it "skips parser clock reads for ordinary zero-timeout events" do
+        cases = {
+          "ASCII"        => Bytes['a'.ord],
+          "CSI"          => "\e[A".to_slice,
+          "SGR mouse"    => "\e[<0;10;20M".to_slice,
+          "normal mouse" => Bytes[0x1B, '['.ord, 'M'.ord, 32, 33, 33],
+          "Kitty"        => "\e[97;1u".to_slice,
+          "UTF-8"        => "€".to_slice,
+        }
+
+        cases.each do |name, bytes|
+          reader = ParserCountingReader.new(bytes)
+          parser = ParserClockProbe.new(reader, monotonic_now)
+
+          event = parser.poll_event(0)
+
+          event.should_not be_nil, name
+          parser.clock_reads.should eq(0), name
+          reader.consumed.should eq(bytes.size), name
+          reader.waits.all?(&.zero?).should be_true, name
+        end
+      end
+
+      it "keeps empty input and a fragmented Escape nonblocking without clock reads" do
+        empty_reader = ParserCountingReader.new(Bytes.empty)
+        empty_parser = ParserClockProbe.new(empty_reader, monotonic_now)
+        empty_parser.poll_event(0).should be_nil
+        empty_parser.clock_reads.should eq(0)
+        empty_reader.waits.should eq([0])
+
+        escape_reader = ParserCountingReader.new(Bytes[0x1B])
+        escape_parser = ParserClockProbe.new(escape_reader, monotonic_now)
+        event = escape_parser.poll_event(0).as(Termisu::Event::Key)
+        event.key.should eq(Termisu::Input::Key::Escape)
+        escape_parser.clock_reads.should eq(0)
+        escape_reader.consumed.should eq(1)
+        escape_reader.waits.should eq([0, 0])
+      end
+
+      it "clears transient deadlines when switching to a zero-timeout poll" do
+        reader = ParserCountingReader.new("a\e[A".to_slice)
+        parser = ParserClockProbe.new(reader, monotonic_now)
+
+        parser.poll_event(10).as(Termisu::Event::Key).key.should eq(Termisu::Input::Key::LowerA)
+        reads_before_zero_poll = parser.clock_reads
+        waits_before_zero_poll = reader.waits.size
+
+        parser.poll_event(0).as(Termisu::Event::Key).key.should eq(Termisu::Input::Key::Up)
+        parser.clock_reads.should eq(reads_before_zero_poll)
+        reader.waits[waits_before_zero_poll..].all?(&.zero?).should be_true
+      end
+
+      it "retains positive and blocking poll deadline setup" do
+        positive_reader = ParserCountingReader.new(Bytes['a'.ord])
+        positive_parser = ParserClockProbe.new(positive_reader, monotonic_now)
+        positive_parser.poll_event(10).as(Termisu::Event::Key).key.should eq(Termisu::Input::Key::LowerA)
+        positive_parser.clock_reads.should eq(1)
+        positive_reader.waits.should eq([10])
+
+        blocking_reader = ParserCountingReader.new(Bytes['a'.ord])
+        blocking_parser = ParserClockProbe.new(blocking_reader, monotonic_now)
+        blocking_parser.poll_event.as(Termisu::Event::Key).key.should eq(Termisu::Input::Key::LowerA)
+        blocking_parser.clock_reads.should eq(2)
+        blocking_reader.waits.should eq([Int32::MAX])
+      end
+
+      it "keeps the paste-tail deadline across zero-timeout polls and recovers after expiry" do
+        reader = ParserCountingReader.new("\e[200~\e".to_slice)
+        parser = ParserClockProbe.new(reader, monotonic_now)
+
+        parser.poll_event(0).as(Termisu::Event::Key).key.should eq(Termisu::Input::Key::PasteStart)
+        parser.clock_reads.should eq(0)
+
+        parser.poll_event(0).should be_nil
+        parser.clock_reads.should eq(2) # establish and check the persistent deadline
+
+        parser.advance(999.milliseconds)
+        parser.poll_event(0).should be_nil
+        parser.clock_reads.should eq(3)
+
+        parser.advance(2.milliseconds)
+        expired = parser.poll_event(0).as(Termisu::Event::Key)
+        expired.key.should eq(Termisu::Input::Key::Escape)
+        expired.char.should eq('\e')
+        parser.clock_reads.should eq(4)
+
+        reader.append("\e[201~".to_slice)
+        parser.poll_event(0).as(Termisu::Event::Key).key.should eq(Termisu::Input::Key::PasteEnd)
+        parser.clock_reads.should eq(5)
+        parser.prepare_raw_handoff.should be_true
+      end
+
+      it "matches the positive-deadline path on a fixed-seed fragmented corpus" do
+        random = Random.new(0x5EED_u64)
+
+        256.times do |index|
+          bytes = case random.rand(10)
+                  when 0
+                    Bytes[(32 + random.rand(95)).to_u8]
+                  when 1
+                    ["é", "€", "界", "🙂"][random.rand(4)].to_slice
+                  when 2
+                    "\e[#{"ABCDHFZ"[random.rand(7)]}".to_slice
+                  when 3
+                    "\e[#{97 + random.rand(26)};#{1 + random.rand(8)}u".to_slice
+                  when 4
+                    "\e[<#{random.rand(80)};#{1 + random.rand(200)};#{1 + random.rand(200)}M".to_slice
+                  when 5
+                    Bytes[0x1B, '['.ord, 'M'.ord, (32 + random.rand(4)).to_u8,
+                      (33 + random.rand(100)).to_u8, (33 + random.rand(100)).to_u8]
+                  when 6
+                    "\eO#{"PQRSABCDHF"[random.rand(10)]}".to_slice
+                  when 7
+                    Bytes[0xF0, 0x9F]
+                  when 8
+                    "\e[1;".to_slice
+                  else
+                    random.rand(2).zero? ? "\e[200~".to_slice : "\e[201~".to_slice
+                  end
+
+          fast_reader = ParserCountingReader.new(bytes)
+          fast = ParserClockProbe.new(fast_reader, monotonic_now)
+          reference_reader = ParserCountingReader.new(bytes)
+          reference = ParserClockProbe.new(reference_reader, monotonic_now)
+
+          fast_event = fast.poll_event(0)
+          reference_event = reference.poll_event(100)
+          fast_event.should eq(reference_event), "case #{index}"
+          fast_reader.consumed.should eq(reference_reader.consumed), "case #{index}"
+
+          sentinel = Bytes['!'.ord]
+          fast_reader.append(sentinel)
+          reference_reader.append(sentinel)
+          fast.poll_event(0).should eq(reference.poll_event(100)), "following event for case #{index}"
+          fast_reader.consumed.should eq(reference_reader.consumed), "following bytes for case #{index}"
+          fast.prepare_raw_handoff.should eq(reference.prepare_raw_handoff), "state for case #{index}"
+        end
+      end
+
       it "parses complete buffered sequences nonblockingly across every read boundary" do
         utf8 = parse_sequence_with_buffer("€".to_slice, 1, 0)
         utf8.should be_a(Termisu::Event::Key)

--- a/src/termisu/input/parser.cr
+++ b/src/termisu/input/parser.cr
@@ -160,6 +160,9 @@ class Termisu::Input::Parser
   # render loop a full second on a truncated paste; instead each call waits only
   # what it has, hands the ESC back, and the next call resumes the probe.
   @paste_deadline : MonotonicTime? = nil
+  # Transient state for the current poll. A zero-timeout poll is explicitly
+  # nonblocking, so continuation reads can skip deadline clock work altogether.
+  @nonblocking : Bool = false
   @poll_deadline : MonotonicTime? = nil
   # Absolute end-to-end deadline used by every byte of the current parse. A
   # blocking poll may wait indefinitely for its first byte, but once parsing has
@@ -225,14 +228,14 @@ class Termisu::Input::Parser
   #
   # Returns an Event or nil if timeout/no data.
   def poll_event(timeout_ms : Int32 = -1) : Event::Any?
-    now = monotonic_now
-    @poll_deadline = timeout_ms < 0 ? nil : now + timeout_ms.milliseconds
-    @parse_deadline = @poll_deadline
+    started_at = prepare_poll(timeout_ms)
 
     # Bytes already taken off the fd while probing for an end marker come first,
     # and without consulting the fd: they have arrived, so no timeout applies.
     if byte = @pending.shift?
-      @parse_deadline ||= now + ESCAPE_TIMEOUT_MS.milliseconds
+      if started_at
+        @parse_deadline ||= started_at + ESCAPE_TIMEOUT_MS.milliseconds
+      end
       return parse_byte(byte)
     end
 
@@ -242,8 +245,25 @@ class Termisu::Input::Parser
 
     # A blocking poll is unbounded only while waiting for its first byte. Once a
     # possible multi-byte event starts, truncated input must not block forever.
-    @parse_deadline ||= monotonic_now + ESCAPE_TIMEOUT_MS.milliseconds
+    unless @nonblocking
+      @parse_deadline ||= monotonic_now + ESCAPE_TIMEOUT_MS.milliseconds
+    end
     parse_byte(byte)
+  end
+
+  # Resets state owned by one poll and establishes its absolute deadline. A
+  # nonblocking poll needs neither a clock sample nor a transient deadline;
+  # persistent paste-tail deadlines remain independent of this state.
+  private def prepare_poll(timeout_ms : Int32) : MonotonicTime?
+    @nonblocking = timeout_ms == 0
+    @poll_deadline = nil
+    @parse_deadline = nil
+    return if @nonblocking
+
+    now = monotonic_now
+    @poll_deadline = now + timeout_ms.milliseconds if timeout_ms >= 0
+    @parse_deadline = @poll_deadline
+    now
   end
 
   # Parses a single byte, potentially reading more for escape sequences.
@@ -374,6 +394,8 @@ class Termisu::Input::Parser
   # How long to block for the next marker byte: the shorter of what the caller
   # asked for and what is left of the marker window.
   private def paste_wait_ms : Int32
+    return 0 if @nonblocking
+
     window = ms_until(@paste_deadline)
     budget = @poll_deadline ? ms_until(@poll_deadline) : window
     {window, budget}.min
@@ -410,6 +432,8 @@ class Termisu::Input::Parser
   end
 
   private def parse_wait_ms(max_wait_ms : Int32?) : Int32
+    return 0 if @nonblocking
+
     wait = ms_until(@parse_deadline)
     max_wait_ms ? {wait, max_wait_ms}.min : wait
   end


### PR DESCRIPTION
## Rationale

`Parser#poll_event(0)` is the production burst-drain path, but it previously created a monotonic deadline and repeatedly sampled the clock even though every continuation wait was necessarily zero.

## Design

- establish explicit per-call nonblocking state for zero-timeout polls
- clear transient poll/parse deadlines at the start of every poll
- skip only the initial monotonic sample and transient deadline work at timeout zero
- retain the independent paste-tail deadline and unchanged positive/blocking deadline setup

The change is centralized in parser wait/deadline setup. It does not change sequence decoding, event order, byte ownership, or allocation-producing parse paths.

## Correctness and evidence

Deterministic clock probes cover ASCII, CSI, SGR/normal mouse, Kitty, UTF-8, empty input, fragmented Escape, timeout-mode transitions, and paste-tail expiry/recovery. Ordinary zero-timeout events use **0 parser clock reads**; the positive ASCII control uses **1**, and the blocking ASCII control uses **2**. A fixed-seed 256-case one-byte-reader corpus compares events, consumed bytes, following events, and observable handoff state against the positive-deadline path.

An independent release allocation probe over ten 100,000-poll ASCII batches observed a median of 0 B per batch (one 192 B outlier). This is only a steady-state allocation check; no throughput, whole-application, or timing claim is made.

## Validation

- Crystal 1.17, 1.18, 1.19, 1.20, 1.21 parser specs: 94 examples, 0 failures each
- Crystal 1.17–1.21 Input source specs: 29 examples, 0 failures each
- Crystal 1.17 and 1.21 no-codegen builds
- Crystal 1.21 full suite under PTY: 1412 examples, 0 failures, 1 environment-dependent pending example
- Crystal-native PTY/E2E: 82 examples, 0 failures
- Ameba: 162 files, 0 failures
- Crystal format check and `git diff --check`
- C formatting/lint checks and native C ABI tests
- Bun check/typecheck and native-backed tests: 48 tests, 0 failures

The 1.19/1.20 parser and Input runs used locally available compiler snapshots because `mise` release installation returned GitHub API HTTP 401.