### PR TITLE
perf: parse bounded terminfo bytes

### DIFF
--- a/spec/termisu/terminfo/parser_spec.cr
+++ b/spec/termisu/terminfo/parser_spec.cr
@@ -38,6 +38,112 @@ private def reference_parse_all_then_filter(data : Bytes, requested : Array(Stri
   result
 end
 
+private def bounded_terminfo_fixture(
+  clear_offset : Int16,
+  table : Bytes,
+  *,
+  trailing : Bytes = Bytes.new(0),
+  magic : Int16 = Termisu::Terminfo::Parser::MAGIC,
+) : Bytes
+  io = IO::Memory.new
+  io.write_bytes(magic, IO::ByteFormat::LittleEndian)
+  io.write_bytes(0_i16, IO::ByteFormat::LittleEndian)             # names length
+  io.write_bytes(0_i16, IO::ByteFormat::LittleEndian)             # boolean count
+  io.write_bytes(0_i16, IO::ByteFormat::LittleEndian)             # number count
+  io.write_bytes(6_i16, IO::ByteFormat::LittleEndian)             # through clear (index 5)
+  io.write_bytes(table.size.to_i16, IO::ByteFormat::LittleEndian) # string table size
+  5.times { io.write_bytes(-1_i16, IO::ByteFormat::LittleEndian) }
+  io.write_bytes(clear_offset, IO::ByteFormat::LittleEndian)
+  io.write(table)
+  io.write(trailing)
+  io.to_slice
+end
+
+private def infocmp_available?(terminal : String) : Bool
+  Termisu::Terminfo::Database.new(terminal).load
+  Process.run("infocmp", ["-1", terminal], output: IO::Memory.new, error: IO::Memory.new).success?
+rescue
+  false
+end
+
+private def infocmp_strings(terminal : String, requested : Array(String)) : Hash(String, String)
+  output = IO::Memory.new
+  status = Process.run("infocmp", ["-1", terminal], output: output, error: IO::Memory.new)
+  raise "infocmp failed for #{terminal}" unless status.success?
+
+  result = {} of String => String
+  output.to_s.each_line do |line|
+    entry = line.strip
+    separator = entry.index('=')
+    next unless separator && entry.ends_with?(',')
+
+    name = entry[0, separator]
+    next unless requested.includes?(name)
+
+    encoded = entry[separator + 1, entry.size - separator - 2]
+    result[name] = decode_infocmp_string(encoded)
+  end
+  result
+end
+
+private def decode_infocmp_string(encoded : String) : String
+  source = encoded.to_slice
+  output = IO::Memory.new
+  index = 0
+
+  while index < source.size
+    byte = source[index]
+    if byte == '\\'.ord
+      index = write_infocmp_escape(output, source, index + 1)
+    elsif byte == '^'.ord && index + 1 < source.size
+      control = source[index + 1]
+      output.write_byte(control == '?'.ord ? 0x7f_u8 : (control & 0x1f).to_u8)
+      index += 2
+    else
+      output.write_byte(byte)
+      index += 1
+    end
+  end
+
+  output.to_s
+end
+
+private def write_infocmp_escape(output : IO, source : Bytes, index : Int32) : Int32
+  return index if index == source.size
+
+  byte = source[index]
+  return write_infocmp_octal(output, source, index) if byte >= '0'.ord && byte <= '7'.ord
+
+  output.write_byte decoded_infocmp_escape_byte(byte)
+  index + 1
+end
+
+private def write_infocmp_octal(output : IO, source : Bytes, index : Int32) : Int32
+  value = 0
+  digits = 0
+  while digits < 3 && index < source.size && source[index] >= '0'.ord && source[index] <= '7'.ord
+    value = (value * 8) + source[index] - '0'.ord
+    index += 1
+    digits += 1
+  end
+  output.write_byte(value.to_u8)
+  index
+end
+
+private def decoded_infocmp_escape_byte(byte : UInt8) : UInt8
+  case byte
+  when 'E'.ord, 'e'.ord then 0x1b_u8
+  when 'a'.ord          then 0x07_u8
+  when 'b'.ord          then 0x08_u8
+  when 'f'.ord          then 0x0c_u8
+  when 'n'.ord, 'l'.ord then 0x0a_u8
+  when 'r'.ord          then 0x0d_u8
+  when 's'.ord          then 0x20_u8
+  when 't'.ord          then 0x09_u8
+  else                       byte
+  end
+end
+
 describe Termisu::Terminfo::Parser do
   describe ".parse" do
     it "is a class method that creates parser and parses by capability name" do
@@ -269,7 +375,107 @@ describe Termisu::Terminfo::Parser do
     end
   end
 
+  describe "bounded string table" do
+    it "raises InvalidOffset when a requested offset points into trailing data" do
+      data = bounded_terminfo_fixture(1_i16, Bytes[0_u8], trailing: "outside\0".to_slice)
+
+      error = expect_raises(Termisu::ParseError) do
+        Termisu::Terminfo::Parser.parse(data, ["clear"])
+      end
+
+      error.type.should eq(Termisu::ParseError::Type::InvalidOffset)
+      error.details.should eq("Offset out of bounds")
+    end
+
+    it "raises CorruptedString rather than scanning for a terminator in trailing data" do
+      data = bounded_terminfo_fixture(0_i16, "inside".to_slice, trailing: Bytes[0_u8])
+
+      error = expect_raises(Termisu::ParseError) do
+        Termisu::Terminfo::Parser.parse(data, ["clear"])
+      end
+
+      error.type.should eq(Termisu::ParseError::Type::CorruptedString)
+      error.details.should eq("String crosses the declared table boundary")
+    end
+
+    it "raises TruncatedData when the declared table extends past the input" do
+      data = bounded_terminfo_fixture(0_i16, "x\0".to_slice)
+      data[10] = 20_u8 # table size, little-endian
+
+      error = expect_raises(Termisu::ParseError) do
+        Termisu::Terminfo::Parser.parse(data, ["clear"])
+      end
+
+      error.type.should eq(Termisu::ParseError::Type::TruncatedData)
+    end
+
+    it "accepts trailing extended-section data without reading it as standard data" do
+      data = bounded_terminfo_fixture(
+        0_i16,
+        "value\0".to_slice,
+        trailing: Bytes[0xff_u8, 0xff_u8, 0xff_u8],
+        magic: Termisu::Terminfo::Parser::EXTENDED_MAGIC
+      )
+
+      Termisu::Terminfo::Parser.parse(data, ["clear"]).should eq({"clear" => "value"})
+    end
+
+    it "validates malformed offsets only for requested capabilities" do
+      data = bounded_terminfo_fixture(1_i16, Bytes[0_u8], trailing: "outside\0".to_slice)
+
+      Termisu::Terminfo::Parser.parse(data, ["cbt"]).should be_empty
+    end
+  end
+
+  describe "requested capability behavior" do
+    it "ignores duplicate and unknown requests without duplicating results" do
+      data = bounded_terminfo_fixture(0_i16, "value\0".to_slice)
+
+      result = Termisu::Terminfo::Parser.parse(data, ["unknown", "clear", "clear", "other"])
+
+      result.should eq({"clear" => "value"})
+    end
+
+    it "omits absent and cancelled negative offsets" do
+      [-1_i16, -2_i16].each do |offset|
+        data = bounded_terminfo_fixture(offset, "unused\0".to_slice)
+        Termisu::Terminfo::Parser.parse(data, ["clear"]).should be_empty
+      end
+    end
+
+    it "preserves the existing omission of empty capability strings" do
+      data = bounded_terminfo_fixture(0_i16, Bytes[0_u8])
+
+      Termisu::Terminfo::Parser.parse(data, ["clear"]).should be_empty
+    end
+
+    it "returns exact owned strings that do not alias the input bytes" do
+      data = bounded_terminfo_fixture(0_i16, "value\0".to_slice)
+      value = Termisu::Terminfo::Parser.parse(data, ["clear"])["clear"]
+      table_start = Termisu::Terminfo::Parser::HEADER_LENGTH + (6 * 2)
+
+      data[table_start] = 'X'.ord.to_u8
+      value.should eq("value")
+      value.bytesize.should eq(5)
+    end
+
+    it "reads little-endian fields safely from an unaligned Bytes slice" do
+      data = bounded_terminfo_fixture(0_i16, "value\0".to_slice)
+      storage = Bytes.new(data.size + 1, 0_u8)
+      unaligned = storage[1, data.size]
+      unaligned.copy_from(data)
+
+      Termisu::Terminfo::Parser.parse(unaligned, ["clear"]).should eq({"clear" => "value"})
+    end
+  end
+
   describe "error details" do
+    it "preserves the named arguments for InvalidOffset errors" do
+      error = Termisu::ParseError.invalid_offset(offset: 1, max: 2)
+
+      error.type.should eq(Termisu::ParseError::Type::InvalidOffset)
+    end
+
     it "provides details for truncated data error" do
       corrupt_data = Bytes[1, 2, 3]
 
@@ -362,6 +568,24 @@ describe Termisu::Terminfo::Parser do
       reference = reference_parse_all_then_filter(data, requested)
 
       fast.should eq(reference)
+    end
+  end
+
+  describe "infocmp differential" do
+    ["xterm", "xterm-256color", "linux", "screen", "tmux"].each do |terminal|
+      if infocmp_available?(terminal)
+        it "matches infocmp for installed #{terminal}" do
+          requested = ["clear", "bold", "cup", "smcup", "rmcup"]
+          data = Termisu::Terminfo::Database.new(terminal).load
+          expected = infocmp_strings(terminal, requested)
+          actual = Termisu::Terminfo::Parser.parse(data, requested)
+
+          expected.should_not be_empty
+          actual.should eq(expected)
+        end
+      else
+        pending "infocmp differential for #{terminal} (entry or infocmp unavailable)"
+      end
     end
   end
 

--- a/src/termisu/error.cr
+++ b/src/termisu/error.cr
@@ -47,7 +47,7 @@ class Termisu::ParseError < Termisu::Error
     InvalidMagic    # Magic number not recognized
     TruncatedData   # Data smaller than expected
     InvalidHeader   # Header contains invalid values
-    InvalidOffset   # String offset points outside data
+    InvalidOffset   # String offset points outside the declared string table
     CorruptedString # String table is malformed
   end
 
@@ -83,7 +83,7 @@ class Termisu::ParseError < Termisu::Error
   # Creates an InvalidOffset error.
   def self.invalid_offset(offset : Int32, max : Int32) : ParseError
     new(Type::InvalidOffset,
-      "Invalid string offset: #{offset} exceeds data size #{max}",
+      "Invalid string offset: #{offset} is outside string table ending at #{max}",
       "Offset out of bounds")
   end
 end

--- a/src/termisu/terminfo/parser.cr
+++ b/src/termisu/terminfo/parser.cr
@@ -26,7 +26,13 @@
 # - `InvalidMagic`: Unrecognized format identifier
 # - `TruncatedData`: File smaller than header indicates
 # - `InvalidHeader`: Negative or unreasonable header values
-# - `InvalidOffset`: String offsets point outside data bounds
+# - `InvalidOffset`: String offsets point outside the declared string table
+# - `CorruptedString`: A requested string has no terminator in that table
+#
+# String offsets and terminator searches are intentionally bounded by the standard
+# string table declared in the header. Trailing extended data is accepted, but is
+# never interpreted as part of that table. Consequently, malformed files that only
+# worked by reading into a trailing section are rejected.
 #
 # ## Usage
 #
@@ -109,17 +115,14 @@ class Termisu::Terminfo::Parser
   def parse(required_caps : Array(String)) : Hash(String, String)
     validate_minimum_size!
 
-    io = IO::Memory.new(@data)
-
-    header = read_header(io)
+    header = read_header
     validate_header!(header)
 
     offsets = calculate_offsets(header)
-    validate_offsets!(offsets, header)
+    table_end = validate_offsets!(offsets, header)
 
     string_count = header[4].to_i32
-
-    read_required_capabilities(io, required_caps, string_count, offsets)
+    read_required_capabilities(required_caps, string_count, offsets, table_end)
   end
 
   # Validates that data is at least large enough for the header.
@@ -153,38 +156,43 @@ class Termisu::Terminfo::Parser
     end
   end
 
-  # Validates that calculated offsets don't exceed data bounds.
-  private def validate_offsets!(offsets : NamedTuple, header : StaticArray(Int16, 6))
-    table_size = header[5]
-    expected_end = offsets[:table_offset] + table_size.to_i32
+  # Validates that calculated offsets don't exceed data bounds and returns the
+  # exclusive end of the declared standard string table. Bytes after that point
+  # may hold an extended section and are deliberately not validated here.
+  private def validate_offsets!(offsets : NamedTuple, header : StaticArray(Int16, 6)) : Int32
+    table_end = offsets[:table_offset] + header[5].to_i32
 
-    if expected_end > @data.size
-      raise ParseError.truncated_data(expected_end, @data.size)
+    if table_end > @data.size
+      raise ParseError.truncated_data(table_end, @data.size)
     end
+
+    table_end
   end
 
   # Decodes only the requested capabilities from the strings section.
   #
   # Maps each requested name to its STRING_CAPS index, reads that entry's
   # 16-bit offset, and extracts the null-terminated string from the string
-  # table. Names beyond the file's string count or with absent (-1) offsets
-  # are omitted, matching a full decode filtered to the same names.
-  private def read_required_capabilities(io, requested, string_count, offsets)
-    result = {} of String => String
+  # table. Names beyond the file's string count, negative offsets, and empty
+  # values are omitted, matching the existing requested-only behavior.
+  private def read_required_capabilities(requested, string_count, offsets, table_end)
+    capacity = Math.min(requested.size, string_count)
+    result = Hash(String, String).new(initial_capacity: capacity)
 
     requested.each do |cap_name|
       index = Capabilities.string_cap_index(cap_name)
       next unless index && index < string_count
 
       offset_position = offsets[:str_offset] + (2 * index)
-      value = read_string_at(io, offset_position, offsets[:table_offset])
-      result[cap_name] = value unless value.empty?
+      value = read_string_at(offset_position, offsets[:table_offset], table_end)
+      result[cap_name] = value if value && !value.empty?
     end
 
     result
   end
 
-  # Reads the 12-byte terminfo header.
+  # Reads the 12-byte terminfo header with endian-explicit byte operations.
+  # This remains safe when the supplied Bytes starts at an unaligned address.
   #
   # Header structure:
   # - [0]: Magic number (format identifier)
@@ -193,9 +201,9 @@ class Termisu::Terminfo::Parser
   # - [3]: Numeric capabilities count
   # - [4]: String capabilities count
   # - [5]: String table size
-  private def read_header(io : IO::Memory)
-    StaticArray(Int16, 6).new do |_|
-      io.read_bytes(Int16, IO::ByteFormat::LittleEndian)
+  private def read_header : StaticArray(Int16, 6)
+    StaticArray(Int16, 6).new do |index|
+      read_i16_le(index * 2)
     end
   end
 
@@ -226,41 +234,40 @@ class Termisu::Terminfo::Parser
     {str_offset: str_offset, table_offset: table_offset}
   end
 
-  # Reads a null-terminated string at the given offset position.
-  #
-  # ## Parameters
-  #
-  # - `io`: Memory IO containing terminfo data
-  # - `offset_pos`: Position of the 16-bit offset value
-  # - `table_start`: Start position of the string table
-  #
-  # ## Returns
-  #
-  # The null-terminated string, or empty string if offset is -1 (absent capability).
-  private def read_string_at(io : IO::Memory, offset_pos : Int32, table_start : Int32) : String
-    io.pos = offset_pos
-    offset = io.read_bytes(Int16, IO::ByteFormat::LittleEndian)
+  # Reads a requested null-terminated string, bounded to the standard string
+  # table. Negative offsets represent absent or cancelled capabilities.
+  private def read_string_at(offset_pos : Int32, table_start : Int32, table_end : Int32) : String?
+    offset = read_i16_le(offset_pos)
+    return nil if offset < 0
 
-    # -1 offset means capability is absent (not an error)
-    return "" if offset < 0
-
-    string_pos = table_start + offset
-
-    # Validate the string position is within bounds
-    if string_pos >= @data.size
-      raise ParseError.invalid_offset(string_pos, @data.size)
+    string_start = table_start + offset
+    if string_start >= table_end
+      raise ParseError.invalid_offset(string_start, table_end)
     end
 
-    io.pos = string_pos
-    read_null_terminated_string(io)
+    string_end = string_start
+    while string_end < table_end && @data[string_end] != 0
+      string_end += 1
+    end
+
+    if string_end == table_end
+      raise ParseError.new(
+        ParseError::Type::CorruptedString,
+        "Corrupted string at offset #{string_start}: no NUL before string table end #{table_end}",
+        "String crosses the declared table boundary"
+      )
+    end
+
+    # String.new(Bytes) copies exactly the capability bytes, so results do not
+    # retain or alias a database-sized backing buffer.
+    String.new(@data[string_start, string_end - string_start])
   end
 
-  # Reads a null-terminated string from the current IO position.
-  private def read_null_terminated_string(io : IO::Memory) : String
-    String.build do |builder|
-      while (byte = io.read_byte) && byte != 0
-        builder.write_byte(byte)
-      end
-    end
+  # Reads a signed little-endian 16-bit value without pointer casts or
+  # alignment assumptions. Callers establish the two-byte bound first.
+  private def read_i16_le(offset : Int32) : Int16
+    value = @data[offset].to_i32 | (@data[offset + 1].to_i32 << 8)
+    value -= 0x10000 if value >= 0x8000
+    value.to_i16
   end
 end


### PR DESCRIPTION
## Rationale and design

Parse requested standard terminfo strings directly from `Bytes` instead of routing through `IO::Memory`. Header and offset fields use endian-explicit byte reads, so no unaligned pointer loads are involved. The parser computes the declared standard string-table end, rejects requested offsets and NUL scans that cross it, copies exact owned strings, and caps result-hash preallocation.

## Correctness constraints

- Retains requested-only validation, unknown/duplicate request behavior, negative offsets, empty-string omission, and acceptance of trailing extended data.
- Preserves the public `ParseError.invalid_offset(offset:, max:)` named-argument API.
- Intentionally changes malformed-input behavior: requested strings that rely on trailing/extended bytes are now `InvalidOffset` or `CorruptedString` errors.
- Differential checks compare complete requested-result hashes with `infocmp`, including key sets.

## Evidence

- Parser + Terminfo specs on Crystal 1.17.0, 1.18.2, 1.19.1, 1.20.0, and 1.21.0: 108 examples, 0 failures/errors/pending on each.
- Full Crystal suite under PTY on Crystal 1.17.0 and 1.21.0: 1,422 examples, 0 failures/errors, 1 existing environment-dependent pending on each.
- Crystal-native E2E/PTTY suite: 82 examples, 0 failures/errors/pending.
- Ameba: 162 files, 0 failures; Crystal format and `git diff --check` pass.
- C format/lint, native FFI build, and C ABI tests pass.
- Bun 1.4.0: Biome and typecheck pass; 48 native/JS tests pass.
- Parsed all 2,899 entries in this host's ncurses database while requesting all standard string capabilities; 2,872 returned at least one string.
- `infocmp` differentials pass for xterm, xterm-256color, linux, screen, and tmux.

## Limitations

No runtime speedup is claimed: this change is justified by bounded parsing and deterministic source/allocation reduction. The 2,899-file corpus count is specific to the local ncurses installation; CI supplies the portable Linux/macOS Crystal 1.17–1.21 and FreeBSD gates.
