### PR TITLE
perf: skip unused terminfo capabilities

### DIFF
--- a/spec/support/mock_helpers.cr
+++ b/spec/support/mock_helpers.cr
@@ -39,4 +39,85 @@ module MockHelpers
 
     io.to_slice
   end
+
+  # Creates a sparse terminfo database containing named string capabilities.
+  # Entries in *malformed_caps* receive an out-of-range string offset while the
+  # rest of the file remains structurally valid.
+  def create_sparse_terminfo_data(
+    capabilities : Hash(String, String),
+    malformed_caps : Array(String) = [] of String,
+  ) : Bytes
+    names = capabilities.keys + malformed_caps
+    highest_index = names.reduce(0) do |highest, name|
+      index = mock_string_cap_index(name)
+      index > highest ? index : highest
+    end
+    string_count = highest_index + 1
+    offsets = Array(Int16).new(string_count, -1_i16)
+    table = IO::Memory.new
+
+    capabilities.each do |name, value|
+      offsets[mock_string_cap_index(name)] = table.pos.to_i16
+      table.write(value.to_slice)
+      table.write_byte(0_u8)
+    end
+
+    malformed_caps.each do |name|
+      offsets[mock_string_cap_index(name)] = Int16::MAX
+    end
+
+    io = IO::Memory.new
+    io.write_bytes(0o432_i16, IO::ByteFormat::LittleEndian)
+    io.write_bytes(6_i16, IO::ByteFormat::LittleEndian) # names section length
+    io.write_bytes(0_i16, IO::ByteFormat::LittleEndian)
+    io.write_bytes(0_i16, IO::ByteFormat::LittleEndian)
+    io.write_bytes(string_count.to_i16, IO::ByteFormat::LittleEndian)
+    io.write_bytes(table.size.to_i16, IO::ByteFormat::LittleEndian)
+    io.write("test\0\0".to_slice)
+    offsets.each { |offset| io.write_bytes(offset, IO::ByteFormat::LittleEndian) }
+    io.write(table.to_slice)
+    io.to_slice
+  end
+
+  # Exposes *data* as the database for *term_name* for the duration of the block.
+  def with_mock_terminfo_database(term_name : String, data : Bytes, &)
+    temp = File.tempfile("termisu-terminfo")
+    root = temp.path
+    temp.close
+    File.delete(root)
+
+    entry_dir = File.join(root, term_name[0].to_s)
+    entry_path = File.join(entry_dir, term_name)
+    Dir.mkdir_p(entry_dir)
+    File.write(entry_path, data)
+
+    original_term = ENV["TERM"]?
+    original_terminfo = ENV["TERMINFO"]?
+    ENV["TERM"] = term_name
+    ENV["TERMINFO"] = root
+    Termisu::Terminfo.clear_caps_cache
+
+    yield
+  ensure
+    Termisu::Terminfo.clear_caps_cache
+    if original_term
+      ENV["TERM"] = original_term
+    else
+      ENV.delete("TERM")
+    end
+    if original_terminfo
+      ENV["TERMINFO"] = original_terminfo
+    else
+      ENV.delete("TERMINFO")
+    end
+
+    File.delete(entry_path) if entry_path && File.exists?(entry_path)
+    Dir.delete(entry_dir) if entry_dir && Dir.exists?(entry_dir)
+    Dir.delete(root) if root && Dir.exists?(root)
+  end
+
+  private def mock_string_cap_index(name : String) : Int32
+    Termisu::Terminfo::Capabilities.string_cap_index(name) ||
+      raise ArgumentError.new("Unknown terminfo capability: #{name}")
+  end
 end

--- a/spec/termisu/terminfo/parser_spec.cr
+++ b/spec/termisu/terminfo/parser_spec.cr
@@ -363,6 +363,26 @@ describe Termisu::Terminfo::Parser do
 
       fast.should eq(reference)
     end
+
+    it "still parses explicitly requested keyboard capabilities" do
+      data = create_sparse_terminfo_data({"kf1" => "\eOP", "kcuu1" => "\e[A"})
+
+      Termisu::Terminfo::Parser.parse(data, ["kf1", "kcuu1"]).should eq({
+        "kf1"   => "\eOP",
+        "kcuu1" => "\e[A",
+      })
+    end
+
+    it "ignores capability-specific corruption only while that capability is unrequested" do
+      data = create_sparse_terminfo_data({"clear" => "custom-clear"}, ["kf1"])
+
+      Termisu::Terminfo::Parser.parse(data, ["clear"]).should eq({"clear" => "custom-clear"})
+
+      error = expect_raises(Termisu::ParseError) do
+        Termisu::Terminfo::Parser.parse(data, ["kf1"])
+      end
+      error.type.should eq(Termisu::ParseError::Type::InvalidOffset)
+    end
   end
 
   describe "integration with Capabilities" do

--- a/spec/termisu/terminfo_spec.cr
+++ b/spec/termisu/terminfo_spec.cr
@@ -335,6 +335,83 @@ describe Termisu::Terminfo do
     end
   end
 
+  describe "runtime capability composition" do
+    it "stores only production output capabilities for builtin fallback" do
+      original_term = ENV["TERM"]?
+
+      begin
+        term_name = "termisu-missing-runtime-caps"
+        ENV["TERM"] = term_name
+        Termisu::Terminfo.clear_caps_cache
+
+        Termisu::Terminfo.new
+        caps = Termisu::Terminfo.cached_caps?(term_name)
+        caps.should_not be_nil
+        caps = caps.as(Hash(String, String))
+
+        caps.size.should eq(Termisu::Terminfo::Capabilities::REQUIRED_FUNCS.size)
+        caps.keys.sort!.should eq(Termisu::Terminfo::Capabilities::REQUIRED_FUNCS.sort)
+      ensure
+        Termisu::Terminfo.clear_caps_cache
+        if original_term
+          ENV["TERM"] = original_term
+        else
+          ENV.delete("TERM")
+        end
+      end
+    end
+
+    it "combines custom database output with function builtins and ignores a malformed key" do
+      data = create_sparse_terminfo_data({"clear" => "custom-clear"}, ["kf1"])
+
+      with_mock_terminfo_database("zterm-termisu-custom", data) do
+        term = Termisu::Terminfo.new
+        caps = Termisu::Terminfo.cached_caps?("zterm-termisu-custom")
+        caps.should_not be_nil
+        caps = caps.as(Hash(String, String))
+
+        term.clear_screen_seq.should eq("custom-clear")
+        term.bold_seq.should eq("\e[1m")
+        caps.size.should eq(Termisu::Terminfo::Capabilities::REQUIRED_FUNCS.size)
+        caps.keys.sort!.should eq(Termisu::Terminfo::Capabilities::REQUIRED_FUNCS.sort)
+        caps.has_key?("kf1").should be_false
+      end
+    end
+
+    if TerminfoHelpers.terminfo_db_available?("xterm")
+      it "combines a real database with function builtins only" do
+        original_term = ENV["TERM"]?
+
+        begin
+          ENV["TERM"] = "xterm"
+          Termisu::Terminfo.clear_caps_cache
+
+          parsed = Termisu::Terminfo::Parser.parse(
+            Termisu::Terminfo::Database.new("xterm").load,
+            Termisu::Terminfo::Capabilities::REQUIRED_FUNCS
+          )
+          expected = parsed.dup
+          builtins = Termisu::Terminfo::Builtin.funcs_for("xterm")
+          Termisu::Terminfo::Capabilities::REQUIRED_FUNCS.each_with_index do |name, index|
+            expected[name] ||= builtins[index]
+          end
+
+          Termisu::Terminfo.new
+          Termisu::Terminfo.cached_caps?("xterm").should eq(expected)
+        ensure
+          Termisu::Terminfo.clear_caps_cache
+          if original_term
+            ENV["TERM"] = original_term
+          else
+            ENV.delete("TERM")
+          end
+        end
+      end
+    else
+      pending "real database runtime composition (no xterm terminfo on this system)"
+    end
+  end
+
   describe "cross-init capability cache" do
     it "caches the merged caps hash by TERM and hits it on subsequent inits" do
       original_term = ENV["TERM"]?
@@ -380,6 +457,53 @@ describe Termisu::Terminfo do
       ensure
         Termisu::Terminfo.clear_caps_cache
         ENV["TERM"] = original_term if original_term
+      end
+    end
+
+    it "serializes concurrent cold cache access" do
+      original_term = ENV["TERM"]?
+
+      begin
+        term_name = "termisu-concurrent-missing"
+        ENV["TERM"] = term_name
+        Termisu::Terminfo.clear_caps_cache
+        worker_count = 8
+        ready = Atomic(Int32).new(0)
+        start = Atomic(Bool).new(false)
+        results = Array(String | Exception | Nil).new(worker_count, nil)
+        threads = Array(Thread).new(worker_count)
+
+        worker_count.times do |index|
+          threads << Thread.new do
+            ready.add(1)
+            until start.get
+              Thread.yield
+            end
+            results[index] = Termisu::Terminfo.new.clear_screen_seq
+          rescue ex
+            results[index] = ex
+          end
+        end
+
+        until ready.get == worker_count
+          Thread.yield
+        end
+        start.set(true)
+        threads.each(&.join)
+        results.should eq(Array.new(worker_count, "\e[H\e[2J"))
+
+        caps = Termisu::Terminfo.cached_caps?(term_name)
+        caps.should_not be_nil
+        caps.as(Hash(String, String)).keys.sort!.should eq(
+          Termisu::Terminfo::Capabilities::REQUIRED_FUNCS.sort
+        )
+      ensure
+        Termisu::Terminfo.clear_caps_cache
+        if original_term
+          ENV["TERM"] = original_term
+        else
+          ENV.delete("TERM")
+        end
       end
     end
   end

--- a/src/termisu/terminfo.cr
+++ b/src/termisu/terminfo.cr
@@ -6,9 +6,13 @@
 #
 # ## Loading Strategy
 #
-# 1. Attempts to load capabilities from terminfo database at standard locations
-# 2. Falls back to built-in escape sequences for xterm/linux if database unavailable
-# 3. Merges database values with builtins, preferring database values
+# 1. Attempts to load the output capabilities Termisu consumes from the terminfo database
+# 2. Falls back to built-in escape sequences for xterm/linux if the database is unavailable
+# 3. Fills missing output capabilities from builtins, preferring database values
+#
+# Keyboard capabilities are not loaded here because input parsing does not consume them.
+# The public keyboard capability tables and generic binary parser remain available to
+# applications that explicitly request those capabilities.
 #
 # ## Usage
 #
@@ -173,11 +177,14 @@ class Termisu::Terminfo
                           @cached_invis == "\e[8m" && @cached_smxx == "\e[9m"
   end
 
-  # Loads capabilities from the terminfo database.
+  # Loads the output capabilities consumed by Terminfo.
+  #
+  # Capability-specific corruption in an unrequested keyboard entry is deliberately
+  # ignored. Keyboard input is parsed independently, while callers that need terminfo
+  # key strings can still request REQUIRED_KEYS directly through Parser.
   private def self.load_from_database(term_name : String) : Hash(String, String)
     data = Database.new(term_name).load
-    required = Capabilities::REQUIRED_FUNCS + Capabilities::REQUIRED_KEYS
-    caps = Parser.parse(data, required)
+    caps = Parser.parse(data, Capabilities::REQUIRED_FUNCS)
     Log.debug { "Loaded #{caps.size} capabilities from database" }
     caps
   rescue ex
@@ -185,11 +192,10 @@ class Termisu::Terminfo
     {} of String => String
   end
 
-  # Fills in missing capabilities with hardcoded fallback values.
+  # Fills in missing output capabilities with hardcoded fallback values.
   private def self.fill_missing_with_builtins(caps : Hash(String, String), term_name : String)
     before_count = caps.size
     fill_capability_group(caps, Capabilities::REQUIRED_FUNCS, Builtin.funcs_for(term_name))
-    fill_capability_group(caps, Capabilities::REQUIRED_KEYS, Builtin.keys_for(term_name))
     added = caps.size - before_count
     Log.debug { "Filled #{added} missing capabilities from builtins" } if added > 0
   end

--- a/src/termisu/terminfo/parser.cr
+++ b/src/termisu/terminfo/parser.cr
@@ -94,6 +94,8 @@ class Termisu::Terminfo::Parser
   # Resolves each requested capability name to its STRING_CAPS index and
   # decodes only those entries from the strings section, skipping the
   # hundreds of unrequested capabilities a terminfo file typically carries.
+  # Structural sections are always validated, but offset or string corruption
+  # belonging solely to an unrequested capability is deliberately not observed.
   #
   # ## Parameters
   #


### PR DESCRIPTION
## Rationale and design

`Terminfo` was parsing and caching keyboard capabilities even though production input parsing does not consume terminfo key strings. Runtime construction now requests only `REQUIRED_FUNCS` and fills only function builtins.

Compatibility is preserved: `REQUIRED_KEYS`, `Builtin.keys_for`, `STRING_CAPS`, and generic `Parser` key-capability parsing remain public and unchanged. Database values still override builtins, missing values still fall back, and the existing per-`TERM` cache and atomic cache locking are unchanged. Corruption confined to an unrequested key entry is deliberately ignored; explicitly requesting that entry still reports the parse error.

## Evidence

On Crystal 1.21 release binaries in 15 fresh processes, the cold missing-database first load was deterministic:

- `GC.stats.total_bytes`: 6,448 bytes on `main` -> 4,256 bytes here (2,192 fewer)
- Runtime cache: 50 -> 28 entries, exactly `REQUIRED_FUNCS` (22 fewer)

This measures cold fallback construction only. It makes no timing or cache-hit performance claim.

## Validation

- Crystal 1.17 focused terminfo/input parser specs: 328 examples, 0 failures
- Crystal 1.21 focused terminfo/input parser specs: 328 examples, 0 failures
- Crystal 1.17 full specs: 1,412 examples, 0 failures, 1 environment-dependent pending
- Crystal 1.21 full specs: 1,412 examples, 0 failures, 1 environment-dependent pending
- Crystal 1.21 PTY/E2E: 82 examples, 0 failures
- Ameba: 162 files, 0 failures
- Crystal format and `git diff --check`: passed
- C format/lint and native C ABI tests: passed
- Bun check/typecheck/tests: 48 tests, 0 failures
