### PR TITLE
perf: isolate and buffer logging

### DIFF
--- a/spec/fixtures/log_process_exit.cr
+++ b/spec/fixtures/log_process_exit.cr
@@ -1,0 +1,6 @@
+require "../../src/termisu"
+
+Termisu::Logging.setup
+500.times do |number|
+  Termisu::Log.info { "exit-numbered-#{number}" }
+end

--- a/spec/support/test_helpers.cr
+++ b/spec/support/test_helpers.cr
@@ -18,10 +18,22 @@ module TestHelpers
     was_log_file = Termisu::Logging.log_file
     was_async = Termisu::Logging.async_mode?
     was_configured = Termisu::Logging.configured?
+    loggers = [
+      Termisu::Log,
+      Termisu::Logs::Terminal,
+      Termisu::Logs::Buffer,
+      Termisu::Logs::Reader,
+      Termisu::Logs::Render,
+      Termisu::Logs::Input,
+      Termisu::Logs::Color,
+      Termisu::Logs::Terminfo,
+      Termisu::Logs::Event,
+    ] of ::Log
+    previous_bindings = loggers.map { |logger| {logger.backend, logger.initial_level} }
 
     begin
-      # Keep Logging.close inside the block from detaching or closing the
-      # process-wide configuration that this fault injector must preserve.
+      # Keep Logging.close inside the block from closing any real configured
+      # resource while injecting failures only into Termisu-owned loggers.
       Termisu::Logging.backend = nil
       Termisu::Logging.log_file = nil
       Termisu::Logging.async_mode = false
@@ -30,14 +42,17 @@ module TestHelpers
         io: RaisingLogIO.new,
         dispatcher: ::Log::DispatchMode::Direct,
       )
-      ::Log.builder.bind("*", ::Log::Severity::Trace, backend)
-
-      begin
-        yield
-      ensure
-        ::Log.builder.unbind("*", ::Log::Severity::Trace, backend)
+      loggers.each do |logger|
+        logger.backend = backend
+        logger.initial_level = ::Log::Severity::Trace
       end
+
+      yield
     ensure
+      loggers.zip(previous_bindings) do |logger, binding|
+        logger.backend = binding[0]
+        logger.initial_level = binding[1]
+      end
       Termisu::Logging.backend = was_backend
       Termisu::Logging.log_file = was_log_file
       Termisu::Logging.async_mode = was_async

--- a/spec/termisu/log_spec.cr
+++ b/spec/termisu/log_spec.cr
@@ -1,11 +1,45 @@
 require "../spec_helper"
 require "file/tempfile"
 
+private class LogSpecType
+end
+
+private class RaisingWriteLogIO < IO
+  def read(slice : Bytes) : Int32
+    0
+  end
+
+  def write(slice : Bytes) : Nil
+    raise IO::Error.new("injected log write failure")
+  end
+end
+
+private class RaisingFlushLogIO < IO
+  getter contents : String { @memory.to_s }
+
+  def initialize
+    @memory = IO::Memory.new
+  end
+
+  def read(slice : Bytes) : Int32
+    @memory.read(slice)
+  end
+
+  def write(slice : Bytes) : Nil
+    @memory.write(slice)
+  end
+
+  def flush : Nil
+    raise IO::Error.new("injected log flush failure")
+  end
+end
+
 private class TrackingLogDispatcher
   include ::Log::Dispatcher
 
   getter close_count : Int32 = 0
   getter? file_open_during_close : Bool = false
+  getter? logger_detached_during_close : Bool = false
 
   def initialize(@delegate : ::Log::Dispatcher, @file : File)
   end
@@ -17,64 +51,394 @@ private class TrackingLogDispatcher
   def close : Nil
     @close_count += 1
     @file_open_during_close = !@file.closed?
+
+    evaluated = false
+    Termisu::Log.info do
+      evaluated = true
+      "must not be accepted while logging closes"
+    end
+    @logger_detached_during_close = !evaluated
+
     @delegate.close
     @file_open_during_close &&= !@file.closed?
   end
 end
 
+private class RaisingCloseLogDispatcher
+  include ::Log::Dispatcher
+
+  getter close_count : Int32 = 0
+
+  def initialize(@delegate : ::Log::Dispatcher)
+  end
+
+  def dispatch(entry : ::Log::Entry, backend : ::Log::Backend) : Nil
+    @delegate.dispatch(entry, backend)
+  end
+
+  def close : Nil
+    @close_count += 1
+    first_error = nil.as(Exception?)
+    begin
+      @delegate.close
+    rescue ex
+      first_error = ex
+    end
+
+    raise first_error if first_error
+    raise IO::Error.new("injected backend close failure")
+  end
+end
+
+private def with_log_environment(level : String, path : String, sync : Bool, &)
+  previous_level = ENV["TERMISU_LOG_LEVEL"]?
+  previous_file = ENV["TERMISU_LOG_FILE"]?
+  previous_sync = ENV["TERMISU_LOG_SYNC"]?
+
+  Termisu::Logging.close rescue nil
+  ENV["TERMISU_LOG_LEVEL"] = level
+  ENV["TERMISU_LOG_FILE"] = path
+  ENV["TERMISU_LOG_SYNC"] = sync.to_s
+  yield
+ensure
+  Termisu::Logging.close rescue nil
+
+  if previous_level
+    ENV["TERMISU_LOG_LEVEL"] = previous_level
+  else
+    ENV.delete("TERMISU_LOG_LEVEL")
+  end
+  if previous_file
+    ENV["TERMISU_LOG_FILE"] = previous_file
+  else
+    ENV.delete("TERMISU_LOG_FILE")
+  end
+  if previous_sync
+    ENV["TERMISU_LOG_SYNC"] = previous_sync
+  else
+    ENV.delete("TERMISU_LOG_SYNC")
+  end
+end
+
+private def numbered_messages(path : String, prefix : String) : Array(Int32)
+  File.read_lines(path).compact_map do |line|
+    match = line.match(/#{prefix}-(\d+)/)
+    match[1].to_i if match
+  end
+end
+
+private def unbind_host(pattern : String, level : ::Log::Severity, backend : ::Log::Backend?) : Nil
+  ::Log.builder.unbind(pattern, level, backend) if backend
+rescue
+  # A failed example may not have reached its bind.
+end
+
 describe Termisu::Logging do
-  it "closes each retained backend exactly once before its file across setup cycles" do
-    previous_level = ENV["TERMISU_LOG_LEVEL"]?
-    previous_file = ENV["TERMISU_LOG_FILE"]?
-    previous_sync = ENV["TERMISU_LOG_SYNC"]?
-    temp = File.tempfile("termisu-logging", ".log")
+  it "keeps host wildcard and scoped backends unchanged before, during, and after setup" do
+    broad_backend = ::Log::MemoryBackend.new
+    scoped_backend = ::Log::MemoryBackend.new
+    broad_level = ::Log::Severity::Info
+    scoped_level = ::Log::Severity::Debug
+    host = ::Log.for("host.application")
+    builder = ::Log.builder
+    temp = File.tempfile("termisu-log-isolation", ".log")
     path = temp.path
     temp.close
 
-    ENV["TERMISU_LOG_LEVEL"] = "debug"
-    ENV["TERMISU_LOG_FILE"] = path
-    ENV["TERMISU_LOG_SYNC"] = "false"
+    builder.bind("*", broad_level, broad_backend)
+    builder.bind("host.*", scoped_level, scoped_backend)
 
-    2.times do |cycle|
+    with_log_environment("debug", path, true) do
+      host.info { "host-before" }
+      Termisu::Log.info { "termisu-before" }
+
+      Termisu::Logging.setup
+      Termisu::Log.info { "termisu-root" }
+      Termisu::Logs::Terminal.info { "termisu-component" }
+      Termisu::Log.for("public-child").info { "termisu-public-child" }
+      host.info { "host-during" }
+
+      Termisu::Logging.close
+      Termisu::Log.info { "termisu-after" }
+      host.info { "host-after" }
+    end
+
+    broad_backend.entries.map(&.message).should eq(["host-before", "host-during", "host-after"])
+    scoped_backend.entries.map(&.message).should eq(["host-before", "host-during", "host-after"])
+
+    contents = File.read(path)
+    contents.should contain("termisu-root")
+    contents.should contain("termisu-component")
+    contents.should contain("termisu-public-child")
+    contents.should_not contain("host-before")
+    contents.should_not contain("host-during")
+    contents.should_not contain("host-after")
+  ensure
+    unbind_host("host.*", ::Log::Severity::Debug, scoped_backend)
+    unbind_host("*", ::Log::Severity::Info, broad_backend)
+    File.delete(path) if path && File.exists?(path)
+  end
+
+  it "makes none silent even when the host has a wildcard backend" do
+    host_backend = ::Log::MemoryBackend.new
+    builder = ::Log.builder
+    temp = File.tempfile("termisu-log-none", ".log")
+    path = temp.path
+    temp.close
+    File.delete(path)
+    builder.bind("*", ::Log::Severity::Trace, host_backend)
+
+    with_log_environment("none", path, false) do
+      Termisu::Logging.setup
+      evaluated = false
+      Termisu::Log.for("none-child").fatal do
+        evaluated = true
+        "must stay silent"
+      end
+
+      evaluated.should be_false
+      host_backend.entries.should be_empty
+      File.exists?(path).should be_false
+    end
+  ensure
+    unbind_host("*", ::Log::Severity::Trace, host_backend)
+    File.delete(path) if path && File.exists?(path)
+  end
+
+  it "keeps public Log.for source behavior inside the isolated registry" do
+    Termisu::Log.source.should eq("termisu")
+    Termisu::Log.for("").should be(Termisu::Log)
+    Termisu::Log.for("public").source.should eq("termisu.public")
+    Termisu::Log.for(LogSpecType).source.should eq("log_spec_type")
+
+    global = ::Log.for("termisu.public")
+    Termisu::Log.for("public").should_not be(global)
+  end
+
+  [true, false].each do |sync|
+    mode = sync ? "direct" : "async"
+
+    it "writes complete ordered numbered messages in #{mode} mode" do
+      temp = File.tempfile("termisu-log-#{mode}", ".log")
+      path = temp.path
+      temp.close
+
+      with_log_environment("debug", path, sync) do
+        Termisu::Logging.setup
+        count = 500
+        count.times { |number| Termisu::Log.info { "#{mode}-numbered-#{number}" } }
+        Termisu::Logging.close
+
+        numbered_messages(path, "#{mode}-numbered").should eq((0...count).to_a)
+      end
+    ensure
+      File.delete(path) if path && File.exists?(path)
+    end
+  end
+
+  it "makes direct entries visible immediately and enables file buffering only for async mode" do
+    direct = File.tempfile("termisu-log-direct-visible", ".log")
+    direct_path = direct.path
+    direct.close
+    async = File.tempfile("termisu-log-async-buffered", ".log")
+    async_path = async.path
+    async.close
+
+    with_log_environment("debug", direct_path, true) do
       Termisu::Logging.setup
       file = Termisu::Logging.log_file || fail("logging did not open its file")
-      backend = Termisu::Logging.backend || fail("logging did not retain its backend")
-      dispatcher = TrackingLogDispatcher.new(backend.dispatcher, file)
+      file.sync?.should be_true
+      Termisu::Log.info { "direct-visible-now" }
+      File.read(direct_path).should contain("direct-visible-now")
+    end
+
+    with_log_environment("debug", async_path, false) do
+      Termisu::Logging.setup
+      file = Termisu::Logging.log_file || fail("logging did not open its file")
+      file.sync?.should be_false
+      Termisu::Log.info { "async-buffered" }
+      Termisu::Logging.flush
+      File.read(async_path).should contain("async-buffered")
+    end
+  ensure
+    File.delete(direct_path) if direct_path && File.exists?(direct_path)
+    File.delete(async_path) if async_path && File.exists?(async_path)
+  end
+
+  it "drains async entries from the process-exit hook" do
+    temp = File.tempfile("termisu-log-process-exit", ".log")
+    path = temp.path
+    temp.close
+    fixture = File.expand_path("../fixtures/log_process_exit.cr", __DIR__)
+
+    output = IO::Memory.new
+    error = IO::Memory.new
+    status = Process.run(
+      "crystal",
+      ["run", fixture],
+      output: output,
+      error: error,
+      env: {
+        "TERMISU_LOG_LEVEL" => "debug",
+        "TERMISU_LOG_FILE"  => path,
+        "TERMISU_LOG_SYNC"  => "false",
+      }
+    )
+
+    status.success?.should be_true,
+      "process-exit fixture failed (#{status.exit_code})\nstdout:\n#{output}\nstderr:\n#{error}"
+    numbered_messages(path, "exit-numbered").should eq((0...500).to_a)
+  ensure
+    File.delete(path) if path && File.exists?(path)
+  end
+
+  it "disables logging without changing host configuration when setup cannot open its file" do
+    host_backend = ::Log::MemoryBackend.new
+    builder = ::Log.builder
+    host = ::Log.for("host.setup-failure")
+    path = File.join(Dir.tempdir, "missing-termisu-log-dir-#{Random.rand(UInt64)}", "output.log")
+    builder.bind("*", ::Log::Severity::Info, host_backend)
+
+    with_log_environment("debug", path, false) do
+      Termisu::Logging.setup
+      Termisu::Logging.configured?.should be_true
+      Termisu::Logging.backend.should be_nil
+      Termisu::Logging.log_file.should be_nil
+
+      evaluated = false
+      Termisu::Log.info do
+        evaluated = true
+        "disabled after setup failure"
+      end
+      evaluated.should be_false
+
+      host.info { "host survives setup failure" }
+      host_backend.entries.map(&.message).should eq(["host survives setup failure"])
+    end
+  ensure
+    unbind_host("*", ::Log::Severity::Info, host_backend)
+  end
+
+  it "drains after async write failures, closes resources, and reports the first error" do
+    temp = File.tempfile("termisu-log-write-failure", ".log")
+    path = temp.path
+    temp.close
+
+    with_log_environment("debug", path, false) do
+      Termisu::Logging.setup
+      file = Termisu::Logging.log_file || fail("logging did not open its file")
+      backend = Termisu::Logging.backend || fail("logging did not install its backend")
+      backend.io = RaisingWriteLogIO.new
+      dispatcher = RaisingCloseLogDispatcher.new(backend.dispatcher)
       backend.dispatcher = dispatcher
+      Termisu::Log.info { "write fails asynchronously" }
 
-      Termisu::Log.info { "logging lifecycle cycle #{cycle}" }
-      Termisu::Logging.close
-      Termisu::Logging.close
-
+      expect_raises(IO::Error, "injected log write failure") { Termisu::Logging.close }
       dispatcher.close_count.should eq(1)
-      dispatcher.file_open_during_close?.should be_true
       file.closed?.should be_true
       Termisu::Logging.backend.should be_nil
       Termisu::Logging.log_file.should be_nil
       Termisu::Logging.configured?.should be_false
+
+      Termisu::Logging.close
+    end
+  ensure
+    File.delete(path) if path && File.exists?(path)
+  end
+
+  it "uses a drain barrier before reporting flush failures" do
+    temp = File.tempfile("termisu-log-flush-failure", ".log")
+    path = temp.path
+    temp.close
+
+    with_log_environment("debug", path, false) do
+      Termisu::Logging.setup
+      file = Termisu::Logging.log_file || fail("logging did not open its file")
+      backend = Termisu::Logging.backend || fail("logging did not install its backend")
+      failing_io = RaisingFlushLogIO.new
+      backend.io = failing_io
+      20.times { |number| Termisu::Log.info { "flush-before-error-#{number}" } }
+
+      expect_raises(IO::Error, "injected log flush failure") { Termisu::Logging.flush }
+      (0...20).each { |number| failing_io.contents.should contain("flush-before-error-#{number}") }
+
+      backend.io = file
+      Termisu::Logging.close
+    end
+  ensure
+    File.delete(path) if path && File.exists?(path)
+  end
+
+  it "unbinds before draining and closes each backend once before its file across cycles" do
+    temp = File.tempfile("termisu-logging-lifecycle", ".log")
+    path = temp.path
+    temp.close
+
+    with_log_environment("debug", path, false) do
+      2.times do |cycle|
+        Termisu::Logging.setup
+        file = Termisu::Logging.log_file || fail("logging did not open its file")
+        backend = Termisu::Logging.backend || fail("logging did not retain its backend")
+        dispatcher = TrackingLogDispatcher.new(backend.dispatcher, file)
+        backend.dispatcher = dispatcher
+
+        Termisu::Log.info { "logging lifecycle cycle #{cycle}" }
+        close_results = Channel(Exception?).new(8)
+        8.times do
+          spawn do
+            error = nil.as(Exception?)
+            begin
+              Termisu::Logging.close
+            rescue ex
+              error = ex
+            end
+            close_results.send(error)
+          end
+        end
+        8.times { close_results.receive.should be_nil }
+        Termisu::Logging.close
+
+        dispatcher.close_count.should eq(1)
+        dispatcher.file_open_during_close?.should be_true
+        dispatcher.logger_detached_during_close?.should be_true
+        file.closed?.should be_true
+        Termisu::Logging.backend.should be_nil
+        Termisu::Logging.log_file.should be_nil
+        Termisu::Logging.configured?.should be_false
+      end
     end
 
     contents = File.read(path)
     contents.should contain("logging lifecycle cycle 0")
     contents.should contain("logging lifecycle cycle 1")
   ensure
-    Termisu::Logging.close
     File.delete(path) if path && File.exists?(path)
+  end
 
-    if previous_level
-      ENV["TERMISU_LOG_LEVEL"] = previous_level
-    else
-      ENV.delete("TERMISU_LOG_LEVEL")
+  it "continues file cleanup after a backend close failure and keeps close idempotent" do
+    temp = File.tempfile("termisu-log-close-failure", ".log")
+    path = temp.path
+    temp.close
+
+    with_log_environment("debug", path, false) do
+      Termisu::Logging.setup
+      file = Termisu::Logging.log_file || fail("logging did not open its file")
+      backend = Termisu::Logging.backend || fail("logging did not install its backend")
+      dispatcher = RaisingCloseLogDispatcher.new(backend.dispatcher)
+      backend.dispatcher = dispatcher
+      Termisu::Log.info { "entry before close failure" }
+
+      expect_raises(IO::Error, "injected backend close failure") { Termisu::Logging.close }
+      dispatcher.close_count.should eq(1)
+      file.closed?.should be_true
+      Termisu::Logging.backend.should be_nil
+      Termisu::Logging.log_file.should be_nil
+      Termisu::Logging.configured?.should be_false
+
+      Termisu::Logging.close
+      dispatcher.close_count.should eq(1)
     end
-    if previous_file
-      ENV["TERMISU_LOG_FILE"] = previous_file
-    else
-      ENV.delete("TERMISU_LOG_FILE")
-    end
-    if previous_sync
-      ENV["TERMISU_LOG_SYNC"] = previous_sync
-    else
-      ENV.delete("TERMISU_LOG_SYNC")
-    end
+  ensure
+    File.delete(path) if path && File.exists?(path)
   end
 end

--- a/src/termisu/log.cr
+++ b/src/termisu/log.cr
@@ -5,6 +5,8 @@ class Termisu
   #
   # Provides structured logging for debugging terminal operations.
   # Logs are written to a file since stdout is used for terminal rendering.
+  # Termisu loggers use an isolated registry, so host application logging
+  # configuration neither receives nor controls Termisu entries.
   #
   # ## Configuration
   #
@@ -13,16 +15,15 @@ class Termisu
   # - `TERMISU_LOG_FILE`: Path to log file (default: /tmp/termisu.log)
   # - `TERMISU_LOG_SYNC`: Dispatch mode (default: false)
   #   - `true`: Sync/direct mode - logs written immediately, ideal for debugging
-  #   - `false`: Async mode - logs queued to fiber, better performance
+  #   - `false`: Async mode - logs queued and buffered, better performance
   #
   # ## Dispatch Modes
   #
-  # **Async mode** (default): Uses `Log::DispatchMode::Async` for better performance.
-  # Logs are queued to a fiber and written asynchronously. The backend is
-  # drained and closed before its log file is released.
+  # **Async mode** (default): Entries are queued to a fiber and file output is
+  # buffered. The queue and file buffer are drained before the file is closed.
   #
-  # **Sync mode**: Uses `Log::DispatchMode::Direct` for real-time logging.
-  # Logs appear immediately in the file, ideal for debugging crashes.
+  # **Sync mode**: Entries are written and flushed immediately for real-time
+  # debugging and visibility during crashes.
   #
   # ## Example
   #
@@ -44,45 +45,244 @@ class Termisu
   # Termisu::Logs::Terminal.trace { "Rendering cell at #{x},#{y}" }
   # ```
 
-  # Main log instance for Termisu library
-  Log = ::Log.for("termisu")
+  # A dispatcher which reports asynchronous failures without abandoning its
+  # queue. In particular, every drain barrier is acknowledged even if an
+  # earlier write failed.
+  private class AsyncLogDispatcher
+    include ::Log::Dispatcher
 
-  # IO wrapper that silently handles writes to closed streams.
-  # Required for async dispatch mode to prevent errors when file closes
-  # before async fiber finishes processing queued log messages.
-  private class SafeFileIO < IO
-    def initialize(@file : File)
+    private record EntryMessage, entry : ::Log::Entry, backend : ::Log::Backend
+    private record DrainMessage, done : Channel(Nil)
+    private alias Message = EntryMessage | DrainMessage
+
+    @channel : Channel(Message)
+    @done : Channel(Nil)
+    @first_error : Exception?
+
+    def initialize(buffer_size : Int32 = 2048)
+      @channel = Channel(Message).new(buffer_size)
+      @done = Channel(Nil).new(1)
+      @first_error = nil
+      spawn(name: "termisu-log-dispatch") { write_logs }
     end
 
-    def read(slice : Bytes) : Int32
-      @file.read(slice)
+    def dispatch(entry : ::Log::Entry, backend : ::Log::Backend) : Nil
+      @channel.send(EntryMessage.new(entry, backend))
     end
 
-    def write(slice : Bytes) : Nil
-      return if @file.closed?
-      @file.write(slice)
-    rescue IO::Error
-      # Silently ignore writes to closed file from async dispatch
+    def drain : Nil
+      barrier = Channel(Nil).new(1)
+      @channel.send(DrainMessage.new(barrier))
+      barrier.receive
+      raise_first_error
     end
 
     def close : Nil
-      @file.close
+      @channel.close
+      @done.receive
+      raise_first_error
     end
 
-    def closed? : Bool
-      @file.closed?
+    private def write_logs : Nil
+      while message = @channel.receive?
+        case message
+        in EntryMessage
+          begin
+            message.backend.write(message.entry)
+          rescue ex
+            @first_error ||= ex
+          end
+        in DrainMessage
+          message.done.send(nil)
+        end
+      end
+    ensure
+      @done.send(nil)
+    end
+
+    private def raise_first_error : Nil
+      if error = @first_error
+        raise error
+      end
+    end
+  end
+
+  # IOBackend variant used by Termisu. Direct writes retain IOBackend's
+  # immediate flush. Async writes leave flushing to explicit barriers/close so
+  # File's output buffer can combine adjacent entries.
+  private class FileLogBackend < ::Log::IOBackend
+    @async : Bool
+    @closing : Bool
+    @dispatch_lock : Mutex
+
+    def initialize(file : File, formatter : ::Log::Formatter, @async : Bool)
+      dispatcher : ::Log::Dispatcher = if @async
+        AsyncLogDispatcher.new
+      else
+        ::Log::DirectDispatcher
+      end
+      super(io: file, formatter: formatter, dispatcher: dispatcher)
+      @closing = false
+      @dispatch_lock = Mutex.new(:unchecked)
+    end
+
+    def dispatch(entry : ::Log::Entry) : Nil
+      @dispatch_lock.synchronize do
+        return if @closing
+        dispatcher.dispatch(entry, self)
+      end
+    end
+
+    def write(entry : ::Log::Entry) : Nil
+      if @async
+        format(entry)
+        io.puts
+      else
+        super
+      end
     end
 
     def flush : Nil
-      @file.flush unless @file.closed?
+      first_error = nil.as(Exception?)
+
+      @dispatch_lock.synchronize do
+        if async_dispatcher = dispatcher.as?(AsyncLogDispatcher)
+          begin
+            async_dispatcher.drain
+          rescue ex
+            first_error = ex
+          end
+        end
+
+        begin
+          io.flush
+        rescue ex
+          first_error ||= ex
+        end
+      end
+
+      if error = first_error
+        raise error
+      end
+    end
+
+    def close : Nil
+      @dispatch_lock.synchronize do
+        return if @closing
+        @closing = true
+        dispatcher.close
+      end
     end
   end
+
+  # Registry for loggers owned by Termisu. It deliberately does not use
+  # `::Log.builder`, because host wildcard bindings on that builder must not
+  # capture Termisu output.
+  private class LogRegistry
+    @logs = Hash(String, WeakRef(OwnedLog)).new
+    @level = ::Log::Severity::None
+    @backend : ::Log::Backend? = nil
+    @mutex = Mutex.new(:unchecked)
+
+    def for(source : String) : ::Log
+      @mutex.synchronize do
+        if log = @logs[source]?.try(&.value)
+          return log
+        end
+
+        log = OwnedLog.new(source, self)
+        log.backend = @backend
+        log.initial_level = @level
+        @logs[source] = WeakRef.new(log)
+        log
+      end
+    end
+
+    def bind(level : ::Log::Severity, backend : ::Log::Backend) : Nil
+      @mutex.synchronize do
+        @level = level
+        @backend = backend
+        each_log do |log|
+          log.backend = backend
+          log.initial_level = level
+        end
+      end
+    end
+
+    # Detaches only the resource passed by its owner. This identity check keeps
+    # stale cleanup from unbinding a later setup cycle.
+    def unbind(backend : ::Log::Backend) : Bool
+      @mutex.synchronize do
+        return false unless @backend.same?(backend)
+
+        @backend = nil
+        @level = ::Log::Severity::None
+        each_log do |log|
+          log.backend = nil
+          log.initial_level = ::Log::Severity::None
+        end
+        true
+      end
+    end
+
+    private def each_log(&) : Nil
+      @logs.reject! { |_, log_ref| log_ref.value.nil? }
+      @logs.each_value do |log_ref|
+        if log = log_ref.value
+          yield log
+        end
+      end
+    end
+  end
+
+  # Log subclass whose child loggers remain in Termisu's isolated registry.
+  private class OwnedLog < ::Log
+    def initialize(source : String, @registry : LogRegistry)
+      super(source, nil, ::Log::Severity::None)
+    end
+
+    def for(child_source : String, level : ::Log::Severity? = nil) : ::Log
+      child = if source.blank?
+                @registry.for(child_source)
+              elsif child_source.blank?
+                @registry.for(source)
+              else
+                @registry.for("#{source}.#{child_source}")
+              end
+      child.level = level if level
+      child
+    end
+
+    def for(type : Class, level : ::Log::Severity? = nil) : ::Log
+      child_source = type.name.underscore.gsub("::", ".")
+      if paren = child_source.index('(')
+        child_source = child_source[0...paren]
+      end
+
+      child = @registry.for(child_source)
+      child.level = level if level
+      child
+    end
+
+    # Owned logs are tracked by LogRegistry and are not members of the
+    # process-global builder's weak-reference table.
+    def finalize : Nil
+    end
+  end
+
+  private LOGGER_REGISTRY = LogRegistry.new
+
+  # Main log instance for Termisu library. `#for` creates another isolated
+  # Termisu-owned logger rather than escaping to the host's global builder.
+  Log = LOGGER_REGISTRY.for("termisu")
 
   # Logging configuration and lifecycle management.
   #
   # Handles setup, configuration, and cleanup of the logging system.
   # Called automatically by Termisu.new and Termisu.close.
   module Logging
+    MUTEX = Mutex.new(:unchecked)
+
     # Open log file handle (nil when logging disabled)
     class_property log_file : File? = nil
 
@@ -135,100 +335,115 @@ class Termisu
 
     # Configures logging based on environment variables.
     #
-    # Reads TERMISU_LOG_LEVEL, TERMISU_LOG_FILE, and TERMISU_LOG_SYNC
-    # to configure the logging backend. Called automatically by Termisu.new.
-    #
-    # In async mode (default), uses async dispatch with SafeFileIO wrapper.
-    # In sync mode, uses direct dispatch for real-time logging.
-    def self.setup
-      return if configured?
+    # Setup failures retain the existing best-effort behavior: Termisu remains
+    # usable with its isolated loggers disabled.
+    def self.setup : Nil
+      MUTEX.synchronize do
+        return if configured?
 
-      level_str = ENV.fetch("TERMISU_LOG_LEVEL", "debug").downcase
-      level = LEVELS[level_str]? || ::Log::Severity::Debug
+        level_str = ENV.fetch("TERMISU_LOG_LEVEL", "debug").downcase
+        level = LEVELS[level_str]? || ::Log::Severity::Debug
 
-      # Don't set up file logging if level is none
-      if level == ::Log::Severity::None
-        self.configured = true
-        return
+        if level == ::Log::Severity::None
+          self.configured = true
+          return
+        end
+
+        file = nil.as(File?)
+        installed_backend = nil.as(FileLogBackend?)
+        bound = false
+
+        begin
+          file_path = ENV.fetch("TERMISU_LOG_FILE", "/tmp/termisu.log")
+          is_sync = ENV.fetch("TERMISU_LOG_SYNC", "false").downcase == "true"
+
+          file = File.open(file_path, "a")
+          file.sync = is_sync
+          installed_backend = FileLogBackend.new(file, FORMATTER, async: !is_sync)
+          LOGGER_REGISTRY.bind(level, installed_backend)
+          bound = true
+
+          self.log_file = file
+          self.backend = installed_backend
+          self.async_mode = !is_sync
+          self.configured = true
+
+          mode = is_sync ? "sync" : "async"
+          Log.info { "Logging initialized: level=#{level}, file=#{file_path}, mode=#{mode}" }
+        rescue
+          LOGGER_REGISTRY.unbind(installed_backend) if bound && installed_backend
+          installed_backend.try(&.close) rescue nil
+          file.try(&.flush) rescue nil
+          file.try(&.close) rescue nil
+          self.log_file = nil
+          self.backend = nil
+          self.async_mode = false
+          self.configured = true
+        end
       end
-
-      # Get log file path
-      file_path = ENV.fetch("TERMISU_LOG_FILE", "/tmp/termisu.log")
-
-      begin
-        file = File.open(file_path, "a")
-        file.sync = true
-        self.log_file = file
-
-        # Choose dispatch mode: async (default) for performance, sync for debugging
-        sync_mode = ENV.fetch("TERMISU_LOG_SYNC", "false").downcase
-        is_sync = sync_mode == "true"
-        self.async_mode = !is_sync
-        dispatch_mode = is_sync ? ::Log::DispatchMode::Direct : ::Log::DispatchMode::Async
-
-        # Async mode needs SafeFileIO wrapper to handle writes after file close
-        io : IO = is_sync ? file : SafeFileIO.new(file)
-        backend = ::Log::IOBackend.new(io: io, formatter: FORMATTER, dispatcher: dispatch_mode)
-        self.backend = backend
-
-        ::Log.setup("*", level, backend)
-
-        mode = is_sync ? "sync" : "async"
-        Log.info { "Logging initialized: level=#{level}, file=#{file_path}, mode=#{mode}" }
-      rescue ex
-        # If we can't open the log file, disable logging silently
-      end
-
-      self.configured = true
     end
 
-    # Closes the logging backend and its file.
-    #
-    # Detaching the backend first prevents new entries while `Backend#close`
-    # drains its async dispatcher. The file must remain open until that drain
-    # completes. Called automatically by Termisu.close.
-    def self.close
-      if retained_backend = backend
-        ::Log.setup { |_| } rescue nil
-        retained_backend.close rescue nil
+    # Unbinds Termisu loggers before draining their backend, then flushes and
+    # closes the file. Every cleanup step runs and the first error is re-raised.
+    def self.close : Nil
+      error = nil.as(Exception?)
+
+      MUTEX.synchronize do
+        retained_backend = backend
+        retained_file = log_file
+
         self.backend = nil
-      end
-
-      if file = log_file
-        file.flush rescue nil
-        file.close rescue nil
         self.log_file = nil
+        self.async_mode = false
+        self.configured = false
+
+        if retained_backend
+          error = capture_error(error) { LOGGER_REGISTRY.unbind(retained_backend) }
+          error = capture_error(error) { retained_backend.close }
+        end
+        if retained_file
+          error = capture_error(error) { retained_file.flush }
+          error = capture_error(error) { retained_file.close }
+        end
       end
 
-      self.async_mode = false
-      self.configured = false
+      if exception = error
+        raise exception
+      end
     end
 
-    # Flushes any buffered log entries to disk.
-    #
-    # In async mode, yields first to let dispatch fiber process.
-    def self.flush
-      Fiber.yield if async_mode?
-      log_file.try(&.flush)
+    # Drains all entries accepted before this call and flushes the file buffer.
+    def self.flush : Nil
+      MUTEX.synchronize do
+        if installed_backend = backend
+          installed_backend.as(FileLogBackend).flush
+        elsif file = log_file
+          file.flush
+        end
+      end
+    end
+
+    private def self.capture_error(error : Exception?, &) : Exception?
+      yield
+      error
+    rescue ex
+      error || ex
     end
   end
 
   # Component-specific log instances for fine-grained filtering.
-  #
-  # Each component has its own log source, allowing selective logging:
-  # - termisu.terminal: Terminal initialization and screen management
-  # - termisu.buffer: Cell buffer operations and rendering
-  # - termisu.reader: Input reading and buffering
-  # - termisu.input: Key/byte input processing
-  # - termisu.terminfo: Terminfo database loading and capabilities
   module Logs
-    Terminal = ::Log.for("termisu.terminal")
-    Buffer   = ::Log.for("termisu.buffer")
-    Reader   = ::Log.for("termisu.reader")
-    Render   = ::Log.for("termisu.render")
-    Input    = ::Log.for("termisu.input")
-    Color    = ::Log.for("termisu.color")
-    Terminfo = ::Log.for("termisu.terminfo")
-    Event    = ::Log.for("termisu.event")
+    Terminal = LOGGER_REGISTRY.for("termisu.terminal")
+    Buffer   = LOGGER_REGISTRY.for("termisu.buffer")
+    Reader   = LOGGER_REGISTRY.for("termisu.reader")
+    Render   = LOGGER_REGISTRY.for("termisu.render")
+    Input    = LOGGER_REGISTRY.for("termisu.input")
+    Color    = LOGGER_REGISTRY.for("termisu.color")
+    Terminfo = LOGGER_REGISTRY.for("termisu.terminfo")
+    Event    = LOGGER_REGISTRY.for("termisu.event")
   end
 end
+
+# Crystal's global builder has its own exit hook. Register Termisu separately
+# so queued entries are drained even when an application omits `Termisu#close`.
+at_exit { Termisu::Logging.close rescue nil }


### PR DESCRIPTION
## Rationale

Termisu logging previously configured Crystal's process-global wildcard logger, which could capture host logs and later clear host bindings. Async dispatch also forced synchronous file output.

## Design

- Keep Termisu loggers in a private registry; setup and teardown bind only Termisu-owned loggers and resources.
- Preserve `Termisu::Log` and `Termisu::Log.for` source behavior while preventing escape to the host builder.
- Treat `none` as a truly silent configuration without opening a file; retain the existing default `debug` policy.
- Keep direct mode immediately visible. Async mode queues entries and permits file buffering, with explicit drain barriers and process-exit cleanup.
- On close, detach loggers before draining, close the backend before the file, run every cleanup stage, retain the first error, and make repeated/concurrent close stale-safe and idempotent.

## Evidence

A Linux/Crystal 1.21 `strace -f` observation over five fresh runs of the 500-message process-exit fixture counted traced `write`/`writev`/`pwrite64` calls as:

- direct: `4008, 4008, 4008, 4008, 4008`
- async: `1, 1, 1, 1, 1`

Every run produced 501 lines (setup plus 500 messages) with all numbered messages complete and ordered. These are workload- and platform-specific syscall observations, not portable exact-count or application-performance claims. Runtime validation here was Linux only; macOS and FreeBSD remain covered by CI rather than local execution.

## Validation

- Crystal 1.21 focused logging: 12 examples, 0 failures
- Crystal 1.17 focused logging: 12 examples, 0 failures
- Crystal 1.21 full PTY suite: 1417 examples, 0 failures, 1 expected pending
- Crystal 1.17 full PTY suite: 1417 examples, 0 failures, 1 expected pending
- Crystal format check: passed
- Ameba: 163 files, 0 failures
- C format and clang-tidy checks: passed
- Native C ABI lifecycle tests: passed with Crystal 1.21 and 1.17
- Bun native/unit tests: 48 passed with libraries built by Crystal 1.21 and 1.17
- Bun format/lint and TypeScript typecheck: passed
- `git diff --check`: passed
