### PR TITLE
perf: reuse bun cell operation buffers

### DIFF
--- a/javascript/core/src/structs.ts
+++ b/javascript/core/src/structs.ts
@@ -19,6 +19,9 @@ export function readSize(buffer: ArrayBuffer): Size {
 function writeColor(view: DataView, offset: number, color?: CellStyle["fg"]): void {
   const mode = color?.mode ?? ColorMode.Default;
   view.setUint8(offset + STRUCT.color.mode, mode);
+  view.setUint8(offset + 1, 0);
+  view.setUint8(offset + 2, 0);
+  view.setUint8(offset + 3, 0);
 
   let index = -1;
   if (color && (color.mode === ColorMode.Ansi8 || color.mode === ColorMode.Ansi256)) {
@@ -29,14 +32,20 @@ function writeColor(view: DataView, offset: number, color?: CellStyle["fg"]): vo
   view.setUint8(offset + STRUCT.color.r, color?.r ?? 0);
   view.setUint8(offset + STRUCT.color.g, color?.g ?? 0);
   view.setUint8(offset + STRUCT.color.b, color?.b ?? 0);
+  view.setUint8(offset + 11, 0);
 }
 
-// Writes every meaningful field, so a reused scratch view never leaks
-// values from a previous call (untouched padding bytes stay zero).
+function writeStyleAt(view: DataView, offset: number, style?: CellStyle): void {
+  writeColor(view, offset + STRUCT.cellStyle.fg, style?.fg);
+  writeColor(view, offset + STRUCT.cellStyle.bg, style?.bg);
+  view.setUint16(offset + STRUCT.cellStyle.attr, style?.attr ?? 0, LITTLE_ENDIAN);
+  view.setUint16(offset + STRUCT.cellStyle.size - 2, 0, LITTLE_ENDIAN);
+}
+
+// Writes the complete ABI record, including reserved and padding bytes, so a
+// reused or caller-provided view has the same bytes as a fresh allocation.
 export function writeStyle(view: DataView, style?: CellStyle): void {
-  writeColor(view, STRUCT.cellStyle.fg, style?.fg);
-  writeColor(view, STRUCT.cellStyle.bg, style?.bg);
-  view.setUint16(STRUCT.cellStyle.attr, style?.attr ?? 0, LITTLE_ENDIAN);
+  writeStyleAt(view, 0, style);
 }
 
 export function createStyleBuffer(style?: CellStyle): ArrayBuffer {
@@ -56,11 +65,13 @@ function opCodepoint(char: string | number): number {
   return codepoint;
 }
 
-// Marshals every op into one contiguous termisu_cell_op_t array so a whole
-// frame crosses the FFI boundary with a single pointer.
-export function createCellOpsBuffer(ops: readonly CellOp[]): ArrayBuffer {
-  const buffer = new ArrayBuffer(STRUCT.cellOp.size * ops.length);
-  const view = new DataView(buffer);
+// Writes every op into contiguous termisu_cell_op_t storage. The view may be
+// larger than the logical batch, but only the first ops.length records change.
+export function writeCellOps(view: DataView, ops: readonly CellOp[]): void {
+  const requiredBytes = STRUCT.cellOp.size * ops.length;
+  if (view.byteLength < requiredBytes) {
+    throw new RangeError("Cell operation buffer is too small");
+  }
 
   let offset = 0;
   for (const op of ops) {
@@ -68,14 +79,16 @@ export function createCellOpsBuffer(ops: readonly CellOp[]): ArrayBuffer {
     view.setInt32(offset + STRUCT.cellOp.y, op.y, LITTLE_ENDIAN);
     view.setInt32(offset + STRUCT.cellOp.codepoint, opCodepoint(op.char), LITTLE_ENDIAN);
 
-    const styleOffset = offset + STRUCT.cellOp.style;
-    writeColor(view, styleOffset + STRUCT.cellStyle.fg, op.style?.fg);
-    writeColor(view, styleOffset + STRUCT.cellStyle.bg, op.style?.bg);
-    view.setUint16(styleOffset + STRUCT.cellStyle.attr, op.style?.attr ?? 0, LITTLE_ENDIAN);
+    writeStyleAt(view, offset + STRUCT.cellOp.style, op.style);
 
     offset += STRUCT.cellOp.size;
   }
+}
 
+// Retained for callers that need an independently allocated ABI buffer.
+export function createCellOpsBuffer(ops: readonly CellOp[]): ArrayBuffer {
+  const buffer = new ArrayBuffer(STRUCT.cellOp.size * ops.length);
+  writeCellOps(new DataView(buffer), ops);
   return buffer;
 }
 

--- a/javascript/core/src/termisu.ts
+++ b/javascript/core/src/termisu.ts
@@ -3,27 +3,22 @@ import { ptr } from "bun:ffi";
 import { EventType, STRUCT, Status } from "./constants";
 import { TermisuError } from "./errors";
 import { loadNative, type NativeLibrary } from "./native";
-import {
-  createCellOpsBuffer,
-  createSizeBuffer,
-  readEventFrom,
-  readSize,
-  writeStyle,
-} from "./structs";
+import { createSizeBuffer, readEventFrom, readSize, writeCellOps, writeStyle } from "./structs";
 import type { AnyEvent, CellOp, CellStyle, TermisuOptions } from "./types";
 
 const ERROR_DECODER = new TextDecoder();
 
 interface Scratch {
+  bytes: Uint8Array;
   view: DataView;
   pointer: number;
 }
 
-// The view retains the backing buffer, keeping the pointer valid for the
+// The bytes retain the backing buffer, keeping the pointer valid for the
 // lifetime of the scratch.
 function createScratch(size: number): Scratch {
   const bytes = new Uint8Array(size);
-  return { view: new DataView(bytes.buffer), pointer: ptr(bytes) };
+  return { bytes, view: new DataView(bytes.buffer), pointer: ptr(bytes) };
 }
 
 function asBigInt(value: number | bigint): bigint {
@@ -51,6 +46,7 @@ export class Termisu {
   // are rewritten in place instead of allocated (and ptr-registered) per call.
   private styleScratch: Scratch | null = null;
   private eventScratch: Scratch | null = null;
+  private cellOpsScratch: Scratch | null = null;
 
   constructor(options: TermisuOptions = {}) {
     this.native = loadNative(options.libraryPath);
@@ -76,6 +72,9 @@ export class Termisu {
     const status = asNumber(this.native.symbols.termisu_destroy(this.handle) as number | bigint);
     this.assertStatus(status, "termisu_destroy");
     this.handle = 0n;
+    this.styleScratch = null;
+    this.eventScratch = null;
+    this.cellOpsScratch = null;
   }
 
   close(): void {
@@ -153,20 +152,18 @@ export class Termisu {
     this.assertStatus(status, "termisu_set_cell");
   }
 
-  // Batched setCell: marshals all ops into one typed array and crosses the
-  // FFI boundary once, instead of one native call (and guard + handle
-  // lookup) per cell.
+  // Batched setCell: marshals all ops into reusable contiguous storage and
+  // crosses the FFI boundary once. Capacity is never passed as the count.
   setCells(ops: readonly CellOp[]): void {
     this.assertAlive();
     if (ops.length === 0) return;
 
-    const buffer = createCellOpsBuffer(ops);
+    const scratch = this.ensureCellOpsScratch(ops.length);
+    writeCellOps(scratch.view, ops);
     const status = asNumber(
-      this.native.symbols.termisu_set_cells(
-        this.handle,
-        ptr(new Uint8Array(buffer)),
-        BigInt(ops.length)
-      ) as number | bigint
+      this.native.symbols.termisu_set_cells(this.handle, scratch.pointer, BigInt(ops.length)) as
+        | number
+        | bigint
     );
     this.assertStatus(status, "termisu_set_cells");
   }
@@ -305,6 +302,14 @@ export class Termisu {
   private ensureEventScratch(): Scratch {
     this.eventScratch ??= createScratch(STRUCT.event.size);
     return this.eventScratch;
+  }
+
+  private ensureCellOpsScratch(count: number): Scratch {
+    const requiredBytes = STRUCT.cellOp.size * count;
+    if (!this.cellOpsScratch || this.cellOpsScratch.bytes.byteLength < requiredBytes) {
+      this.cellOpsScratch = createScratch(requiredBytes);
+    }
+    return this.cellOpsScratch;
   }
 
   private assertAlive(): void {

--- a/javascript/core/tests/structs.test.ts
+++ b/javascript/core/tests/structs.test.ts
@@ -8,6 +8,7 @@ import {
   createStyleBuffer,
   readEvent,
   readSize,
+  writeCellOps,
 } from "../src/structs";
 
 const LE = true;
@@ -219,6 +220,62 @@ describe("struct helpers", () => {
     );
     expect(view.getInt32(second + style + STRUCT.cellStyle.fg + STRUCT.color.index, LE)).toBe(-1);
     expect(view.getUint16(second + style + STRUCT.cellStyle.attr, LE)).toBe(0);
+  });
+
+  it("writes cell ops in place with exact allocating-helper parity", () => {
+    const ops = [
+      { x: -1, y: 2, char: "🙂" },
+      {
+        x: 3,
+        y: 4,
+        char: "A",
+        style: {
+          fg: { mode: ColorMode.Rgb, r: 7, g: 8, b: 9 } as const,
+          bg: { mode: ColorMode.Ansi256, index: 201 } as const,
+          attr: 0xabcd,
+        },
+      },
+      {
+        x: 5,
+        y: 6,
+        char: 0x10ffff,
+        style: {
+          fg: { mode: ColorMode.Ansi8, index: 2 } as const,
+          bg: { mode: ColorMode.Default } as const,
+        },
+      },
+    ];
+    const expected = createCellOpsBuffer(ops);
+    const storage = new ArrayBuffer(expected.byteLength + STRUCT.cellOp.size);
+    const bytes = new Uint8Array(storage);
+    bytes.fill(0xa5);
+    const view = new DataView(storage);
+    const previousOps = ops.map((op) => ({
+      ...op,
+      style: {
+        fg: { mode: ColorMode.Ansi256, index: 255 } as const,
+        bg: { mode: ColorMode.Rgb, r: 255, g: 254, b: 253 } as const,
+        attr: 0xffff,
+      },
+    }));
+
+    writeCellOps(view, previousOps);
+    writeCellOps(view, ops);
+
+    expect(Array.from(bytes.subarray(0, expected.byteLength))).toEqual(
+      Array.from(new Uint8Array(expected))
+    );
+    expect(Array.from(bytes.subarray(expected.byteLength))).toEqual(
+      Array(STRUCT.cellOp.size).fill(0xa5)
+    );
+  });
+
+  it("requires enough in-place storage before writing", () => {
+    const buffer = new ArrayBuffer(STRUCT.cellOp.size - 1);
+    expect(() => writeCellOps(new DataView(buffer), [{ x: 0, y: 0, char: "A" }])).toThrow(
+      RangeError
+    );
+    expect(Array.from(new Uint8Array(buffer))).toEqual(Array(buffer.byteLength).fill(0));
   });
 
   it("returns an empty buffer for zero cell ops and rejects empty chars", () => {

--- a/javascript/core/tests/termisu.test.ts
+++ b/javascript/core/tests/termisu.test.ts
@@ -2,13 +2,19 @@ import { describe, expect, it } from "bun:test";
 
 import { Attribute, attrs } from "../src/attribute";
 import { Color } from "../src/color";
-import { Status } from "../src/constants";
+import { STRUCT, Status } from "../src/constants";
 import { TermisuError } from "../src/errors";
 import { Termisu } from "../src/termisu";
 import type { CellOp } from "../src/types";
 
 type NativeValue = number | bigint | undefined;
 type SymbolFn = (...args: Array<number | bigint>) => NativeValue;
+
+type TestScratch = {
+  bytes: Uint8Array;
+  view: DataView;
+  pointer: number;
+};
 
 type TestTermisu = {
   size(): { width: number; height: number };
@@ -44,6 +50,9 @@ type TestTermisu = {
     path: string;
   };
   handle: bigint;
+  styleScratch: TestScratch | null;
+  eventScratch: TestScratch | null;
+  cellOpsScratch: TestScratch | null;
   getLastError: () => string;
 };
 
@@ -234,13 +243,81 @@ describe("Termisu wrapper behavior", () => {
     expect(batchCalls[0]?.args[2]).toBe(4n);
   });
 
-  it("skips the native call for empty setCells batches", () => {
+  it("reuses cell op scratch, grows it, and ignores stale capacity", () => {
+    const { termisu, calls } = buildMockTermisu();
+
+    termisu.setCells([
+      { x: 10, y: 0, char: "A" },
+      { x: 20, y: 0, char: "B" },
+    ]);
+    const initial = termisu.cellOpsScratch;
+    if (!initial) throw new Error("expected cell op scratch");
+    expect(initial.bytes.byteLength).toBe(2 * STRUCT.cellOp.size);
+
+    termisu.setCells([{ x: 30, y: 1, char: "🙂" }]);
+    expect(termisu.cellOpsScratch).toBe(initial);
+
+    termisu.setCells([
+      { x: 40, y: 2, char: "D" },
+      { x: 50, y: 2, char: "E" },
+      { x: 60, y: 2, char: "F" },
+    ]);
+    const grown = termisu.cellOpsScratch;
+    if (!grown) throw new Error("expected grown cell op scratch");
+    expect(grown).not.toBe(initial);
+    expect(grown.pointer).not.toBe(initial.pointer);
+    expect(grown.bytes.byteLength).toBe(3 * STRUCT.cellOp.size);
+
+    termisu.setCells([{ x: 70, y: 3, char: "G" }]);
+    expect(termisu.cellOpsScratch).toBe(grown);
+    expect(grown.view.getInt32(STRUCT.cellOp.size + STRUCT.cellOp.x, true)).toBe(50);
+
+    const batchCalls = calls.filter((entry) => entry.name === "termisu_set_cells");
+    expect(batchCalls.map((entry) => entry.args[1])).toEqual([
+      initial.pointer,
+      initial.pointer,
+      grown.pointer,
+      grown.pointer,
+    ]);
+    expect(batchCalls.map((entry) => entry.args[2])).toEqual([2n, 1n, 3n, 1n]);
+  });
+
+  it("skips allocation and the native call for empty setCells batches", () => {
     const { termisu, calls } = buildMockTermisu();
 
     termisu.setCells([]);
 
+    expect(termisu.cellOpsScratch).toBeFalsy();
     const batchCalls = calls.filter((entry) => entry.name === "termisu_set_cells");
     expect(batchCalls).toHaveLength(0);
+  });
+
+  it("does not call native code when setCells marshalling fails", () => {
+    const { termisu, calls } = buildMockTermisu();
+
+    expect(() =>
+      termisu.setCells([
+        { x: 0, y: 0, char: "A" },
+        { x: 1, y: 0, char: "" },
+      ])
+    ).toThrow("Character must not be empty");
+    expect(calls.filter((entry) => entry.name === "termisu_set_cells")).toHaveLength(0);
+  });
+
+  it("checks a destroyed handle before validating setCells input", () => {
+    const { termisu, calls } = buildMockTermisu({}, 0n);
+
+    let thrown: unknown;
+    try {
+      termisu.setCells([{ x: 0, y: 0, char: "" }]);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(TermisuError);
+    expect((thrown as TermisuError).status).toBe(Status.InvalidHandle);
+    expect(calls).toHaveLength(0);
+    expect(termisu.cellOpsScratch).toBeFalsy();
   });
 
   it("throws TermisuError when setCells reports a rejected batch", () => {
@@ -261,20 +338,33 @@ describe("Termisu wrapper behavior", () => {
     expect(okNone.pollEvent(0)).toBeNull();
   });
 
-  it("throws TermisuError and preserves handle when destroy fails", () => {
+  it("throws TermisuError and preserves scratch when destroy fails", () => {
     const { termisu } = buildMockTermisu({
       termisu_destroy: () => Status.InvalidHandle,
     });
+    termisu.setCells([{ x: 0, y: 0, char: "A" }]);
+    const scratch = termisu.cellOpsScratch;
 
     expect(() => termisu.destroy()).toThrow(TermisuError);
     expect(termisu.handle).toBe(1n);
+    expect(termisu.cellOpsScratch).toBe(scratch);
   });
 
-  it("sets handle to zero after successful destroy and enforces closed-handle checks", () => {
+  it("releases marshalling scratch after successful destroy", () => {
     const { termisu } = buildMockTermisu();
+    termisu.setCell(0, 0, "A", { fg: Color.green });
+    termisu.setCells([{ x: 0, y: 0, char: "A" }]);
+    termisu.pollEvent(0);
+    expect(termisu.styleScratch).toBeTruthy();
+    expect(termisu.cellOpsScratch).toBeTruthy();
+    expect(termisu.eventScratch).toBeTruthy();
 
     termisu.destroy();
+
     expect(termisu.handle).toBe(0n);
+    expect(termisu.styleScratch).toBeNull();
+    expect(termisu.cellOpsScratch).toBeNull();
+    expect(termisu.eventScratch).toBeNull();
     expect(() => termisu.clear()).toThrow(TermisuError);
   });
 


### PR DESCRIPTION
## Rationale

`setCells` previously allocated and pointer-registered a new frame-sized backing store on every call. Retain one scratch buffer per `Termisu` instance so steady-state batches at or below the high-water mark rewrite existing storage instead.

## Design and correctness

- Add in-place `writeCellOps` marshalling while retaining `createCellOpsBuffer` for compatibility.
- Retain the `Uint8Array`, `DataView`, and Bun FFI pointer; replace them only when a larger batch arrives.
- Pass `ops.length`, never scratch capacity, and skip allocation/native calls for empty batches.
- Preserve destroyed-handle and marshalling-validation precedence; errors do not invoke `termisu_set_cells`.
- Keep the exact 40-byte C ABI record, including deterministic reserved/padding bytes, across default, RGB, ANSI8/ANSI256, numeric, and astral inputs.
- Release scratch only after successful destroy; failed destroy keeps the handle and scratch intact.

## Evidence and limitations

Deterministic regressions observe pointer reuse without growth, pointer replacement on growth, and native counts `[2, 1, 3, 1]` for larger/smaller batches. An 80x24 batch retains one 76,800-byte backing store after first use rather than creating that backing store on every call. No end-to-end frame-time or throughput claim is made; runtime timing effects remain workload-dependent.

## Validation

- Bun 1.4.0 full unit/native suite: 53 passed, 0 failed
- Bun focused scratch/marshalling suite: 29 passed, 0 failed
- TypeScript typecheck, Biome check/format/lint, and package build passed
- Crystal 1.21.0 full suite: 1,406 passed, 0 failed (15 environment-dependent pending)
- Oldest-supported Crystal 1.17.0 full suite: 1,406 passed, 0 failed (15 environment-dependent pending)
- Ameba: 162 files, 0 failures; Crystal format check passed
- C ABI build/tests passed; C format and clang-tidy checks passed
- PTY/E2E: 82 passed, 0 failed
- `git diff --check` passed
